### PR TITLE
fix: improve mobile responsiveness for chat UI

### DIFF
--- a/src/app/agentapi/page.tsx
+++ b/src/app/agentapi/page.tsx
@@ -2,8 +2,8 @@ import AgentAPIChat from '../components/AgentAPIChat';
 
 export default function AgentAPIPage() {
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="container mx-auto py-8 h-screen flex flex-col">
+    <div className="h-dvh bg-gray-50">
+      <div className="container mx-auto h-full flex flex-col">
         <AgentAPIChat />
       </div>
     </div>

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -144,21 +144,21 @@ export default function AgentAPIChat() {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4">
+      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-3 md:p-4 flex-shrink-0">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">AgentAPI Chat</h2>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-2 md:space-x-4">
             {agentStatus && (
-              <div className="flex items-center space-x-2">
+              <div className="flex items-center space-x-1 md:space-x-2">
                 <div className={`w-2 h-2 rounded-full ${agentStatus.status === 'stable' ? 'bg-green-500' : 'bg-yellow-500'}`}></div>
-                <span className={`text-sm font-medium ${getStatusColor(agentStatus.status)}`}>
+                <span className={`text-xs md:text-sm font-medium ${getStatusColor(agentStatus.status)}`}>
                   {agentStatus.status}
                 </span>
               </div>
             )}
-            <div className={`flex items-center space-x-2`}>
+            <div className={`flex items-center space-x-1 md:space-x-2`}>
               <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`}></div>
-              <span className={`text-sm ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+              <span className={`text-xs md:text-sm ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                 {isConnected ? 'Connected' : 'Disconnected'}
               </span>
             </div>
@@ -172,7 +172,7 @@ export default function AgentAPIChat() {
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4 bg-gray-50 dark:bg-gray-900">
+      <div className="flex-1 overflow-y-auto p-3 md:p-4 space-y-4 bg-gray-50 dark:bg-gray-900 mobile-scroll min-h-0">
         {messages.length === 0 && isConnected && (
           <div className="text-center text-gray-500 dark:text-gray-400 py-8">
             No messages yet. Start a conversation with the agent!
@@ -185,13 +185,13 @@ export default function AgentAPIChat() {
             className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
           >
             <div
-              className={`max-w-lg px-4 py-2 rounded-lg ${
+              className={`max-w-[85%] md:max-w-lg px-3 md:px-4 py-2 rounded-lg ${
                 message.role === 'user'
                   ? 'bg-blue-600 text-white'
                   : 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-600'
               }`}
             >
-              <div className="whitespace-pre-wrap break-words">{message.content}</div>
+              <div className="whitespace-pre-wrap break-words text-sm md:text-base">{message.content}</div>
               <div
                 className={`text-xs mt-1 ${
                   message.role === 'user' ? 'text-blue-100' : 'text-gray-500 dark:text-gray-400'
@@ -206,8 +206,8 @@ export default function AgentAPIChat() {
       </div>
 
       {/* Input */}
-      <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-4">
-        <div className="flex space-x-4">
+      <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-3 md:p-4 flex-shrink-0">
+        <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-4">
           <textarea
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
@@ -219,14 +219,14 @@ export default function AgentAPIChat() {
                   ? "Agent is running, please wait..."
                   : "Type your message and press Enter to send..."
             }
-            className="flex-1 resize-none border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            rows={3}
+            className="flex-1 resize-none border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent min-h-[2.5rem]"
+            rows={2}
             disabled={!isConnected || isLoading || agentStatus?.status === 'running'}
           />
           <button
             onClick={sendMessage}
             disabled={!isConnected || isLoading || !inputValue.trim() || agentStatus?.status === 'running'}
-            className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
+            className="px-4 md:px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed text-sm md:text-base flex-shrink-0"
           >
             {isLoading ? 'Sending...' : 'Send'}
           </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,3 +25,31 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+/* Mobile viewport fixes */
+@supports (height: 100dvh) {
+  .h-dvh {
+    height: 100dvh;
+  }
+}
+
+@supports not (height: 100dvh) {
+  .h-dvh {
+    height: 100vh;
+  }
+}
+
+/* Mobile-specific improvements */
+@media (max-width: 768px) {
+  /* Ensure proper mobile scrolling */
+  .mobile-scroll {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+  
+  /* Adjust container padding for mobile */
+  .container {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}


### PR DESCRIPTION
Fixes #38

This PR addresses the mobile responsiveness issue where the chat UI was being cut off vertically on mobile devices.

## Changes
- Replace h-screen with h-dvh for better mobile viewport handling
- Remove conflicting padding that caused vertical overflow
- Add responsive spacing and sizing throughout chat interface
- Improve message bubbles and input layout for mobile screens
- Add mobile-specific CSS optimizations for scrolling

## Testing
- Build validation passed
- Linting passed
- TypeScript compilation successful

Generated with [Claude Code](https://claude.ai/code)