### PR TITLE
セッション一覧画面をシンプルなリスト形式に変更

### DIFF
--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -9,22 +9,23 @@ interface SessionCardProps {
 }
 
 export default function SessionCard({ session }: SessionCardProps) {
-  const formatDate = (dateString: string) => {
+  const formatRelativeTime = (dateString: string) => {
     const date = new Date(dateString)
     const now = new Date()
-    const diff = now.getTime() - date.getTime()
-    
-    if (diff < 60 * 1000) {
-      return 'Just now'
-    } else if (diff < 60 * 60 * 1000) {
-      return `${Math.floor(diff / (60 * 1000))} minutes ago`
-    } else if (diff < 24 * 60 * 60 * 1000) {
-      return `${Math.floor(diff / (60 * 60 * 1000))} hours ago`
-    } else {
-      return date.toLocaleDateString()
-    }
+    const diffMs = now.getTime() - date.getTime()
+    const diffMins = Math.floor(diffMs / (1000 * 60))
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+    if (diffMins < 60) return `${diffMins}分前`
+    if (diffHours < 24) return `${diffHours}時間前`
+    return `${diffDays}日前`
   }
 
+  const truncateText = (text: string, maxLength: number = 80) => {
+    if (text.length <= maxLength) return text
+    return text.substring(0, maxLength) + '...'
+  }
 
   return (
     <div className="border-b border-gray-200 dark:border-gray-700 px-4 py-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
@@ -32,16 +33,15 @@ export default function SessionCard({ session }: SessionCardProps) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3 mb-2">
             <h3 className="text-base font-medium text-gray-900 dark:text-white truncate">
-              {(typeof session.metadata?.description === 'string' ? session.metadata.description : null) || `Session ${session.session_id.substring(0, 8)}`}
+              {truncateText(String(session.metadata?.description || `Session ${session.session_id.substring(0, 8)}`), 80)}
             </h3>
-            <StatusBadge 
-              status={session.status}
-            />
+            <StatusBadge status={session.status} />
           </div>
 
           <div className="flex items-center text-xs text-gray-500 dark:text-gray-400 space-x-4 mb-2">
             <span>#{session.session_id.substring(0, 8)}</span>
-            <span>opened {formatDate(session.created_at)}</span>
+            <span>作成: {formatRelativeTime(session.created_at)}</span>
+            <span>更新: {formatRelativeTime(session.updated_at)}</span>
             <span>by {session.user_id}</span>
             {session.environment?.WORKSPACE_NAME && (
               <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300">
@@ -49,6 +49,23 @@ export default function SessionCard({ session }: SessionCardProps) {
               </span>
             )}
           </div>
+
+          {/* メタデータタグ */}
+          {session.metadata && (
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(session.metadata).map(([key, value]) => {
+                if (key === 'description') return null
+                return (
+                  <span
+                    key={key}
+                    className="inline-flex items-center px-2 py-1 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full"
+                  >
+                    {key}: {String(value)}
+                  </span>
+                )
+              })}
+            </div>
+          )}
         </div>
 
         <div className="flex items-center space-x-2 ml-4">
@@ -60,7 +77,7 @@ export default function SessionCard({ session }: SessionCardProps) {
               <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
               </svg>
-              Chat
+              チャット
             </Link>
           )}
           
@@ -72,7 +89,7 @@ export default function SessionCard({ session }: SessionCardProps) {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
             </svg>
-            View
+            詳細
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
セッション一覧画面をGitHub Issues風のシンプルなリスト形式に変更しました。

### 主な変更点
- **SessionListView**: 複雑なカード形式からシンプルなリスト形式に変更
- **SessionCard**: 同様にシンプルなリスト形式に統一
- **UI改善**: より直感的で使いやすいインターフェースに
- **機能整理**: 不要な機能（メッセージ送信、説明の展開など）を削除
- **日本語対応**: 相対時間表示を日本語に変更
- **メタデータ表示**: タグ形式での見やすい表示

### 技術的変更
- ホバー効果とクリーンなボーダー区切りでリスト表示
- レスポンシブデザインを維持
- メタデータタグの表示を改善
- コードの簡素化とパフォーマンス向上

## Test plan
- [ ] セッション一覧画面が正しく表示される
- [ ] セッションのメタデータが適切にタグ表示される
- [ ] チャットボタンと削除ボタンが正常に動作する
- [ ] レスポンシブデザインが維持されている
- [ ] ダークモードでも正常に表示される

🤖 Generated with [Claude Code](https://claude.ai/code)