### PR TITLE
チャット画面削除後にconversation画面に戻るよう修正

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -315,8 +315,8 @@ export default function AgentAPIChat() {
 
     try {
       await agentAPI.delete(sessionId);
-      // セッション削除後、セッション一覧ページにリダイレクト
-      router.push('/');
+      // セッション削除後、conversation画面にリダイレクト
+      router.push('/chats');
     } catch (err) {
       console.error('Failed to delete session:', err);
       if (err instanceof AgentAPIProxyError) {


### PR DESCRIPTION
## Summary
- 個別チャット画面でセッションを削除した際のリダイレクト先を修正
- ルートページ（/）からconversation画面（/chats）に変更

## Test plan
- [ ] 個別チャット画面でセッション削除ボタンをクリック
- [ ] 削除後にconversation画面（/chats）にリダイレクトされることを確認
- [ ] セッション一覧が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)