### PR TITLE
Add force stop button to chat interface

### DIFF
--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -213,7 +213,7 @@ export interface SessionMessageListParams {
 
 export interface SendSessionMessageRequest {
   content: string;
-  type: 'user' | 'system';
+  type: 'user' | 'system' | 'raw';
 }
 
 // Session events types for Server-Sent Events


### PR DESCRIPTION
## Summary
- Add stop button that appears when agent is running
- Implement sendStopSignal function that sends ESC key via raw message  
- Extend sendMessage function to support raw message type
- Update types to include 'raw' message type

## Test plan
- [ ] Verify stop button appears only when agent status is 'running'
- [ ] Test that clicking stop button sends ESC sequence to agent
- [ ] Confirm button is properly disabled when disconnected or loading
- [ ] Verify TypeScript compilation succeeds
- [ ] Test responsive design on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)