### PR TITLE
fix: correct deleteAgent implementation to match API capabilities

### DIFF
--- a/src/lib/__tests__/agentapi-client.test.ts
+++ b/src/lib/__tests__/agentapi-client.test.ts
@@ -318,15 +318,13 @@ describe('AgentAPIClient', () => {
       );
     });
 
-    it('should delete agent', async () => {
-      await client.deleteAgent('agent-1');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/v1/agents/agent-1',
-        expect.objectContaining({
-          method: 'DELETE',
-        })
+    it('should throw error when attempting to delete agent', async () => {
+      await expect(client.deleteAgent('agent-1')).rejects.toThrow(
+        'Agent deletion is not supported by the AgentAPI backend. This feature is only available in mock mode.'
       );
+      
+      // Should not make any HTTP request
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/agentapi-client.ts
+++ b/src/lib/agentapi-client.ts
@@ -203,9 +203,7 @@ export class AgentAPIClient {
   }
 
   async deleteAgent(id: string): Promise<void> {
-    await this.makeRequest<void>(`/agents/${id}`, {
-      method: 'DELETE',
-    });
+    throw new Error('Agent deletion is not supported by the AgentAPI backend. This feature is only available in mock mode.');
   }
 
   // Metrics Methods


### PR DESCRIPTION
Fixes issue #84

The deleteAgent method in agentapi-client.ts was incorrectly trying to call a DELETE /agents/{id} endpoint that doesn't exist in the real agentapi backend.

According to the agentapi OpenAPI spec, only these endpoints are available:
- /events
- /message
- /messages
- /status

Agent deletion is only supported in mock mode for development/testing.

Generated with [Claude Code](https://claude.ai/code)