### PR TITLE
チャット内URLリンクの改行問題を修正

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -75,7 +75,7 @@ function formatTextWithLinks(text: string): JSX.Element {
               href={part}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline"
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline whitespace-nowrap"
             >
               {part}
             </a>


### PR DESCRIPTION
## 概要
チャット画面でURLが改行によって途切れてしまう問題を修正しました。

## 変更内容
- `formatTextWithLinks`関数内のURLリンクに`whitespace-nowrap`クラスを追加
- これによりURLが改行で分割されることなく、一行で表示されるようになります

## 修正前の問題
- 長いURLが改行位置で途切れてリンクが正常に動作しない
- URLの一部しかクリックできない状態

## 修正後の改善
- URLが改行されずに一行で表示される
- URL全体がクリック可能なリンクとして機能する

🤖 Generated with [Claude Code](https://claude.ai/code)