### PR TITLE
機能しないPR作成ボタンを削除

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -257,17 +257,6 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     router.push(`/agentapi?session=${sessionId}`)
   }
 
-  const handleCreatePR = async (sessionId: string) => {
-    try {
-      const prMessage = 'ブランチにすべての変更をプッシュし PR を作成してください'
-      
-      // チャット画面に遷移し、PR作成メッセージを送信するためのクエリパラメータを追加
-      router.push(`/agentapi?session=${sessionId}&message=${encodeURIComponent(prMessage)}`)
-    } catch (err) {
-      console.error('PR作成リクエストの送信に失敗しました:', err)
-      alert('PR作成リクエストの送信に失敗しました')
-    }
-  }
 
   const deleteSession = async (sessionId: string) => {
     if (!confirm('このセッションを削除してもよろしいですか？')) return
@@ -566,17 +555,7 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                             </svg>
                             <span className="hidden sm:inline">PR表示</span>
                           </a>
-                        ) : (
-                          <button
-                            onClick={() => handleCreatePR(session.session_id)}
-                            className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-green-300 dark:border-green-600 hover:bg-green-50 dark:hover:bg-green-700 text-green-700 dark:text-green-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"
-                          >
-                            <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-                            </svg>
-                            <span className="hidden sm:inline">PR作成</span>
-                          </button>
-                        )}
+                        ) : null}
                         
                         <button
                           onClick={() => deleteSession(session.session_id)}


### PR DESCRIPTION
## Summary
- 機能していないPR作成ボタンとその関連機能を削除
- `handleCreatePR`関数を削除
- PR作成ボタンのUIコンポーネントを削除
- PR URLが存在しない場合は何も表示しないよう変更

## Test plan
- セッション一覧画面でPR作成ボタンが表示されないことを確認
- PR URLが存在するセッションではPR表示ボタンのみが表示されることを確認
- 削除機能とチャット機能は正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)