### PR TITLE
feat: add PR creation button to session list

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -235,6 +235,18 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     router.push(`/agentapi?session=${sessionId}`)
   }
 
+  const handleCreatePR = async (sessionId: string) => {
+    try {
+      const prMessage = 'ブランチにすべての変更をプッシュし PR を作成してください'
+      
+      // チャット画面に遷移し、PR作成メッセージを送信するためのクエリパラメータを追加
+      router.push(`/agentapi?session=${sessionId}&message=${encodeURIComponent(prMessage)}`)
+    } catch (err) {
+      console.error('PR作成リクエストの送信に失敗しました:', err)
+      alert('PR作成リクエストの送信に失敗しました')
+    }
+  }
+
   const deleteSession = async (sessionId: string) => {
     if (!confirm('このセッションを削除してもよろしいですか？')) return
 
@@ -493,6 +505,16 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                             <span className="hidden sm:inline">チャット</span>
                           </button>
                         )}
+                        
+                        <button
+                          onClick={() => handleCreatePR(session.session_id)}
+                          className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-green-300 dark:border-green-600 hover:bg-green-50 dark:hover:bg-green-700 text-green-700 dark:text-green-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"
+                        >
+                          <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+                          </svg>
+                          <span className="hidden sm:inline">PR作成</span>
+                        </button>
                         
                         <button
                           onClick={() => deleteSession(session.session_id)}


### PR DESCRIPTION
## Summary
- Add PR creation button to each session in the chat list
- Button navigates to chat with pre-filled PR request message
- Maintains existing UI consistency with green styling for PR actions

## Test plan
- [ ] Verify PR creation button appears on each session
- [ ] Click button redirects to chat with correct session ID
- [ ] Message parameter is properly encoded and handled
- [ ] Button styling is consistent with existing design

🤖 Generated with [Claude Code](https://claude.ai/code)