### PR TITLE
fix: handle null sessions data to prevent forEach TypeError

### DIFF
--- a/src/app/components/ConversationList.tsx
+++ b/src/app/components/ConversationList.tsx
@@ -66,7 +66,7 @@ export default function ConversationList() {
       }
 
       const response = await client.getSessions(params)
-      setAllSessions(response.sessions)
+      setAllSessions(response.sessions || [])
     } catch (err) {
       if (err instanceof AgentAPIError) {
         setError(`Failed to load sessions: ${err.message}`)

--- a/src/lib/agentapi-client.ts
+++ b/src/lib/agentapi-client.ts
@@ -312,7 +312,10 @@ export class AgentAPIClient {
 
     const endpoint = `/search${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
     const result = await this.makeRequest<SessionListResponse>(endpoint);
-    return result.data;
+    return {
+      ...result.data,
+      sessions: result.data.sessions || []
+    };
   }
 
   async createSession(data: CreateSessionRequest): Promise<Session> {
@@ -343,7 +346,10 @@ export class AgentAPIClient {
 
     const endpoint = `/${sessionId}/messages${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
     const result = await this.makeRequest<SessionMessageListResponse>(endpoint);
-    return result.data;
+    return {
+      ...result.data,
+      messages: result.data.messages || []
+    };
   }
 
   async sendSessionMessage(sessionId: string, data: SendSessionMessageRequest): Promise<SessionMessage> {

--- a/src/lib/filter-utils.ts
+++ b/src/lib/filter-utils.ts
@@ -25,6 +25,11 @@ export function extractFilterGroups(sessions: Session[]): FilterGroup[] {
   const metadataKeys = new Map<string, Map<string, number>>()
   const environmentKeys = new Map<string, Map<string, number>>()
 
+  // Handle null/undefined sessions gracefully
+  if (!sessions || !Array.isArray(sessions)) {
+    return []
+  }
+
   // Process each session to extract keys and values
   sessions.forEach(session => {
     // Process metadata
@@ -91,6 +96,11 @@ export function extractFilterGroups(sessions: Session[]): FilterGroup[] {
  * Apply filters to sessions (client-side filtering)
  */
 export function applySessionFilters(sessions: Session[], filters: SessionFilter): Session[] {
+  // Handle null/undefined sessions gracefully
+  if (!sessions || !Array.isArray(sessions)) {
+    return []
+  }
+
   return sessions.filter(session => {
     // Status filter
     if (filters.status && session.status !== filters.status) {


### PR DESCRIPTION
Fixes #68

Added null safety checks to handle cases where agentapi-proxy returns null for sessions data, preventing the TypeError: "Cannot read properties of null (reading 'forEach')"

## Changes
- Added null safety checks to extractFilterGroups() and applySessionFilters() in filter-utils.ts
- Added fallback to empty array in ConversationList.tsx when setting sessions from API response
- Added null safety to getSessions() and getSessionMessages() API client methods

Generated with [Claude Code](https://claude.ai/code)