### PR TITLE
feat: add error display for failed session setup

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -364,15 +364,24 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                   )}
                 </div>
 
-                {/* ローディングアニメーション */}
-                {creatingSession.status !== 'failed' && creatingSession.status !== 'completed' && (
+                {/* ステータスアイコン */}
+                {creatingSession.status === 'failed' ? (
+                  <div className="ml-4">
+                    <div className="flex items-center gap-2 text-red-600 dark:text-red-400">
+                      <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <span className="text-sm font-medium">セットアップに失敗しました</span>
+                    </div>
+                  </div>
+                ) : creatingSession.status !== 'completed' ? (
                   <div className="ml-4">
                     <svg className="animate-spin h-5 w-5 text-blue-600" fill="none" viewBox="0 0 24 24">
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                       <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
                   </div>
-                )}
+                ) : null}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- セットアップ失敗時にセッション一覧でエラー表示を追加
- 初期メッセージ送信に失敗した場合の視覚的フィードバックを改善

## Test plan
- [ ] セッション作成でセットアップが失敗した場合の表示確認
- [ ] エラー表示のスタイリングが正しく適用されることを確認
- [ ] ダークモード対応の確認

🤖 Generated with [Claude Code](https://claude.ai/code)