### PR TITLE
fix: improve mobile UI for long initial messages

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -428,7 +428,7 @@ export default function AgentAPIChat() {
                     </span>
                   </div>
                   <div className="prose prose-sm max-w-none text-gray-700 dark:text-gray-300">
-                    <div className="whitespace-pre-wrap break-words">{message.content}</div>
+                    <div className="whitespace-pre-wrap break-words overflow-wrap-anywhere max-w-full">{message.content}</div>
                   </div>
                 </div>
               </div>

--- a/src/app/components/NewSessionModal.tsx
+++ b/src/app/components/NewSessionModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { agentAPI } from '../../lib/api'
 import type { UnifiedAgentAPIInterface } from '../../lib/unified-agentapi-client'
 
@@ -26,6 +26,16 @@ export default function NewSessionModal({
   const [isCreating, setIsCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [statusMessage, setStatusMessage] = useState('')
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 640)
+    }
+    checkMobile()
+    window.addEventListener('resize', checkMobile)
+    return () => window.removeEventListener('resize', checkMobile)
+  }, [])
 
   const createSessionInBackground = async (client: UnifiedAgentAPIInterface, message: string, repo: string, sessionId: string) => {
     try {
@@ -183,8 +193,8 @@ export default function NewSessionModal({
               value={initialMessage}
               onChange={(e) => setInitialMessage(e.target.value)}
               placeholder="このセッションで何をしたいか説明してください..."
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
-              rows={4}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white resize-y min-h-[120px] max-h-[300px] sm:min-h-[96px]"
+              rows={isMobile ? 6 : 4}
               disabled={isCreating}
               required
             />

--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -50,7 +50,7 @@ export default function SessionCard({ session, onDelete, isDeleting }: SessionCa
           {/* タイトルとステータス */}
           <div className="flex items-start gap-3 mb-2">
             <h3 className="text-sm sm:text-base font-medium text-gray-900 dark:text-white leading-5 sm:leading-6">
-              {truncateText(String(session.metadata?.description || `Session ${session.session_id.substring(0, 8)}`), isMobile ? 60 : 80)}
+              {truncateText(String(session.metadata?.description || `Session ${session.session_id.substring(0, 8)}`), isMobile ? 100 : 120)}
             </h3>
             <StatusBadge status={session.status} />
           </div>


### PR DESCRIPTION
## Summary
- Fixed mobile UI issues when displaying long initial messages
- Improved text wrapping and overflow handling in chat interface
- Enhanced responsive design for session creation modal

## Changes
- **AgentAPIChat**: Added `overflow-wrap-anywhere` and `max-w-full` to prevent horizontal overflow of long messages on mobile devices
- **NewSessionModal**: Made textarea responsive with mobile-specific rows (6 vs 4) and resizable height constraints
- **SessionCard**: Increased text truncation limits for better readability on mobile (100 vs 60 characters)

## Test plan
- [ ] Test chat interface with very long messages on mobile devices
- [ ] Verify session creation modal works well with long initial messages
- [ ] Check session list displays appropriately truncated text on mobile
- [ ] Ensure responsive behavior works across different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)