### PR TITLE
feat: add settings navigation button to conversation top bar

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { agentAPI } from '../../lib/api';
 import { AgentAPIProxyError } from '../../lib/agentapi-proxy-client';
 import { SessionMessage, SessionMessageListResponse } from '../../types/agentapi';
@@ -62,6 +62,7 @@ function convertSessionMessageId(id: string | number, fallbackId: number): numbe
 
 export default function AgentAPIChat() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const sessionId = searchParams.get('session');
   
   const [messages, setMessages] = useState<Message[]>([]);
@@ -324,6 +325,18 @@ export default function AgentAPIChat() {
                 {isConnected ? 'Connected' : 'Disconnected'}
               </span>
             </div>
+
+            {/* Settings Navigation Button */}
+            <button
+              onClick={() => router.push('/settings')}
+              className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+              title="Settings"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            </button>
           </div>
         </div>
         {error && (


### PR DESCRIPTION
## Summary
- Add settings navigation button with gear icon to the AgentAPIChat component header
- Button positioned alongside existing agent status and connection status indicators
- Clicking the button navigates to the `/settings` page

## Changes
- Import `useRouter` from `next/navigation` in AgentAPIChat component
- Add settings navigation button with hover states and dark mode support
- Use SVG gear icon for clear visual indication

## Test plan
- [ ] Verify settings button appears in conversation top bar
- [ ] Test clicking button navigates to settings page
- [ ] Confirm button styling works in both light and dark modes
- [ ] Ensure button positioning aligns properly with other status indicators

🤖 Generated with [Claude Code](https://claude.ai/code)