### PR TITLE
feat: restructure UI to show session list on main page

### DIFF
--- a/src/app/components/TopNavigationBar.tsx
+++ b/src/app/components/TopNavigationBar.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export default function TopNavigationBar() {
+  const pathname = usePathname()
+
+  return (
+    <nav className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+      <div className="px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          {/* Logo/Title */}
+          <div className="flex-shrink-0">
+            <Link href="/" className="flex items-center">
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+                AgentAPI UI
+              </h1>
+            </Link>
+          </div>
+
+          {/* Navigation Links */}
+          <div className="hidden md:block">
+            <div className="ml-10 flex items-baseline space-x-4">
+              <Link
+                href="/"
+                className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  pathname === '/'
+                    ? 'bg-gray-900 text-white dark:bg-gray-700'
+                    : 'text-gray-500 hover:bg-gray-700 hover:text-white dark:text-gray-300 dark:hover:bg-gray-600'
+                }`}
+              >
+                Sessions
+              </Link>
+              <Link
+                href="/agentapi"
+                className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  pathname === '/agentapi'
+                    ? 'bg-gray-900 text-white dark:bg-gray-700'
+                    : 'text-gray-500 hover:bg-gray-700 hover:text-white dark:text-gray-300 dark:hover:bg-gray-600'
+                }`}
+              >
+                Chat
+              </Link>
+            </div>
+          </div>
+
+          {/* Settings Button */}
+          <div className="flex items-center">
+            <Link
+              href="/settings"
+              className={`inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md transition-colors ${
+                pathname === '/settings'
+                  ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/20'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
+              }`}
+            >
+              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              Settings
+            </Link>
+          </div>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
+import TopNavigationBar from './components/TopNavigationBar'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -46,7 +47,10 @@ export default function RootLayout({
         <link rel="icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" href="/icon-192x192.png" />
       </head>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <TopNavigationBar />
+        {children}
+      </body>
     </html>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,102 +1,28 @@
-import Link from 'next/link'
+'use client'
+
+import { Suspense } from 'react'
+import ConversationList from './components/ConversationList'
+import LoadingSpinner from './components/LoadingSpinner'
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
-        <h1 className="text-4xl font-bold text-center lg:text-left">
-          Welcome to AgentAPI UI
-        </h1>
-      </div>
-
-      <div className="relative flex place-items-center before:absolute before:h-[300px] before:w-[480px] before:-translate-x-1/2 before:translate-y-[-10px] before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-[240px] after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 before:lg:h-[360px] z-[-1]">
-        <div className="text-center">
-          <h2 className="mb-3 text-2xl font-semibold">
-            AgentAPI Interface
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            A powerful UI for interacting with AgentAPI
+    <main className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="px-4 md:px-6 lg:px-8 py-6 md:py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+            Sessions
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            Manage and monitor your conversation sessions
           </p>
         </div>
-      </div>
 
-      <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left">
-        <Link
-          href="/agentapi"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            AgentAPI Chat{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            Chat directly with AgentAPI from your browser.
-          </p>
-        </Link>
-
-        <Link
-          href="/chats"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Conversations{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            View and manage your conversation sessions.
-          </p>
-        </Link>
-
-        <a
-          href="/agents"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          rel="noopener noreferrer"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Agents{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            Manage and monitor your agents.
-          </p>
-        </a>
-
-        <a
-          href="/metrics"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          rel="noopener noreferrer"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Metrics{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            View real-time metrics and performance data.
-          </p>
-        </a>
-
-        <Link
-          href="/settings"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Settings{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-balance`}>
-            Configure your AgentAPI settings and preferences.
-          </p>
-        </Link>
+        {/* Session List */}
+        <div className="w-full">
+          <Suspense fallback={<LoadingSpinner />}>
+            <ConversationList />
+          </Suspense>
+        </div>
       </div>
     </main>
   )


### PR DESCRIPTION
Closes #63

This PR restructures the UI as requested:

- ✅ Changed the main page to show session list instead of welcome cards
- ✅ Added top navigation bar with settings button
- ✅ Maintains all existing session functionality (filtering, quick start, pagination)
- ✅ Responsive design with proper navigation states

Generated with [Claude Code](https://claude.ai/code)