### PR TITLE
セッション一覧にエージェント稼働状態表示を追加

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -463,7 +463,7 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                           <div className="flex items-center gap-2">
                             <StatusBadge status={session.status} />
                             {sessionAgentStatus[session.session_id] && (
-                              <span className={`w-3 h-3 rounded-full ${
+                              <div className={`w-3 h-3 rounded-full flex-shrink-0 ${
                                 sessionAgentStatus[session.session_id].status === 'running'
                                   ? 'bg-yellow-500 animate-pulse'
                                   : sessionAgentStatus[session.session_id].status === 'stable'

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { Session, Agent, AgentStatus } from '../../types/agentapi'
+import { Session, AgentStatus } from '../../types/agentapi'
 import { agentAPI } from '../../lib/api'
 import { agentAPIProxy, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
 import StatusBadge from './StatusBadge'

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -462,21 +462,15 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                           </h3>
                           <div className="flex items-center gap-2">
                             <StatusBadge status={session.status} />
-                            {sessionAgentStatus[session.session_id] && (() => {
-                              const statusInfo = getAgentStatusDisplayInfo(sessionAgentStatus[session.session_id])
-                              return (
-                                <span className={`inline-flex items-center px-2 py-1 text-xs font-medium rounded-full ${statusInfo.colorClass}`}>
-                                  <span className={`w-2 h-2 rounded-full mr-1.5 ${
-                                    sessionAgentStatus[session.session_id].status === 'running'
-                                      ? 'bg-yellow-500 animate-pulse'
-                                      : sessionAgentStatus[session.session_id].status === 'stable'
-                                      ? 'bg-green-500'
-                                      : 'bg-red-500'
-                                  }`} />
-                                  Agent: {statusInfo.text}
-                                </span>
-                              )
-                            })()}
+                            {sessionAgentStatus[session.session_id] && (
+                              <span className={`w-3 h-3 rounded-full ${
+                                sessionAgentStatus[session.session_id].status === 'running'
+                                  ? 'bg-yellow-500 animate-pulse'
+                                  : sessionAgentStatus[session.session_id].status === 'stable'
+                                  ? 'bg-green-500'
+                                  : 'bg-red-500'
+                              }`} title={`Agent: ${getAgentStatusDisplayInfo(sessionAgentStatus[session.session_id]).text}`} />
+                            )}
                           </div>
                         </div>
 


### PR DESCRIPTION
## Summary

- セッション一覧でエージェントの稼働状態をリアルタイム表示
- Chat画面と同様の状態インジケーターを実装  
- 10秒間隔での自動更新機能を追加

## 変更内容

- `agentAPIProxy.getSessionStatus()`を使用してセッション単位でエージェント状態を取得
- stable（緑）/running（黄・パルス）/error（赤）の3状態を視覚的に表示
- エージェントの最終活動時刻と現在実行中のタスクも表示
- 各セッションの状態を並列で効率的に取得
- エラー時のフォールバック処理を実装

## Test plan

- [ ] セッション一覧でエージェント状態が表示されることを確認
- [ ] 10秒間隔で状態が更新されることを確認
- [ ] Chat画面の状態表示と一致することを確認
- [ ] エラー時のフォールバック動作を確認
- [ ] モバイル表示での動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)