### PR TITLE
feat: add Basic Auth support for agentapi proxy

### DIFF
--- a/src/app/settings/[repo_fullname]/page.tsx
+++ b/src/app/settings/[repo_fullname]/page.tsx
@@ -299,10 +299,13 @@ export default function SettingsPage() {
                     <input
                       type="text"
                       value={settings.agentApiProxy.basicAuth?.username || ''}
-                      onChange={(e) => updateAgentApiProxySetting('basicAuth', {
-                        username: e.target.value,
-                        password: settings.agentApiProxy.basicAuth?.password || ''
-                      })}
+                      onChange={(e) => {
+                        const username = e.target.value;
+                        const password = settings.agentApiProxy.basicAuth?.password || '';
+                        updateAgentApiProxySetting('basicAuth', 
+                          username || password ? { username, password } : undefined
+                        );
+                      }}
                       placeholder="Enter username"
                       disabled={!settings.agentApiProxy.enabled}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
@@ -316,10 +319,13 @@ export default function SettingsPage() {
                     <input
                       type="password"
                       value={settings.agentApiProxy.basicAuth?.password || ''}
-                      onChange={(e) => updateAgentApiProxySetting('basicAuth', {
-                        username: settings.agentApiProxy.basicAuth?.username || '',
-                        password: e.target.value
-                      })}
+                      onChange={(e) => {
+                        const password = e.target.value;
+                        const username = settings.agentApiProxy.basicAuth?.username || '';
+                        updateAgentApiProxySetting('basicAuth', 
+                          username || password ? { username, password } : undefined
+                        );
+                      }}
                       placeholder="Enter password"
                       disabled={!settings.agentApiProxy.enabled}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -288,10 +288,13 @@ export default function GlobalSettingsPage() {
                     <input
                       type="text"
                       value={settings.agentApiProxy.basicAuth?.username || ''}
-                      onChange={(e) => updateAgentApiProxySetting('basicAuth', {
-                        username: e.target.value,
-                        password: settings.agentApiProxy.basicAuth?.password || ''
-                      })}
+                      onChange={(e) => {
+                        const username = e.target.value;
+                        const password = settings.agentApiProxy.basicAuth?.password || '';
+                        updateAgentApiProxySetting('basicAuth', 
+                          username || password ? { username, password } : undefined
+                        );
+                      }}
                       placeholder="Enter username"
                       disabled={!settings.agentApiProxy.enabled}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
@@ -305,10 +308,13 @@ export default function GlobalSettingsPage() {
                     <input
                       type="password"
                       value={settings.agentApiProxy.basicAuth?.password || ''}
-                      onChange={(e) => updateAgentApiProxySetting('basicAuth', {
-                        username: settings.agentApiProxy.basicAuth?.username || '',
-                        password: e.target.value
-                      })}
+                      onChange={(e) => {
+                        const password = e.target.value;
+                        const username = settings.agentApiProxy.basicAuth?.username || '';
+                        updateAgentApiProxySetting('basicAuth', 
+                          username || password ? { username, password } : undefined
+                        );
+                      }}
                       placeholder="Enter password"
                       disabled={!settings.agentApiProxy.enabled}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -80,8 +80,8 @@ export class AgentAPIProxyClient {
       'Accept': 'application/json, application/problem+json',
     };
 
-    // Add Basic Auth header if configured
-    if (this.basicAuth) {
+    // Add Basic Auth header if configured with valid credentials
+    if (this.basicAuth && this.basicAuth.username && this.basicAuth.password) {
       const credentials = btoa(`${this.basicAuth.username}:${this.basicAuth.password}`);
       defaultHeaders['Authorization'] = `Basic ${credentials}`;
     }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -55,7 +55,8 @@ export const getDefaultSettings = (): SettingsFormData => ({
   agentApiProxy: {
     endpoint: process.env.NEXT_PUBLIC_AGENTAPI_PROXY_URL || 'http://localhost:8080',
     enabled: true,
-    timeout: 30000
+    timeout: 30000,
+    basicAuth: undefined
   },
   environmentVariables: []
 })


### PR DESCRIPTION
Adds Basic Auth authentication support for agentapi proxy to secure access to the backend agentapi service.

## Changes
- Add basicAuth field to AgentApiProxySettings interface
- Update proxy client to send Basic Auth headers when configured
- Add Basic Auth configuration UI to both global and repository settings pages
- Support environment variables for Basic Auth credentials

Closes #89

Generated with [Claude Code](https://claude.ai/code)