### PR TITLE
チャット内URLの自動リンク化機能を追加

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -60,6 +60,33 @@ function convertSessionMessageId(id: string | number, fallbackId: number): numbe
   return hashId > 0 ? hashId : fallbackId;
 }
 
+function formatTextWithLinks(text: string): JSX.Element {
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  
+  const parts = text.split(urlRegex);
+  
+  return (
+    <>
+      {parts.map((part, index) => {
+        if (urlRegex.test(part)) {
+          return (
+            <a
+              key={index}
+              href={part}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline"
+            >
+              {part}
+            </a>
+          );
+        }
+        return part;
+      })}
+    </>
+  );
+}
+
 export default function AgentAPIChat() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -495,7 +522,9 @@ export default function AgentAPIChat() {
                     </span>
                   </div>
                   <div className="prose prose-sm max-w-none text-gray-700 dark:text-gray-300">
-                    <div className="whitespace-pre-wrap break-words overflow-wrap-anywhere max-w-full">{message.content}</div>
+                    <div className="whitespace-pre-wrap break-words overflow-wrap-anywhere max-w-full">
+                      {formatTextWithLinks(message.content)}
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- チャットメッセージ内でHTTP/HTTPSのURLを自動検出してクリック可能なリンクに変換する機能を追加
- 新しいタブでリンクを開くよう設定（target="_blank"、rel="noopener noreferrer"）
- ダークモード対応のスタイリングとホバー効果を実装

## Test plan
- [ ] チャットでURLを含むメッセージを送信して、URLがリンクとして表示されることを確認
- [ ] リンクをクリックして新しいタブで正しく開くことを確認
- [ ] ダークモードでリンクの色が適切に表示されることを確認
- [ ] ホバー時の色変化が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)