### PR TITLE
feat: improve mobile responsiveness for individual chat screen

### DIFF
--- a/src/app/agentapi/page.tsx
+++ b/src/app/agentapi/page.tsx
@@ -5,7 +5,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 export default function AgentAPIPage() {
   return (
     <div className="h-dvh bg-gray-50">
-      <div className="container mx-auto h-full flex flex-col">
+      <div className="w-full h-full flex flex-col px-0 sm:container sm:mx-auto sm:px-4">
         <Suspense fallback={<LoadingSpinner />}>
           <AgentAPIChat />
         </Suspense>

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -294,33 +294,33 @@ export default function AgentAPIChat() {
   return (
     <div className="flex flex-col h-full bg-white dark:bg-gray-900">
       {/* Header */}
-      <div className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-6 py-4 flex-shrink-0">
+      <div className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 sm:px-6 py-4 flex-shrink-0">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-              AgentAPI Chat
+            <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white">
+              <span className="block sm:inline">AgentAPI Chat</span>
               {sessionId && (
-                <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+                <span className="ml-0 sm:ml-2 text-sm font-normal text-gray-500 dark:text-gray-400 block sm:inline">
                   #{sessionId.substring(0, 8)}
                 </span>
               )}
             </h2>
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-2 sm:space-x-4">
             {/* Agent Status */}
             {agentStatus && (
-              <div className="flex items-center space-x-2">
+              <div className="flex items-center space-x-1 sm:space-x-2">
                 <div className={`w-2 h-2 rounded-full ${agentStatus.status === 'stable' ? 'bg-green-500' : 'bg-yellow-500'}`}></div>
-                <span className={`text-sm ${getStatusColor(agentStatus.status)}`}>
+                <span className={`text-xs sm:text-sm ${getStatusColor(agentStatus.status)} hidden sm:inline`}>
                   {agentStatus.status === 'stable' ? 'Agent Available' : agentStatus.status === 'running' ? 'Agent Running' : agentStatus.status}
                 </span>
               </div>
             )}
             
             {/* Connection Status */}
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-1 sm:space-x-2">
               <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`}></div>
-              <span className={`text-sm ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+              <span className={`text-xs sm:text-sm ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'} hidden sm:inline`}>
                 {isConnected ? 'Connected' : 'Disconnected'}
               </span>
             </div>
@@ -353,27 +353,27 @@ export default function AgentAPIChat() {
         
         <div className="divide-y divide-gray-200 dark:divide-gray-700">
           {messages.map((message) => (
-            <div key={message.id} className="px-6 py-4">
-              <div className="flex items-start space-x-3">
+            <div key={message.id} className="px-4 sm:px-6 py-4">
+              <div className="flex items-start space-x-2 sm:space-x-3">
                 <div className="flex-shrink-0">
-                  <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                  <div className={`w-7 h-7 sm:w-8 sm:h-8 rounded-full flex items-center justify-center ${
                     message.role === 'user' 
                       ? 'bg-blue-500 text-white' 
                       : 'bg-purple-500 text-white'
                   }`}>
                     {message.role === 'user' ? (
-                      <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
                       </svg>
                     ) : (
-                      <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                       </svg>
                     )}
                   </div>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center space-x-2 mb-2">
+                  <div className="flex items-center space-x-1 sm:space-x-2 mb-2">
                     <span className="text-sm font-medium text-gray-900 dark:text-white">
                       {message.role === 'user' ? 'You' : 'AgentAPI'}
                     </span>
@@ -430,11 +430,11 @@ export default function AgentAPIChat() {
       </div>
 
       {/* Input */}
-      <div className="bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-6 py-4 flex-shrink-0">
-        <div className="flex items-start space-x-3">
+      <div className="bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-4 sm:px-6 py-4 flex-shrink-0">
+        <div className="flex items-start space-x-2 sm:space-x-3">
           <div className="flex-shrink-0">
-            <div className="w-8 h-8 rounded-full bg-blue-500 text-white flex items-center justify-center">
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-full bg-blue-500 text-white flex items-center justify-center">
+              <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
               </svg>
             </div>
@@ -456,13 +456,16 @@ export default function AgentAPIChat() {
               disabled={!isConnected || isLoading || agentStatus?.status === 'running'}
             />
             <div className="flex items-center justify-between mt-3">
-              <div className="text-xs text-gray-500 dark:text-gray-400">
+              <div className="text-xs text-gray-500 dark:text-gray-400 hidden sm:block">
                 Press Enter to send, Shift+Enter for new line
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 block sm:hidden">
+                Enter: send
               </div>
               <button
                 onClick={sendMessage}
                 disabled={!isConnected || isLoading || !inputValue.trim() || agentStatus?.status === 'running'}
-                className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed text-sm font-medium"
+                className="px-3 sm:px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed text-sm font-medium"
               >
                 {isLoading ? 'Sending...' : 'Comment'}
               </button>


### PR DESCRIPTION
## Summary
- スマホでの個別チャット画面の幅を全幅に最適化
- パディングやレイアウトをモバイル端末に適したサイズに調整
- ヘッダー要素とステータス表示のレスポンシブ対応を改善

## Changes Made
- パディングを `px-6` から `px-4 sm:px-6` に変更してスマホ時の余白を削減
- ヘッダータイトルとセッションIDの表示を縦積みから横並びに適応
- ステータス表示をスマホでは点のみ表示、テキストはタブレット以上で表示
- アバターとアイコンサイズをスマホ向けに縮小
- 入力エリアのヘルプテキストをスマホ向けに短縮
- 親コンテナをスマホで全幅表示、大画面でコンテナ制限を適用

## Test plan
- [ ] スマホ表示でチャット画面が全幅になることを確認
- [ ] タブレット・デスクトップ表示で既存レイアウトが維持されることを確認
- [ ] ヘッダー要素が適切にレスポンシブ対応されていることを確認
- [ ] メッセージ表示とアバターサイズが適切にスケールされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)