### PR TITLE
feat: searchのtagsフィールドを用いたフィルタ機能を実装

### DIFF
--- a/src/app/components/SessionFilterSidebar.tsx
+++ b/src/app/components/SessionFilterSidebar.tsx
@@ -40,7 +40,19 @@ export default function SessionFilterSidebar({
   const handleFilterValueChange = (groupKey: string, value: string, checked: boolean) => {
     const newFilters = { ...currentFilters }
 
-    if (groupKey.startsWith('metadata.')) {
+    if (groupKey.startsWith('tags.')) {
+      const tagKey = groupKey.replace('tags.', '')
+      const currentValues = newFilters.tagFilters[tagKey] || []
+      
+      if (checked) {
+        newFilters.tagFilters[tagKey] = [...currentValues, value]
+      } else {
+        newFilters.tagFilters[tagKey] = currentValues.filter(v => v !== value)
+        if (newFilters.tagFilters[tagKey].length === 0) {
+          delete newFilters.tagFilters[tagKey]
+        }
+      }
+    } else if (groupKey.startsWith('metadata.')) {
       const metadataKey = groupKey.replace('metadata.', '')
       const currentValues = newFilters.metadataFilters[metadataKey] || []
       
@@ -70,7 +82,10 @@ export default function SessionFilterSidebar({
   }
 
   const isValueSelected = (groupKey: string, value: string): boolean => {
-    if (groupKey.startsWith('metadata.')) {
+    if (groupKey.startsWith('tags.')) {
+      const tagKey = groupKey.replace('tags.', '')
+      return currentFilters.tagFilters[tagKey]?.includes(value) || false
+    } else if (groupKey.startsWith('metadata.')) {
       const metadataKey = groupKey.replace('metadata.', '')
       return currentFilters.metadataFilters[metadataKey]?.includes(value) || false
     } else if (groupKey.startsWith('environment.')) {
@@ -84,6 +99,7 @@ export default function SessionFilterSidebar({
     onFiltersChange({
       metadataFilters: {},
       environmentFilters: {},
+      tagFilters: {},
       status: undefined
     })
   }
@@ -91,7 +107,8 @@ export default function SessionFilterSidebar({
   const hasActiveFilters = 
     currentFilters.status ||
     Object.keys(currentFilters.metadataFilters).length > 0 ||
-    Object.keys(currentFilters.environmentFilters).length > 0
+    Object.keys(currentFilters.environmentFilters).length > 0 ||
+    Object.keys(currentFilters.tagFilters).length > 0
 
   const statusOptions = [
     { value: 'all' as const, label: 'All Statuses' },

--- a/src/app/components/TagFilterSidebar.tsx
+++ b/src/app/components/TagFilterSidebar.tsx
@@ -45,6 +45,19 @@ export default function TagFilterSidebar({
       const tagMap = new Map<string, Set<string>>()
       
       sessions.forEach(session => {
+        // Process tags field first (prioritize tags over metadata)
+        if (session.tags) {
+          Object.entries(session.tags).forEach(([key, value]) => {
+            if (value && value !== '') {
+              if (!tagMap.has(key)) {
+                tagMap.set(key, new Set())
+              }
+              tagMap.get(key)!.add(value)
+            }
+          })
+        }
+        
+        // Fallback to metadata for backward compatibility
         if (session.metadata) {
           Object.entries(session.metadata).forEach(([key, value]) => {
             if (key !== 'description') { // description は除外

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -157,6 +157,7 @@ export interface Session {
   updated_at: string;
   environment?: Record<string, string>;
   metadata?: Record<string, unknown>;
+  tags?: Record<string, string>;
 }
 
 export interface SessionListParams {


### PR DESCRIPTION
## 概要

セッション検索・フィルタリング機能でtagsフィールドを使用するように変更し、metadataベースのフィルタからtagsベースのフィルタに移行しました。

## 主な変更点

### ✅ コア機能の更新
- **SessionFilter**: `tagFilters`フィールドを追加し、tagsを優先してmetadataをフォールバック
- **Session型定義**: `tags?: Record<string, string>`フィールドを追加
- **フィルタ処理**: tagsを優先し、URLパラメータも`tags.`プレフィックスで対応

### ✅ UI改善
- **フィルタサイドバー**: tagsフィールドのフィルタリング機能をサポート
- **セッション一覧**: タグ（緑色）とメタデータ（青色）を区別して表示
- **後方互換性**: 既存のmetadataベースフィルタも引き続き動作

### ✅ セッション作成の最適化
- **NewSessionModal** & **NewConversationModal**: 
  - セッション作成時に適切なtagsフィールドを使用
  - `project_type`、`technology`等の分類可能なキーをmetadataからtagsに移動

## テスト計画

- [x] ビルドエラーがないことを確認
- [x] TypeScript型チェックに通ることを確認
- [ ] 既存のmetadataベースフィルタが正常に動作することを確認
- [ ] 新しいtagsベースフィルタが正常に動作することを確認
- [ ] セッション作成時にtagsが適切に設定されることを確認
- [ ] URLパラメータでのフィルタ状態保存が動作することを確認

## 技術的詳細

### フィルタ優先順位
1. **tags フィールド**: 構造化された分類情報（優先）
2. **metadata フィールド**: 自由形式の追加情報（フォールバック）

### 後方互換性
- 既存のmetadataベースフィルタは引き続き動作
- 段階的にtagsフィールドへ移行可能
- UIでタグとメタデータを視覚的に区別

🤖 Generated with [Claude Code](https://claude.ai/code)