### PR TITLE
メッセージ送信時のJavaScriptエラーを修正

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -61,6 +61,10 @@ function convertSessionMessageId(id: string | number, fallbackId: number): numbe
 }
 
 function formatTextWithLinks(text: string): JSX.Element {
+  if (!text || typeof text !== 'string') {
+    return <>{text || ''}</>;
+  }
+  
   const urlRegex = /(https?:\/\/[^\s]+)/g;
   
   const parts = text.split(urlRegex);


### PR DESCRIPTION
## Summary
- メッセージ送信時に発生していた「Cannot read properties of undefined (reading 'split')」エラーを修正
- `formatTextWithLinks`関数で`text`パラメータが`undefined`の場合のnull/undefinedチェックを追加

## 問題
メッセージを送信した際に以下のJavaScriptエラーが発生していました：
```
Uncaught TypeError: Cannot read properties of undefined (reading 'split')
```

## 原因
`src/app/components/AgentAPIChat.tsx`の`formatTextWithLinks`関数で、`text`パラメータが`undefined`または`null`の場合にチェックを行わずに`.split()`メソッドを呼び出していたため。

## 修正内容
`formatTextWithLinks`関数の先頭に以下の安全性チェックを追加：
```typescript
if (\!text || typeof text \!== 'string') {
  return <>{text || ''}</>;
}
```

## Test plan
- [x] メッセージ送信機能が正常に動作することを確認
- [x] URLリンク自動化機能が引き続き動作することを確認
- [x] エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)