### PR TITLE
Remove filter button from TopBar

### DIFF
--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -62,9 +62,6 @@ export default function ChatsPage() {
     <main className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <TopBar
         title="Conversations"
-        showFilterButton={true}
-        filterButtonText={sidebarVisible ? 'フィルタを隠す' : 'フィルタを表示'}
-        onFilterToggle={() => setSidebarVisible(!sidebarVisible)}
         showSettingsButton={true}
       />
 

--- a/src/app/components/TopBar.tsx
+++ b/src/app/components/TopBar.tsx
@@ -45,18 +45,6 @@ export default function TopBar({
           
           {/* 右側のボタン群 */}
           <div className="flex items-center gap-2 flex-shrink-0">
-            {/* フィルタボタン */}
-            {showFilterButton && onFilterToggle && (
-              <button
-                onClick={onFilterToggle}
-                className="inline-flex items-center px-3 py-2 text-sm bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md transition-colors"
-              >
-                <svg className="w-4 h-4 sm:mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.414A1 1 0 013 6.707V4z" />
-                </svg>
-                <span className="hidden sm:inline">{filterButtonText}</span>
-              </button>
-            )}
 
             {/* 新しいセッションボタン */}
             {showNewSessionButton && onNewSession && (


### PR DESCRIPTION
## Summary
- 左上のフィルタボタンを削除しました
- TopBar コンポーネントからフィルタボタンの表示ロジックを削除
- chats ページで渡していたフィルタボタン関連のプロパティを削除

## Changes
- `/src/app/components/TopBar.tsx`: フィルタボタンの表示部分を削除
- `/src/app/chats/page.tsx`: `showFilterButton`, `filterButtonText`, `onFilterToggle` プロパティを削除

## Notes
- フィルタサイドバーは引き続き存在しており、サイドバー自体の閉じるボタンで操作可能です
- フィルタサイドバーを開く方法が必要な場合は、別途実装が必要になります

🤖 Generated with [Claude Code](https://claude.ai/code)