### PR TITLE
feat: upgrade Next.js to 15.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "14.2.16",
+    "next": "15.3.0",
     "react": "^18",
     "react-dom": "^18"
   },
@@ -27,7 +27,7 @@
     "@types/react-dom": "^18",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^8",
-    "eslint-config-next": "14.2.16",
+    "eslint-config-next": "15.3.0",
     "jsdom": "^25.0.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
Upgraded Next.js from 14.2.16 to 15.3.0 as requested in issue #22.

**Changes:**
- Updated `next` to 15.3.0
- Updated `eslint-config-next` to 15.3.0

Resolves #22

Generated with [Claude Code](https://claude.ai/code)