### PR TITLE
feat: implement repository-filtered chat view

### DIFF
--- a/src/app/chats/[repo_fullname]/page.tsx
+++ b/src/app/chats/[repo_fullname]/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from 'react'
+import LoadingSpinner from '../../components/LoadingSpinner'
+import RepositoryConversationList from './RepositoryConversationList'
+
+interface RepositoryChatsPageProps {
+  params: {
+    repo_fullname: string
+  }
+}
+
+export default function RepositoryChatsPage({ params }: RepositoryChatsPageProps) {
+  // Decode the repo_fullname parameter (since it comes URL-encoded)
+  const repoFullname = decodeURIComponent(params.repo_fullname)
+  
+  // Parse owner and repo name from the full name (e.g. "users/repo_name" or "orgs/repo_name")
+  const [ownerType, repoName] = repoFullname.split('/', 2)
+  const displayName = ownerType && repoName ? `${ownerType}/${repoName}` : repoFullname
+
+  return (
+    <main className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <div className="flex items-center gap-2 mb-2">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              Repository Conversations
+            </h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+              {displayName}
+            </span>
+          </div>
+          <p className="text-gray-600 dark:text-gray-400 mt-2">
+            Conversations filtered for repository: {displayName}
+          </p>
+        </div>
+
+        <Suspense fallback={<LoadingSpinner />}>
+          <RepositoryConversationList repository={repoFullname} />
+        </Suspense>
+      </div>
+    </main>
+  )
+}

--- a/src/app/components/ConversationCard.tsx
+++ b/src/app/components/ConversationCard.tsx
@@ -76,6 +76,11 @@ export default function ConversationCard({ chat }: ConversationCardProps) {
           <span className="text-xs text-gray-400 dark:text-gray-500">
             ID: {chat.id.slice(0, 8)}...
           </span>
+          {chat.metadata?.repository && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+              {chat.metadata.repository}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <button className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -56,12 +56,14 @@ export const chatApi = {
     page?: number
     limit?: number
     status?: Chat['status']
+    repository?: string
   }): Promise<ChatListResponse> {
     const searchParams = new URLSearchParams()
     
     if (params?.page) searchParams.set('page', params.page.toString())
     if (params?.limit) searchParams.set('limit', params.limit.toString())
     if (params?.status) searchParams.set('status', params.status)
+    if (params?.repository) searchParams.set('repository', params.repository)
 
     const endpoint = `/chats${searchParams.toString() ? `?${searchParams.toString()}` : ''}`
     return apiRequest<ChatListResponse>(endpoint)

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -7,7 +7,15 @@ export interface Chat {
   updated_at: string
   message_count?: number
   duration?: number
-  metadata?: Record<string, any>
+  metadata?: {
+    repository?: string
+    repository_url?: string
+    repository_owner?: string
+    repository_name?: string
+    branch?: string
+    commit_hash?: string
+    [key: string]: any
+  }
 }
 
 export interface ChatListResponse {


### PR DESCRIPTION
This PR implements the repository-filtered chat view feature requested in #14.

## Changes
- Add /chats/{repo_fullname} dynamic route for repository-specific conversations
- Extend Chat type to include repository metadata fields
- Update API client to support repository filtering parameter
- Create RepositoryConversationList component with repo-specific filtering logic
- Add repository badges to conversation cards for better visibility
- Update mock data to include repository information for testing
- Support orgs/repo_name and users/repo_name format as specified

Closes #14

Generated with [Claude Code](https://claude.ai/code)