### PR TITLE
feat: change agentapi-proxy default port from 8081 to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cp .env.example .env.local
 NEXT_PUBLIC_AGENTAPI_URL=http://localhost:8080/api/v1
 
 # AgentAPI Proxy Configuration (Session management)
-NEXT_PUBLIC_AGENTAPI_PROXY_URL=http://localhost:8081
+NEXT_PUBLIC_AGENTAPI_PROXY_URL=http://localhost:8080
 ```
 
 4. 開発サーバーの起動:
@@ -42,7 +42,7 @@ npm run dev
 
 1. [agentapi-proxy](https://github.com/takutakahashi/agentapi-proxy) を起動
 2. UIの設定画面 (`/settings`) でproxy設定を有効化
-3. Proxy Endpoint を設定 (デフォルト: `http://localhost:8081`)
+3. Proxy Endpoint を設定 (デフォルト: `http://localhost:8080`)
 
 ### Settings管理
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -250,7 +250,7 @@ export default function GlobalSettingsPage() {
                   type="url"
                   value={settings.agentApiProxy.endpoint}
                   onChange={(e) => updateAgentApiProxySetting('endpoint', e.target.value)}
-                  placeholder="http://localhost:8081"
+                  placeholder="http://localhost:8080"
                   disabled={!settings.agentApiProxy.enabled}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
                 />

--- a/src/lib/agentapi-client.ts
+++ b/src/lib/agentapi-client.ts
@@ -457,7 +457,7 @@ export function getAgentAPIConfigFromStorage(repoFullname?: string): AgentAPICli
   if (typeof window === 'undefined') {
     // Server-side rendering or Node.js environment - use environment variables
     return {
-      baseURL: process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || process.env.NEXT_PUBLIC_AGENTAPI_URL || 'http://localhost:8081',
+      baseURL: process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || process.env.NEXT_PUBLIC_AGENTAPI_URL || 'http://localhost:8080',
       apiKey: process.env.AGENTAPI_API_KEY,
       timeout: parseInt(process.env.AGENTAPI_TIMEOUT || '10000'),
       debug: process.env.NODE_ENV === 'development',
@@ -485,7 +485,7 @@ export function getAgentAPIConfigFromStorage(repoFullname?: string): AgentAPICli
       : settings.agentApi.timeout;
     
     return {
-      baseURL: baseURL || process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || process.env.NEXT_PUBLIC_AGENTAPI_URL || 'http://localhost:8081',
+      baseURL: baseURL || process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || process.env.NEXT_PUBLIC_AGENTAPI_URL || 'http://localhost:8080',
       apiKey: settings.agentApi.apiKey || process.env.AGENTAPI_API_KEY,
       timeout: timeout || parseInt(process.env.AGENTAPI_TIMEOUT || '10000'),
       debug: process.env.NODE_ENV === 'development',
@@ -494,7 +494,7 @@ export function getAgentAPIConfigFromStorage(repoFullname?: string): AgentAPICli
     console.warn('Failed to load settings from storage, using environment variables:', error);
     // Fallback to environment variables if storage access fails
     return {
-      baseURL: process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || process.env.NEXT_PUBLIC_AGENTAPI_URL || 'http://localhost:8081',
+      baseURL: process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || process.env.NEXT_PUBLIC_AGENTAPI_URL || 'http://localhost:8080',
       apiKey: process.env.AGENTAPI_API_KEY,
       timeout: parseInt(process.env.AGENTAPI_TIMEOUT || '10000'),
       debug: process.env.NODE_ENV === 'development',

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -49,7 +49,7 @@ export const getDefaultSettings = (): SettingsFormData => ({
     customHeaders: {}
   },
   agentApiProxy: {
-    endpoint: process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || 'http://localhost:8081',
+    endpoint: process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || 'http://localhost:8080',
     enabled: true,
     timeout: 30000
   },


### PR DESCRIPTION
agentapi-proxy のデフォルトポートを8081から8080に変更しました。

## 変更内容
- 設定のデフォルトプロキシエンドポイントを更新
- agentapi-clientのフォールバック設定を更新
- 設定ページのUIプレースホルダーテキストを更新
- ドキュメント例を更新

Fixes #56

Generated with [Claude Code](https://claude.ai/code)