### PR TITLE
Change API token header from Authorization to X-API-Key

### DIFF
--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -84,7 +84,7 @@ export class AgentAPIProxyClient {
 
     // Add API Key header if available
     if (this.apiKey) {
-      defaultHeaders['Authorization'] = `Bearer ${this.apiKey}`;
+      defaultHeaders['X-API-Key'] = this.apiKey;
     }
 
     const requestOptions: RequestInit = {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -46,9 +46,9 @@ async function apiRequest<T>(
     'Content-Type': 'application/json',
   }
 
-  // Add authorization header if API key is available
+  // Add API key header if API key is available
   if (config.apiKey) {
-    defaultHeaders['Authorization'] = `Bearer ${config.apiKey}`
+    defaultHeaders['X-API-Key'] = config.apiKey
   }
 
   try {


### PR DESCRIPTION
## Summary
- Changed API token header from `Authorization: Bearer <token>` to `X-API-Key: <token>`
- Updated both `src/lib/api.ts` and `src/lib/agentapi-proxy-client.ts`
- Removed Bearer token format and use API key directly

## Test plan
- [ ] Verify API authentication works with X-API-Key header
- [ ] Test both chat API and agent proxy client functionality
- [ ] Confirm no breaking changes in API communication

🤖 Generated with [Claude Code](https://claude.ai/code)