### PR TITLE
プロファイル設定を使用したagentapi-proxyリクエストの実装

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -120,5 +120,10 @@ export const chatApi = {
   },
 }
 
-// AgentAPI Proxy client
+// AgentAPI Proxy client factory
+export function createAgentAPIClient(repoFullname?: string, profileId?: string) {
+  return createAgentAPIProxyClientFromStorage(repoFullname, profileId)
+}
+
+// Default AgentAPI Proxy client for backward compatibility
 export const agentAPI = createAgentAPIProxyClientFromStorage()


### PR DESCRIPTION
## Summary
- プロファイル機能で設定したURLや環境変数を使用してagentapi-proxyにリクエストするように変更
- AgentAPIProxyClientでプロファイルベースの設定取得を実装
- 主要コンポーネントでプロファイル対応を追加

## Changes
- `AgentAPIProxyClient`でプロファイルID指定による設定取得機能を追加
- `AgentAPIChat`、`SessionListView`、`ConversationList`コンポーネントをプロファイル対応に変更
- プロファイル変更イベントに対応してクライアントを動的に再作成
- ProfileManagerからデフォルトプロファイルまたは指定プロファイルの設定を読み込み
- リポジトリ固有の設定とプロファイル履歴の管理を追加

## Test plan
- [ ] プロファイル作成・編集でendpoint/apiKeyを設定
- [ ] プロファイル切り替え時にリクエスト先が変更されることを確認
- [ ] 既存機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)