### PR TITLE
Add repository history with incremental search to session modals

### DIFF
--- a/src/utils/repositoryHistory.ts
+++ b/src/utils/repositoryHistory.ts
@@ -1,0 +1,67 @@
+const REPOSITORY_HISTORY_KEY = 'agentapi-repository-history';
+const MAX_HISTORY_SIZE = 10;
+
+export interface RepositoryHistoryItem {
+  repository: string;
+  lastUsed: Date;
+}
+
+export class RepositoryHistory {
+  static getHistory(): RepositoryHistoryItem[] {
+    try {
+      const stored = localStorage.getItem(REPOSITORY_HISTORY_KEY);
+      if (!stored) return [];
+      
+      const items = JSON.parse(stored) as Array<{repository: string; lastUsed: string}>;
+      return items.map(item => ({
+        repository: item.repository,
+        lastUsed: new Date(item.lastUsed)
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  static addRepository(repository: string): void {
+    if (!repository.trim()) return;
+
+    const history = this.getHistory();
+    const existing = history.findIndex(item => item.repository === repository);
+    
+    if (existing !== -1) {
+      history[existing].lastUsed = new Date();
+    } else {
+      history.unshift({
+        repository,
+        lastUsed: new Date()
+      });
+    }
+
+    history.sort((a, b) => b.lastUsed.getTime() - a.lastUsed.getTime());
+    
+    const trimmed = history.slice(0, MAX_HISTORY_SIZE);
+    
+    try {
+      localStorage.setItem(REPOSITORY_HISTORY_KEY, JSON.stringify(trimmed));
+    } catch {
+      // ストレージエラーを無視
+    }
+  }
+
+  static searchRepositories(query: string): string[] {
+    const history = this.getHistory();
+    const lowerQuery = query.toLowerCase();
+    
+    return history
+      .filter(item => item.repository.toLowerCase().includes(lowerQuery))
+      .map(item => item.repository);
+  }
+
+  static clearHistory(): void {
+    try {
+      localStorage.removeItem(REPOSITORY_HISTORY_KEY);
+    } catch {
+      // ストレージエラーを無視
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added repository history functionality to both NewSessionModal and NewConversationModal
- Implemented incremental search with autocomplete dropdown for previously used repositories
- Repository inputs are automatically saved to browser localStorage when sessions are created
- Added dark mode compatible UI styling for the suggestion dropdown

## Features
- Browser storage of up to 10 recent repository inputs
- Incremental search that filters suggestions based on user input
- Click-to-select functionality for suggested repositories
- Automatic history saving when sessions are successfully created
- Last-used ordering of repository suggestions
- Focus/blur event handling for improved UX

## Test plan
- [ ] Test repository input and autocomplete in NewSessionModal
- [ ] Test repository input and autocomplete in NewConversationModal  
- [ ] Verify repository history persists across browser sessions
- [ ] Confirm incremental search filters suggestions correctly
- [ ] Test dark mode compatibility of suggestion dropdown
- [ ] Verify clicking suggestions populates the input field
- [ ] Test that successful session creation saves repository to history

🤖 Generated with [Claude Code](https://claude.ai/code)