### PR TITLE
feat: implement global settings screen with hierarchy support

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,16 +1,11 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { useParams } from 'next/navigation'
-import Link from 'next/link'
-import { SettingsFormData, loadRepositorySettings, saveRepositorySettings } from '../../../types/settings'
-import type { AgentApiSettings, EnvironmentVariable } from '../../../types/settings'
+import { SettingsFormData, loadGlobalSettings, saveGlobalSettings } from '../../types/settings'
+import type { AgentApiSettings, EnvironmentVariable } from '../../types/settings'
 
-export default function SettingsPage() {
-  const params = useParams()
-  const repoFullname = params.repo_fullname as string
-  
-  const [settings, setSettings] = useState<SettingsFormData>(loadRepositorySettings(repoFullname))
+export default function GlobalSettingsPage() {
+  const [settings, setSettings] = useState<SettingsFormData>(loadGlobalSettings())
   
   const [loading, setLoading] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -18,12 +13,12 @@ export default function SettingsPage() {
   
   const loadSettings = useCallback(() => {
     try {
-      const repoSettings = loadRepositorySettings(repoFullname)
-      setSettings(repoSettings)
+      const globalSettings = loadGlobalSettings()
+      setSettings(globalSettings)
     } catch (err) {
-      console.error('Failed to load settings:', err)
+      console.error('Failed to load global settings:', err)
     }
-  }, [repoFullname])
+  }, [])
 
   // Load saved settings on component mount
   useEffect(() => {
@@ -35,12 +30,12 @@ export default function SettingsPage() {
       setLoading(true)
       setError(null)
       
-      saveRepositorySettings(repoFullname, settings)
+      saveGlobalSettings(settings)
       
       setSaved(true)
       setTimeout(() => setSaved(false), 3000) // Clear saved message after 3 seconds
     } catch {
-      setError('Failed to save settings')
+      setError('Failed to save global settings')
     } finally {
       setLoading(false)
     }
@@ -110,19 +105,13 @@ export default function SettingsPage() {
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
-            Settings
+            Global Settings
           </h1>
           <p className="text-gray-600 dark:text-gray-400 mb-1">
-            Repository: <span className="font-mono text-sm bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">{repoFullname}</span>
-          </p>
-          <p className="text-gray-600 dark:text-gray-400 mb-2">
-            Configure AgentAPI settings and environment variables for this repository
+            Configure default AgentAPI settings and environment variables
           </p>
           <p className="text-sm text-gray-500 dark:text-gray-500">
-            Repository settings override global defaults. 
-            <Link href="/settings" className="text-blue-600 dark:text-blue-400 hover:underline ml-1">
-              Edit global settings
-            </Link>
+            These settings will be used as defaults for all repositories. Individual repository settings can override these values.
           </p>
         </div>
 
@@ -130,7 +119,7 @@ export default function SettingsPage() {
           {/* AgentAPI Configuration */}
           <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
             <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
-              AgentAPI Configuration
+              Default AgentAPI Configuration
             </h2>
             
             <div className="space-y-4">
@@ -155,7 +144,7 @@ export default function SettingsPage() {
                   type="password"
                   value={settings.agentApi.apiKey}
                   onChange={(e) => updateAgentApiSetting('apiKey', e.target.value)}
-                  placeholder="Enter your API key"
+                  placeholder="Enter your default API key"
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 />
               </div>
@@ -178,7 +167,7 @@ export default function SettingsPage() {
               <div>
                 <div className="flex items-center justify-between mb-2">
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Custom Headers
+                    Default Custom Headers
                   </label>
                   <button
                     onClick={addCustomHeader}
@@ -190,7 +179,7 @@ export default function SettingsPage() {
                 
                 {Object.entries(settings.agentApi.customHeaders).length === 0 ? (
                   <p className="text-sm text-gray-500 dark:text-gray-400 italic">
-                    No custom headers configured
+                    No default custom headers configured
                   </p>
                 ) : (
                   <div className="space-y-2">
@@ -224,7 +213,7 @@ export default function SettingsPage() {
           <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-                Environment Variables
+                Default Environment Variables
               </h2>
               <button
                 onClick={addEnvironmentVariable}
@@ -236,7 +225,7 @@ export default function SettingsPage() {
 
             {settings.environmentVariables.length === 0 ? (
               <p className="text-sm text-gray-500 dark:text-gray-400 italic">
-                No environment variables configured
+                No default environment variables configured
               </p>
             ) : (
               <div className="space-y-4">
@@ -301,7 +290,7 @@ export default function SettingsPage() {
             <div className="flex items-center gap-4">
               {saved && (
                 <span className="text-sm text-green-600 dark:text-green-400">
-                  ✓ Settings saved successfully
+                  ✓ Global settings saved successfully
                 </span>
               )}
               {error && (
@@ -319,7 +308,7 @@ export default function SettingsPage() {
               {loading && (
                 <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
               )}
-              {loading ? 'Saving...' : 'Save Settings'}
+              {loading ? 'Saving...' : 'Save Global Settings'}
             </button>
           </div>
         </div>

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -19,6 +19,13 @@ export interface RepositorySettings {
   updated_at: string
 }
 
+export interface GlobalSettings {
+  agentApi: AgentApiSettings
+  environmentVariables: EnvironmentVariable[]
+  created_at: string
+  updated_at: string
+}
+
 export interface SettingsFormData {
   agentApi: AgentApiSettings
   environmentVariables: EnvironmentVariable[]
@@ -34,3 +41,78 @@ export const getDefaultSettings = (): SettingsFormData => ({
   },
   environmentVariables: []
 })
+
+// Global settings utilities
+export const loadGlobalSettings = (): SettingsFormData => {
+  try {
+    const savedSettings = localStorage.getItem('agentapi-global-settings')
+    if (savedSettings) {
+      return JSON.parse(savedSettings)
+    }
+  } catch (err) {
+    console.error('Failed to load global settings:', err)
+  }
+  return getDefaultSettings()
+}
+
+export const saveGlobalSettings = (settings: SettingsFormData): void => {
+  try {
+    localStorage.setItem('agentapi-global-settings', JSON.stringify(settings))
+  } catch (err) {
+    console.error('Failed to save global settings:', err)
+    throw err
+  }
+}
+
+// Repository settings utilities with hierarchy support
+export const loadRepositorySettings = (repoFullname: string): SettingsFormData => {
+  const globalSettings = loadGlobalSettings()
+  
+  try {
+    const savedSettings = localStorage.getItem(`agentapi-settings-${repoFullname}`)
+    if (savedSettings) {
+      const repoSettings = JSON.parse(savedSettings)
+      // Merge global settings with repository-specific overrides
+      return mergeSettings(globalSettings, repoSettings)
+    }
+  } catch (err) {
+    console.error('Failed to load repository settings:', err)
+  }
+  
+  // Return global settings as fallback
+  return globalSettings
+}
+
+export const saveRepositorySettings = (repoFullname: string, settings: SettingsFormData): void => {
+  try {
+    localStorage.setItem(`agentapi-settings-${repoFullname}`, JSON.stringify(settings))
+  } catch (err) {
+    console.error('Failed to save repository settings:', err)
+    throw err
+  }
+}
+
+// Merge settings with hierarchy: global settings as base, repo settings as overrides
+const mergeSettings = (globalSettings: SettingsFormData, repoSettings: SettingsFormData): SettingsFormData => {
+  return {
+    agentApi: {
+      ...globalSettings.agentApi,
+      ...repoSettings.agentApi,
+      customHeaders: {
+        ...globalSettings.agentApi.customHeaders,
+        ...repoSettings.agentApi.customHeaders
+      }
+    },
+    environmentVariables: [
+      ...globalSettings.environmentVariables,
+      ...repoSettings.environmentVariables.filter(repoVar => 
+        !globalSettings.environmentVariables.some(globalVar => globalVar.key === repoVar.key)
+      )
+    ]
+  }
+}
+
+// Get effective settings for display (what would actually be used)
+export const getEffectiveSettings = (repoFullname: string): SettingsFormData => {
+  return loadRepositorySettings(repoFullname)
+}


### PR DESCRIPTION
Implements global settings screen at `/settings` with hierarchy support as requested in issue #27.

## Features
- Global settings page with same structure as repo-specific settings
- Settings hierarchy: global → repo override system
- Browser localStorage storage for settings
- Smart merging of environment variables and custom headers
- Repository settings can override global defaults

## Changes
- Added `src/app/settings/page.tsx` for global settings
- Enhanced `src/types/settings.ts` with hierarchy utilities
- Updated repo settings page to use hierarchy system

Fixes #27

Generated with [Claude Code](https://claude.ai/code)