### PR TITLE
feat: remove agents and chat navigation from home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,22 +20,7 @@ export default function Home() {
         </div>
       </div>
 
-      <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left">
-        <Link
-          href="/agentapi"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            AgentAPI Chat{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            Chat directly with AgentAPI from your browser.
-          </p>
-        </Link>
-
+      <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-3 lg:text-left">
         <Link
           href="/chats"
           className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
@@ -50,22 +35,6 @@ export default function Home() {
             View and manage your conversation sessions.
           </p>
         </Link>
-
-        <a
-          href="/agents"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          rel="noopener noreferrer"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Agents{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            Manage and monitor your agents.
-          </p>
-        </a>
 
         <a
           href="/metrics"


### PR DESCRIPTION
## Summary
- Remove AgentAPI Chat navigation link from home page
- Remove Agents navigation link from home page  
- Update grid layout from 4 columns to 3 columns for better visual balance
- Keep essential navigation: Conversations, Metrics, and Settings

## Test plan
- [ ] Verify home page loads without errors
- [ ] Confirm navigation grid displays correctly with 3 columns
- [ ] Test remaining navigation links work properly
- [ ] Check responsive design on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)