### PR TITLE
feat: セッション削除機能をUIに統合

### DIFF
--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -7,9 +7,11 @@ import StatusBadge from './StatusBadge'
 
 interface SessionCardProps {
   session: Session
+  onDelete?: (sessionId: string) => Promise<void>
+  isDeleting?: boolean
 }
 
-export default function SessionCard({ session }: SessionCardProps) {
+export default function SessionCard({ session, onDelete, isDeleting }: SessionCardProps) {
   const [isMobile, setIsMobile] = useState(false)
 
   useEffect(() => {
@@ -117,6 +119,19 @@ export default function SessionCard({ session }: SessionCardProps) {
             </svg>
             <span className="hidden sm:inline">詳細</span>
           </Link>
+          
+          {onDelete && (
+            <button
+              onClick={() => onDelete(session.session_id)}
+              disabled={isDeleting}
+              className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-red-300 dark:border-red-600 hover:bg-red-50 dark:hover:bg-red-700 text-red-700 dark:text-red-300 text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] sm:min-h-0"
+            >
+              <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              <span className="hidden sm:inline">{isDeleting ? '削除中...' : '削除'}</span>
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/agentapi-client.ts
+++ b/src/lib/agentapi-client.ts
@@ -327,7 +327,7 @@ export class AgentAPIClient {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    await this.makeRequest<void>(`/${sessionId}`, {
+    await this.makeRequest<void>(`/sessions/${sessionId}`, {
       method: 'DELETE',
     });
   }


### PR DESCRIPTION
## Summary

PR #62で追加されたDELETE /sessions/{sessionId} APIエンドポイントをUI側に統合しました。

### 変更内容

- **API修正**: `deleteSession`のエンドポイントを`/sessions/{sessionId}`に修正
- **SessionCard**: セッション削除ボタンを追加（オプショナルプロパティ）
- **ConversationList**: セッション削除機能を実装
- **UX改善**: 削除確認ダイアログ、ローディング状態、エラーハンドリングを追加

### 機能

- ✅ 削除前の確認ダイアログ表示
- ✅ 削除中のローディング状態表示
- ✅ エラーハンドリングとユーザーフィードバック
- ✅ 削除後の自動リスト更新
- ✅ モバイル対応UI
- ✅ TypeScript型安全性

### Test plan

- [ ] セッション一覧でセッション削除ボタンが表示されることを確認
- [ ] 削除ボタンクリック時に確認ダイアログが表示されることを確認
- [ ] 削除実行時にローディング状態が表示されることを確認
- [ ] 削除完了後にセッションが一覧から消えることを確認
- [ ] エラー時に適切なエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)