### PR TITLE
Add docker-compose.yaml for development environment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  # Frontend Development Server
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: base
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+      - /app/.next
+    environment:
+      - NODE_ENV=development
+      - NEXT_TELEMETRY_DISABLED=1
+    command: bun run dev
+    stdin_open: true
+    tty: true
+    networks:
+      - agentapi-network
+
+  # Production Build (for testing)
+  app-prod:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3000"
+    environment:
+      - NODE_ENV=production
+    networks:
+      - agentapi-network
+    profiles:
+      - production
+
+networks:
+  agentapi-network:
+    driver: bridge
+
+volumes:
+  node_modules:


### PR DESCRIPTION
## Summary
- Add docker-compose.yaml with development and production testing configurations
- Enable hot reload development on port 3000
- Support production build testing on port 3001

## Test plan
- [ ] Run `docker-compose up app` and verify development server starts
- [ ] Test hot reload functionality
- [ ] Run production build with `docker-compose --profile production up app-prod`

🤖 Generated with [Claude Code](https://claude.ai/code)