### PR TITLE
Add agent list with automatic status updates

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -3,19 +3,22 @@
 import { useEffect, useState, useCallback } from 'react'
 import { Agent, AgentListResponse } from '@/types/agentapi'
 import { agentAPIProxy } from '@/lib/agentapi-proxy-client'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-import { Button } from '@/components/ui/button'
-import { RefreshCw } from 'lucide-react'
-import { format } from 'date-fns'
+
+// Simple badge component
+function Badge({ children, variant }: { children: React.ReactNode; variant: string }) {
+  const variants: Record<string, string> = {
+    default: 'bg-green-100 text-green-800',
+    secondary: 'bg-gray-100 text-gray-800',
+    destructive: 'bg-red-100 text-red-800',
+    outline: 'bg-white text-gray-600 border border-gray-300',
+  }
+  
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${variants[variant] || variants.outline}`}>
+      {children}
+    </span>
+  )
+}
 
 export default function AgentsPage() {
   const [agents, setAgents] = useState<Agent[]>([])
@@ -100,11 +103,9 @@ export default function AgentsPage() {
   if (loading) {
     return (
       <div className="p-6">
-        <Card>
-          <CardContent className="p-6">
-            <div className="text-center">Loading agents...</div>
-          </CardContent>
-        </Card>
+        <div className="bg-white shadow rounded-lg p-6">
+          <div className="text-center">Loading agents...</div>
+        </div>
       </div>
     )
   }
@@ -112,93 +113,99 @@ export default function AgentsPage() {
   if (error) {
     return (
       <div className="p-6">
-        <Card>
-          <CardContent className="p-6">
-            <div className="text-center text-destructive">
-              Error: {error}
-            </div>
-            <div className="mt-4 text-center">
-              <Button onClick={handleRefresh}>Try Again</Button>
-            </div>
-          </CardContent>
-        </Card>
+        <div className="bg-white shadow rounded-lg p-6">
+          <div className="text-center text-red-600">
+            Error: {error}
+          </div>
+          <div className="mt-4 text-center">
+            <button
+              onClick={handleRefresh}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
       </div>
     )
   }
 
   return (
     <div className="p-6">
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Agents</CardTitle>
-          <Button
-            variant="outline"
-            size="sm"
+      <div className="bg-white shadow rounded-lg">
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">Agents</h2>
+          <button
             onClick={handleRefresh}
             disabled={refreshing}
+            className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
           >
-            <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+            <svg className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
             Refresh
-          </Button>
-        </CardHeader>
-        <CardContent>
+          </button>
+        </div>
+        <div className="p-6">
           {agents.length === 0 ? (
-            <div className="text-center text-muted-foreground p-8">
+            <div className="text-center text-gray-500 p-8">
               No agents found
             </div>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Running</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Success Rate</TableHead>
-                  <TableHead>Last Activity</TableHead>
-                  <TableHead>Created</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Running</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Success Rate</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Activity</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
                 {agents.map((agent) => {
                   const runningStatus = getRunningStatus(agent)
                   return (
-                    <TableRow key={agent.id}>
-                      <TableCell className="font-medium">
+                    <tr key={agent.id}>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                         {agent.name}
-                      </TableCell>
-                      <TableCell>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
                         <Badge variant={getStatusBadgeVariant(agent.status)}>
                           {agent.status}
                         </Badge>
-                      </TableCell>
-                      <TableCell>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
                         <Badge variant={runningStatus.variant}>
                           {runningStatus.status}
                         </Badge>
-                      </TableCell>
-                      <TableCell>{agent.config.type}</TableCell>
-                      <TableCell>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{agent.config.type}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         {agent.metrics
                           ? `${(agent.metrics.success_rate * 100).toFixed(1)}%`
                           : '-'}
-                      </TableCell>
-                      <TableCell>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         {agent.metrics?.last_activity
-                          ? format(new Date(agent.metrics.last_activity), 'PPp')
+                          ? new Date(agent.metrics.last_activity).toLocaleString()
                           : '-'}
-                      </TableCell>
-                      <TableCell>
-                        {format(new Date(agent.created_at), 'PP')}
-                      </TableCell>
-                    </TableRow>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {new Date(agent.created_at).toLocaleDateString()}
+                      </td>
+                    </tr>
                   )
                 })}
-              </TableBody>
-            </Table>
+                </tbody>
+              </table>
+            </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { Agent, AgentListResponse } from '@/types/agentapi'
+import { agentAPIProxy } from '@/lib/agentapi-proxy-client'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { RefreshCw } from 'lucide-react'
+import { format } from 'date-fns'
+
+export default function AgentsPage() {
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const fetchAgents = useCallback(async () => {
+    try {
+      setError(null)
+      const response: AgentListResponse = await agentAPIProxy.getAgents({
+        limit: 50,
+        page: 1,
+      })
+      setAgents(response.agents)
+    } catch (err) {
+      console.error('Failed to fetch agents:', err)
+      setError(err instanceof Error ? err.message : 'Failed to fetch agents')
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [])
+
+  const handleRefresh = () => {
+    setRefreshing(true)
+    fetchAgents()
+  }
+
+  useEffect(() => {
+    fetchAgents()
+
+    // Set up periodic refresh every 10 seconds
+    const interval = setInterval(() => {
+      fetchAgents()
+    }, 10000)
+
+    return () => clearInterval(interval)
+  }, [fetchAgents])
+
+  const getStatusBadgeVariant = (status: Agent['status']) => {
+    switch (status) {
+      case 'active':
+        return 'default'
+      case 'inactive':
+        return 'secondary'
+      case 'error':
+        return 'destructive'
+      default:
+        return 'outline'
+    }
+  }
+
+  const getRunningStatus = (agent: Agent) => {
+    // Check if agent has metrics to determine if it's running
+    if (!agent.metrics) {
+      return { status: 'idle', variant: 'secondary' as const }
+    }
+
+    // Check last activity to determine if agent is running
+    const lastActivity = agent.metrics.last_activity
+    if (!lastActivity) {
+      return { status: 'idle', variant: 'secondary' as const }
+    }
+
+    const lastActivityDate = new Date(lastActivity)
+    const now = new Date()
+    const diffInSeconds = (now.getTime() - lastActivityDate.getTime()) / 1000
+
+    // If last activity was within 30 seconds, consider it running
+    if (diffInSeconds < 30) {
+      return { status: 'running', variant: 'default' as const }
+    } else if (diffInSeconds < 300) {
+      // If within 5 minutes, consider it idle
+      return { status: 'idle', variant: 'secondary' as const }
+    } else {
+      // Otherwise, consider it stopped
+      return { status: 'stopped', variant: 'outline' as const }
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-6">
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-center">Loading agents...</div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-center text-destructive">
+              Error: {error}
+            </div>
+            <div className="mt-4 text-center">
+              <Button onClick={handleRefresh}>Try Again</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Agents</CardTitle>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={refreshing}
+          >
+            <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {agents.length === 0 ? (
+            <div className="text-center text-muted-foreground p-8">
+              No agents found
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Running</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Success Rate</TableHead>
+                  <TableHead>Last Activity</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {agents.map((agent) => {
+                  const runningStatus = getRunningStatus(agent)
+                  return (
+                    <TableRow key={agent.id}>
+                      <TableCell className="font-medium">
+                        {agent.name}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={getStatusBadgeVariant(agent.status)}>
+                          {agent.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={runningStatus.variant}>
+                          {runningStatus.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{agent.config.type}</TableCell>
+                      <TableCell>
+                        {agent.metrics
+                          ? `${(agent.metrics.success_rate * 100).toFixed(1)}%`
+                          : '-'}
+                      </TableCell>
+                      <TableCell>
+                        {agent.metrics?.last_activity
+                          ? format(new Date(agent.metrics.last_activity), 'PPp')
+                          : '-'}
+                      </TableCell>
+                      <TableCell>
+                        {format(new Date(agent.created_at), 'PP')}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,22 @@ export default function Home() {
         </div>
       </div>
 
-      <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-3 lg:text-left">
+      <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left">
+        <Link
+          href="/agents"
+          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+        >
+          <h2 className={`mb-3 text-2xl font-semibold`}>
+            Agents{' '}
+            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
+              -&gt;
+            </span>
+          </h2>
+          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
+            View and monitor your agents status.
+          </p>
+        </Link>
+
         <Link
           href="/chats"
           className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -8,7 +8,10 @@ import {
   SessionMessageListParams,
   SendSessionMessageRequest,
   SessionEventData,
-  SessionEventsOptions
+  SessionEventsOptions,
+  Agent,
+  AgentListResponse,
+  AgentListParams
 } from '../types/agentapi';
 import { loadGlobalSettings, loadRepositorySettings } from '../types/settings';
 
@@ -338,6 +341,34 @@ export class AgentAPIProxyClient {
 
   // Session management utilities
 
+  // Agent operations
+
+  /**
+   * Get list of agents
+   */
+  async getAgents(params?: AgentListParams): Promise<AgentListResponse> {
+    const searchParams = new URLSearchParams();
+    
+    if (params?.page) searchParams.set('page', params.page.toString());
+    if (params?.limit) searchParams.set('limit', params.limit.toString());
+    if (params?.status) searchParams.set('status', params.status);
+    if (params?.name) searchParams.set('name', params.name);
+
+    const endpoint = `/agents${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
+    const result = await this.makeRequest<AgentListResponse>(endpoint);
+    
+    return {
+      ...result,
+      agents: result.agents || []
+    };
+  }
+
+  /**
+   * Get a specific agent by ID
+   */
+  async getAgent(agentId: string): Promise<Agent> {
+    return this.makeRequest<Agent>(`/agents/${agentId}`);
+  }
 
   /**
    * Health check for the proxy


### PR DESCRIPTION
## Summary
- エージェント一覧を表示する新しいページを追加しました
- 10秒間隔でエージェントのステータスを自動更新する機能を実装しました
- エージェントの実行状態（running/idle/stopped）を視覚的に表示します

## Changes
- `agentapi-proxy-client.ts`: エージェント取得用のAPIメソッド（`getAgents`、`getAgent`）を追加
- `/agents` ページ: エージェント一覧を表示する新しいページを作成
- ホームページ: エージェントページへのナビゲーションリンクを追加

## Features
### ステータス表示
- **Agent Status**: active/inactive/error のエージェント状態を表示
- **Running Status**: last_activityに基づいて実行状態を判定
  - 30秒以内: running（実行中）
  - 5分以内: idle（アイドル）
  - それ以上: stopped（停止）

### 自動更新
- 10秒間隔でエージェント一覧を自動的に再取得
- 手動リフレッシュボタンも用意

## Test plan
- [ ] `/agents` ページにアクセスしてエージェント一覧が表示されることを確認
- [ ] 10秒待ってデータが自動更新されることを確認
- [ ] リフレッシュボタンで手動更新できることを確認
- [ ] ホームページからエージェントページへのリンクが機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)