### PR TITLE
Add PR link display to session list

### DIFF
--- a/docs/PR_URL_INTEGRATION.md
+++ b/docs/PR_URL_INTEGRATION.md
@@ -1,0 +1,111 @@
+# PR URL Integration with agentapi-proxy
+
+このドキュメントは、agentapi-ui が PR URL を表示するために agentapi-proxy から期待するリクエスト形式について説明します。
+
+## 概要
+
+agentapi-ui のセッション一覧画面で PR へのリンクを表示するため、セッションのメタデータに `pr_url` フィールドを含める必要があります。
+
+## 期待されるデータ形式
+
+### セッション作成時
+
+セッションを作成する際、または既存のセッションを更新する際に、`metadata` フィールドに `pr_url` を含めてください：
+
+```json
+{
+  "session_id": "session-001",
+  "user_id": "user-alice",
+  "status": "active",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z",
+  "metadata": {
+    "description": "Feature implementation for user authentication",
+    "repository": "owner/repo-name",
+    "pr_url": "https://github.com/owner/repo-name/pull/123"
+  },
+  "tags": {
+    "project_type": "backend",
+    "technology": "Node.js"
+  }
+}
+```
+
+### セッションリスト取得時
+
+`GET /sessions` または検索エンドポイントでセッション一覧を返す際も、同様に `metadata.pr_url` を含めてください：
+
+```json
+{
+  "sessions": [
+    {
+      "session_id": "session-001",
+      "user_id": "user-alice",
+      "status": "active",
+      "created_at": "2024-01-01T00:00:00Z",
+      "updated_at": "2024-01-01T00:00:00Z",
+      "metadata": {
+        "description": "Feature implementation",
+        "pr_url": "https://github.com/owner/repo/pull/123"
+      }
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "limit": 20
+}
+```
+
+## UI での表示
+
+`metadata.pr_url` が存在する場合：
+- 「PR作成」ボタンの代わりに「PR表示」リンクが表示されます
+- リンクは紫色のボーダーで表示され、外部リンクアイコンが付きます
+- クリックすると新しいタブで PR が開きます
+
+`metadata.pr_url` が存在しない場合：
+- 通常通り「PR作成」ボタンが表示されます
+- クリックするとチャット画面に遷移し、PR 作成メッセージが送信されます
+
+## 実装の推奨事項
+
+### PR URL の設定タイミング
+
+1. **エージェントが PR を作成した時点で設定**
+   - エージェントが `gh pr create` コマンドを実行し、PR URL を取得した際に、セッションのメタデータを更新
+
+2. **PR URL の形式**
+   - GitHub の PR URL 形式に従う: `https://github.com/{owner}/{repo}/pull/{number}`
+   - 完全な URL を保存（相対パスではなく）
+
+### API エンドポイントの推奨実装
+
+セッションメタデータを更新するためのエンドポイント：
+
+```
+PATCH /sessions/{session_id}
+Content-Type: application/json
+
+{
+  "metadata": {
+    "pr_url": "https://github.com/owner/repo/pull/123"
+  }
+}
+```
+
+または、既存のセッション更新エンドポイントがある場合は、それを使用してメタデータを更新してください。
+
+## 注意事項
+
+- `pr_url` は `metadata` オブジェクト内に配置する必要があります
+- URL は文字列型で保存してください
+- セッションの他のメタデータは保持されるべきです（部分更新をサポート）
+
+## 今後の拡張可能性
+
+将来的に以下の情報も追加することを検討できます：
+
+- `pr_status`: PR のステータス（open, merged, closed）
+- `pr_created_at`: PR 作成日時
+- `pr_merged_at`: PR マージ日時
+- `pr_branch`: PR のブランチ名

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -554,15 +554,29 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                           </button>
                         )}
                         
-                        <button
-                          onClick={() => handleCreatePR(session.session_id)}
-                          className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-green-300 dark:border-green-600 hover:bg-green-50 dark:hover:bg-green-700 text-green-700 dark:text-green-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"
-                        >
-                          <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-                          </svg>
-                          <span className="hidden sm:inline">PR作成</span>
-                        </button>
+                        {session.metadata?.pr_url ? (
+                          <a
+                            href={String(session.metadata.pr_url)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-purple-300 dark:border-purple-600 hover:bg-purple-50 dark:hover:bg-purple-700 text-purple-700 dark:text-purple-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"
+                          >
+                            <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                            </svg>
+                            <span className="hidden sm:inline">PR表示</span>
+                          </a>
+                        ) : (
+                          <button
+                            onClick={() => handleCreatePR(session.session_id)}
+                            className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-green-300 dark:border-green-600 hover:bg-green-50 dark:hover:bg-green-700 text-green-700 dark:text-green-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"
+                          >
+                            <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+                            </svg>
+                            <span className="hidden sm:inline">PR作成</span>
+                          </button>
+                        )}
                         
                         <button
                           onClick={() => deleteSession(session.session_id)}


### PR DESCRIPTION
## Summary
- Added conditional PR link display in session list when `pr_url` exists in session metadata
- Button changes from "PR作成" (Create PR) to "PR表示" (Show PR) when a PR URL is available
- PR links open in a new tab with proper security attributes

## Implementation Details
- Modified `SessionListView.tsx` to check for `session.metadata?.pr_url`
- When PR URL exists, displays a purple-bordered link instead of green creation button
- Uses external link icon to indicate the link opens in a new tab
- Maintains existing PR creation functionality when no PR URL is present

## Test plan
- [ ] Verify sessions without `pr_url` in metadata show "PR作成" button
- [ ] Verify sessions with `pr_url` in metadata show "PR表示" link
- [ ] Confirm PR links open correctly in new tabs
- [ ] Test on both desktop and mobile viewports
- [ ] Verify dark mode styling works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)