### PR TITLE
fix: handle tags and environment parameters in start operations

### DIFF
--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -147,11 +147,25 @@ export class AgentAPIProxyClient {
   /**
    * Start a new session for a user
    */
-  async start(userId: string, metadata?: Record<string, unknown>): Promise<Session> {
-    const data: CreateSessionRequest = {
-      user_id: userId,
-      metadata: metadata || { source: 'agentapi-ui' }
-    };
+  async start(userId: string, sessionData?: Partial<CreateSessionRequest> | Record<string, unknown>): Promise<Session> {
+    // Handle backward compatibility and new format
+    let data: CreateSessionRequest;
+    
+    if (sessionData && (sessionData.environment || sessionData.tags || sessionData.metadata)) {
+      // New format: sessionData contains environment, metadata, and/or tags
+      data = {
+        user_id: userId,
+        environment: sessionData.environment,
+        metadata: sessionData.metadata || { source: 'agentapi-ui' },
+        tags: sessionData.tags
+      };
+    } else {
+      // Backward compatibility: sessionData is just metadata
+      data = {
+        user_id: userId,
+        metadata: (sessionData as Record<string, unknown>) || { source: 'agentapi-ui' }
+      };
+    }
 
     const session = await this.makeRequest<Session>('/start', {
       method: 'POST',
@@ -360,8 +374,8 @@ export class AgentAPIProxyClient {
   /**
    * Start multiple sessions in parallel
    */
-  async startBatch(userIds: string[], metadata?: Record<string, unknown>): Promise<Session[]> {
-    const promises = userIds.map(userId => this.start(userId, metadata));
+  async startBatch(userIds: string[], sessionData?: Partial<CreateSessionRequest> | Record<string, unknown>): Promise<Session[]> {
+    const promises = userIds.map(userId => this.start(userId, sessionData));
     return Promise.all(promises);
   }
 

--- a/src/lib/unified-agentapi-client.ts
+++ b/src/lib/unified-agentapi-client.ts
@@ -13,6 +13,7 @@ import {
   Session,
   SessionListParams,
   SessionListResponse,
+  CreateSessionRequest,
   SessionMessage,
   SessionMessageListResponse,
   SessionMessageListParams,
@@ -294,14 +295,14 @@ export class UnifiedAgentAPIClient implements UnifiedAgentAPIInterface {
   }
 
   // Session management methods (proxy enabled)
-  async start(userId: string, metadata?: Record<string, unknown>): Promise<Session> {
+  async start(userId: string, sessionData?: Partial<CreateSessionRequest> | Record<string, unknown>): Promise<Session> {
     await this.initialize();
     
     if (!this.proxyClient) {
       throw new Error('Session management features require proxy to be enabled');
     }
     
-    return this.proxyClient.start(userId, metadata);
+    return this.proxyClient.start(userId, sessionData);
   }
 
   async search(params?: SessionListParams): Promise<SessionListResponse> {


### PR DESCRIPTION
Fixes #91

Updated AgentAPIProxyClient.start() and UnifiedAgentAPIClient.start() methods to properly accept and process environment, metadata, and tags parameters from CreateSessionRequest structure.

Previously, UI components were passing {environment, metadata, tags} object but the start methods only used the metadata field, dropping tags and environment parameters.

## Changes
- Updated method signatures to accept Partial<CreateSessionRequest>
- Added logic to extract environment, metadata, and tags from input
- Maintained backward compatibility with existing metadata-only calls
- Updated startBatch method to use new signature

Generated with [Claude Code](https://claude.ai/code)