### PR TITLE
Fix Docker qemu-x86_64 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN bun install --frozen-lockfile
 RUN bun run build
 
 # Production stage
-FROM oven/bun:1.2.11-alpine AS runner
+FROM oven/bun:1.2.11-debian AS runner
 WORKDIR /app
 
 # Create non-root user


### PR DESCRIPTION
## Summary
- DockerのproductionステージでBunのdebianベースイメージを使用するよう変更
- `qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory` エラーを修正

## Test plan
- [ ] Docker環境でアプリケーションが正常に起動することを確認
- [ ] productionビルドが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)