### PR TITLE
Remove userId parameter from session creation

### DIFF
--- a/src/app/components/ConversationList.tsx
+++ b/src/app/components/ConversationList.tsx
@@ -209,7 +209,7 @@ export default function ConversationList() {
       // Get current filter values to use as default parameters for new session
       const { metadata, environment } = getFilterValuesForSessionCreation(sessionFilters)
       
-      await agentAPI.start('current-user', { // TODO: Get actual user ID
+      await agentAPI.start({
         ...metadata,
         description: quickStartMessage.trim(),
         environment: {

--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -192,13 +192,12 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
 
       // Use unified API client with createSession -> start mapping
       const sessionData = {
-        user_id: userId.trim(),
         environment: Object.keys(environment).length > 0 ? environment : undefined,
         metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         tags: Object.keys(tags).length > 0 ? tags : undefined
       }
       
-      await agentAPI.start!(userId.trim(), {
+      await agentAPI.start!({
         environment: sessionData.environment,
         metadata: sessionData.metadata,
         tags: sessionData.tags

--- a/src/app/components/NewSessionModal.tsx
+++ b/src/app/components/NewSessionModal.tsx
@@ -52,7 +52,7 @@ export default function NewSessionModal({
       }
 
       // セッションを作成 (createSession -> start)
-      const session = await client.start('current-user', {
+      const session = await client.start({
         environment: repo ? {
           REPOSITORY: repo
         } : {},

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -146,16 +146,15 @@ export class AgentAPIProxyClient {
   // High-level operations based on agentapi-proxy
   
   /**
-   * Start a new session for a user
+   * Start a new session
    */
-  async start(userId: string, sessionData?: Partial<CreateSessionRequest> | Record<string, unknown>): Promise<Session> {
+  async start(sessionData?: Partial<CreateSessionRequest> | Record<string, unknown>): Promise<Session> {
     // Handle backward compatibility and new format
-    let data: CreateSessionRequest;
+    let data: Partial<CreateSessionRequest>;
     
     if (sessionData && (sessionData.environment || sessionData.tags || sessionData.metadata)) {
       // New format: sessionData contains environment, metadata, and/or tags
       data = {
-        user_id: userId,
         environment: sessionData.environment as Record<string, string> | undefined,
         metadata: sessionData.metadata as Record<string, unknown> | undefined || { source: 'agentapi-ui' },
         tags: sessionData.tags as Record<string, string> | undefined
@@ -163,7 +162,6 @@ export class AgentAPIProxyClient {
     } else {
       // Backward compatibility: sessionData is just metadata
       data = {
-        user_id: userId,
         metadata: (sessionData as Record<string, unknown>) || { source: 'agentapi-ui' }
       };
     }
@@ -326,8 +324,8 @@ export class AgentAPIProxyClient {
   /**
    * Start multiple sessions in parallel
    */
-  async startBatch(userIds: string[], sessionData?: Partial<CreateSessionRequest> | Record<string, unknown>): Promise<Session[]> {
-    const promises = userIds.map(userId => this.start(userId, sessionData));
+  async startBatch(count: number, sessionData?: Partial<CreateSessionRequest> | Record<string, unknown>): Promise<Session[]> {
+    const promises = Array.from({ length: count }, () => this.start(sessionData));
     return Promise.all(promises);
   }
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `userId` parameter from `AgentAPIProxyClient.start()` method
- Update all component calls to use the new signature without userId
- Change `startBatch()` method to accept a count instead of userIds array
- Eliminate sending 'current-user' string in authentication flow

## Test plan
- [ ] Test session creation from NewSessionModal
- [ ] Test quick session creation from ConversationList
- [ ] Test advanced session creation from NewConversationModal
- [ ] Verify API requests no longer include user_id field

🤖 Generated with [Claude Code](https://claude.ai/code)