### PR TITLE
Remove floating new session button

### DIFF
--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -5,7 +5,6 @@ import TagFilterSidebar from '../components/TagFilterSidebar'
 import SessionListView from '../components/SessionListView'
 import NewSessionModal from '../components/NewSessionModal'
 import TopBar from '../components/TopBar'
-import FloatingNewSessionButton from '../components/FloatingNewSessionButton'
 
 interface TagFilter {
   [key: string]: string[]
@@ -154,8 +153,6 @@ export default function ChatsPage() {
         </div>
       </div>
 
-      {/* フローティング新セッションボタン */}
-      <FloatingNewSessionButton onClick={() => setShowNewSessionModal(true)} />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- Removed the floating new session button (blue circular button) from the bottom-right corner of the chats page
- Cleaned up unused import statement

## Changes
- Deleted the `<FloatingNewSessionButton>` component from `/src/app/chats/page.tsx`
- Removed the import for `FloatingNewSessionButton`

## Notes
- Desktop users can still create new sessions using the button in the top area
- The floating button was only visible on mobile devices (`md:hidden` class)

🤖 Generated with [Claude Code](https://claude.ai/code)