### PR TITLE
ダークモードでのテキスト色可視性を修正

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -7,10 +7,10 @@ import { agentAPIProxy } from '@/lib/agentapi-proxy-client'
 // Simple badge component
 function Badge({ children, variant }: { children: React.ReactNode; variant: string }) {
   const variants: Record<string, string> = {
-    default: 'bg-green-100 text-green-800',
-    secondary: 'bg-gray-100 text-gray-800',
-    destructive: 'bg-red-100 text-red-800',
-    outline: 'bg-white text-gray-600 border border-gray-300',
+    default: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    secondary: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+    destructive: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+    outline: 'bg-white text-gray-600 border border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600',
   }
   
   return (
@@ -103,8 +103,8 @@ export default function AgentsPage() {
   if (loading) {
     return (
       <div className="p-6">
-        <div className="bg-white shadow rounded-lg p-6">
-          <div className="text-center">Loading agents...</div>
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <div className="text-center text-gray-900 dark:text-white">Loading agents...</div>
         </div>
       </div>
     )
@@ -113,14 +113,14 @@ export default function AgentsPage() {
   if (error) {
     return (
       <div className="p-6">
-        <div className="bg-white shadow rounded-lg p-6">
-          <div className="text-center text-red-600">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <div className="text-center text-red-600 dark:text-red-400">
             Error: {error}
           </div>
           <div className="mt-4 text-center">
             <button
               onClick={handleRefresh}
-              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600"
             >
               Try Again
             </button>
@@ -132,13 +132,13 @@ export default function AgentsPage() {
 
   return (
     <div className="p-6">
-      <div className="bg-white shadow rounded-lg">
-        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-          <h2 className="text-xl font-semibold text-gray-900">Agents</h2>
+      <div className="bg-white dark:bg-gray-800 shadow rounded-lg">
+        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Agents</h2>
           <button
             onClick={handleRefresh}
             disabled={refreshing}
-            className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+            className="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50"
           >
             <svg className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -148,29 +148,29 @@ export default function AgentsPage() {
         </div>
         <div className="p-6">
           {agents.length === 0 ? (
-            <div className="text-center text-gray-500 p-8">
+            <div className="text-center text-gray-500 dark:text-gray-400 p-8">
               No agents found
             </div>
           ) : (
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-700">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Running</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Success Rate</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Activity</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Running</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Type</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Success Rate</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Last Activity</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Created</th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {agents.map((agent) => {
                   const runningStatus = getRunningStatus(agent)
                   return (
                     <tr key={agent.id}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                         {agent.name}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
@@ -183,18 +183,18 @@ export default function AgentsPage() {
                           {runningStatus.status}
                         </Badge>
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{agent.config.type}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{agent.config.type}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {agent.metrics
                           ? `${(agent.metrics.success_rate * 100).toFixed(1)}%`
                           : '-'}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {agent.metrics?.last_activity
                           ? new Date(agent.metrics.last_activity).toLocaleString()
                           : '-'}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {new Date(agent.created_at).toLocaleDateString()}
                       </td>
                     </tr>

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -2,11 +2,11 @@
 
 export default function Offline() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
       <div className="max-w-md mx-auto text-center p-6">
         <div className="mb-4">
           <svg
-            className="w-16 h-16 mx-auto text-gray-400"
+            className="w-16 h-16 mx-auto text-gray-400 dark:text-gray-500"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -19,15 +19,15 @@ export default function Offline() {
             />
           </svg>
         </div>
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
           You&apos;re offline
         </h1>
-        <p className="text-gray-600 mb-4">
+        <p className="text-gray-600 dark:text-gray-300 mb-4">
           Please check your internet connection and try again.
         </p>
         <button
           onClick={() => window.location.reload()}
-          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md transition-colors"
+          className="bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white px-4 py-2 rounded-md transition-colors"
         >
           Try Again
         </button>

--- a/src/app/profiles/[id]/edit/page.tsx
+++ b/src/app/profiles/[id]/edit/page.tsx
@@ -105,7 +105,7 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="text-lg">Loading profile...</div>
+        <div className="text-lg text-gray-900 dark:text-white">Loading profile...</div>
       </div>
     );
   }
@@ -113,7 +113,7 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
   if (!profile) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="text-lg">Profile not found</div>
+        <div className="text-lg text-gray-900 dark:text-white">Profile not found</div>
       </div>
     );
   }
@@ -121,44 +121,44 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
   return (
     <div className="container mx-auto px-4 py-8 max-w-2xl">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Edit Profile</h1>
-        <p className="text-gray-600">Update your profile configuration</p>
+        <h1 className="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Edit Profile</h1>
+        <p className="text-gray-600 dark:text-gray-300">Update your profile configuration</p>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold mb-4">Basic Information</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Basic Information</h2>
           
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Profile Name *
               </label>
               <input
                 type="text"
                 value={formData.name || ''}
                 onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Enter profile name"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Description
               </label>
               <textarea
                 value={formData.description || ''}
                 onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Enter profile description"
                 rows={3}
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Icon
               </label>
               <div className="flex flex-wrap gap-2">
@@ -169,8 +169,8 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                     onClick={() => setFormData(prev => ({ ...prev, icon: emoji }))}
                     className={`text-2xl p-2 rounded-md border-2 transition-colors ${
                       formData.icon === emoji
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 hover:border-gray-300'
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900'
+                        : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
                     }`}
                   >
                     {emoji}
@@ -187,19 +187,19 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                 onChange={(e) => setFormData(prev => ({ ...prev, isDefault: e.target.checked }))}
                 className="mr-2"
               />
-              <label htmlFor="isDefault" className="text-sm text-gray-700">
+              <label htmlFor="isDefault" className="text-sm text-gray-700 dark:text-gray-300">
                 Set as default profile
               </label>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold mb-4">AgentAPI Proxy Settings</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">AgentAPI Proxy Settings</h2>
           
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Endpoint URL *
               </label>
               <input
@@ -209,14 +209,14 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                   ...prev,
                   agentApiProxy: { ...prev.agentApiProxy, endpoint: e.target.value }
                 }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="http://localhost:8080"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 API Key
               </label>
               <input
@@ -226,13 +226,13 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                   ...prev,
                   agentApiProxy: { ...prev.agentApiProxy, apiKey: e.target.value }
                 }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Enter API key"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Timeout (ms)
               </label>
               <input
@@ -242,7 +242,7 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                   ...prev,
                   agentApiProxy: { ...prev.agentApiProxy, timeout: parseInt(e.target.value) }
                 }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 min="1000"
                 max="300000"
               />
@@ -259,16 +259,16 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                 }))}
                 className="mr-2"
               />
-              <label htmlFor="enabled" className="text-sm text-gray-700">
+              <label htmlFor="enabled" className="text-sm text-gray-700 dark:text-gray-300">
                 Enable proxy
               </label>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
           <div className="flex justify-between items-center mb-4">
-            <h2 className="text-xl font-semibold">Environment Variables</h2>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Environment Variables</h2>
             <button
               type="button"
               onClick={addEnvironmentVariable}
@@ -286,21 +286,21 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                   placeholder="Key"
                   value={env.key}
                   onChange={(e) => updateEnvironmentVariable(index, 'key', e.target.value)}
-                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 />
                 <input
                   type="text"
                   placeholder="Value"
                   value={env.value}
                   onChange={(e) => updateEnvironmentVariable(index, 'value', e.target.value)}
-                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 />
                 <input
                   type="text"
                   placeholder="Description (optional)"
                   value={env.description || ''}
                   onChange={(e) => updateEnvironmentVariable(index, 'description', e.target.value)}
-                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 />
                 <button
                   type="button"
@@ -312,21 +312,21 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
               </div>
             ))}
             {(formData.environmentVariables || []).length === 0 && (
-              <div className="text-gray-500 text-sm">No environment variables configured</div>
+              <div className="text-gray-500 dark:text-gray-400 text-sm">No environment variables configured</div>
             )}
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold mb-4">Repository History</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Repository History</h2>
           <div className="space-y-2">
             {profile.repositoryHistory.length === 0 ? (
-              <div className="text-gray-500 text-sm">No repository history</div>
+              <div className="text-gray-500 dark:text-gray-400 text-sm">No repository history</div>
             ) : (
               profile.repositoryHistory.map((repo, index) => (
-                <div key={index} className="flex justify-between items-center py-2 px-3 bg-gray-50 rounded">
-                  <span className="font-mono text-sm">{repo.repository}</span>
-                  <span className="text-xs text-gray-500">
+                <div key={index} className="flex justify-between items-center py-2 px-3 bg-gray-50 dark:bg-gray-700 rounded">
+                  <span className="font-mono text-sm text-gray-900 dark:text-white">{repo.repository}</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
                     {new Date(repo.lastUsed).toLocaleDateString()}
                   </span>
                 </div>
@@ -339,14 +339,14 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
           <button
             type="submit"
             disabled={saving}
-            className="flex-1 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 text-white py-2 px-4 rounded-lg transition-colors"
+            className="flex-1 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 dark:disabled:bg-blue-700 text-white py-2 px-4 rounded-lg transition-colors"
           >
             {saving ? 'Saving...' : 'Save Changes'}
           </button>
           <button
             type="button"
             onClick={handleCancel}
-            className="flex-1 bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded-lg transition-colors"
+            className="flex-1 bg-gray-500 hover:bg-gray-600 dark:bg-gray-600 dark:hover:bg-gray-700 text-white py-2 px-4 rounded-lg transition-colors"
           >
             Cancel
           </button>

--- a/src/app/profiles/new/page.tsx
+++ b/src/app/profiles/new/page.tsx
@@ -75,44 +75,44 @@ export default function NewProfilePage() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-2xl">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Create New Profile</h1>
-        <p className="text-gray-600">Configure a new profile for your agentapi connections</p>
+        <h1 className="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Create New Profile</h1>
+        <p className="text-gray-600 dark:text-gray-300">Configure a new profile for your agentapi connections</p>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold mb-4">Basic Information</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Basic Information</h2>
           
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Profile Name *
               </label>
               <input
                 type="text"
                 value={formData.name}
                 onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Enter profile name"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Description
               </label>
               <textarea
                 value={formData.description}
                 onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Enter profile description"
                 rows={3}
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Icon
               </label>
               <div className="flex flex-wrap gap-2">
@@ -123,8 +123,8 @@ export default function NewProfilePage() {
                     onClick={() => setFormData(prev => ({ ...prev, icon: emoji }))}
                     className={`text-2xl p-2 rounded-md border-2 transition-colors ${
                       formData.icon === emoji
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 hover:border-gray-300'
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900'
+                        : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
                     }`}
                   >
                     {emoji}
@@ -141,19 +141,19 @@ export default function NewProfilePage() {
                 onChange={(e) => setFormData(prev => ({ ...prev, isDefault: e.target.checked }))}
                 className="mr-2"
               />
-              <label htmlFor="isDefault" className="text-sm text-gray-700">
+              <label htmlFor="isDefault" className="text-sm text-gray-700 dark:text-gray-300">
                 Set as default profile
               </label>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold mb-4">AgentAPI Proxy Settings</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">AgentAPI Proxy Settings</h2>
           
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Endpoint URL *
               </label>
               <input
@@ -163,14 +163,14 @@ export default function NewProfilePage() {
                   ...prev,
                   agentApiProxy: { ...prev.agentApiProxy, endpoint: e.target.value }
                 }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="http://localhost:8080"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 API Key
               </label>
               <input
@@ -180,13 +180,13 @@ export default function NewProfilePage() {
                   ...prev,
                   agentApiProxy: { ...prev.agentApiProxy, apiKey: e.target.value }
                 }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Enter API key"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Timeout (ms)
               </label>
               <input
@@ -196,7 +196,7 @@ export default function NewProfilePage() {
                   ...prev,
                   agentApiProxy: { ...prev.agentApiProxy, timeout: parseInt(e.target.value) }
                 }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 min="1000"
                 max="300000"
               />
@@ -213,16 +213,16 @@ export default function NewProfilePage() {
                 }))}
                 className="mr-2"
               />
-              <label htmlFor="enabled" className="text-sm text-gray-700">
+              <label htmlFor="enabled" className="text-sm text-gray-700 dark:text-gray-300">
                 Enable proxy
               </label>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
           <div className="flex justify-between items-center mb-4">
-            <h2 className="text-xl font-semibold">Environment Variables</h2>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Environment Variables</h2>
             <button
               type="button"
               onClick={addEnvironmentVariable}
@@ -240,21 +240,21 @@ export default function NewProfilePage() {
                   placeholder="Key"
                   value={env.key}
                   onChange={(e) => updateEnvironmentVariable(index, 'key', e.target.value)}
-                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 />
                 <input
                   type="text"
                   placeholder="Value"
                   value={env.value}
                   onChange={(e) => updateEnvironmentVariable(index, 'value', e.target.value)}
-                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 />
                 <input
                   type="text"
                   placeholder="Description (optional)"
                   value={env.description || ''}
                   onChange={(e) => updateEnvironmentVariable(index, 'description', e.target.value)}
-                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 />
                 <button
                   type="button"
@@ -266,7 +266,7 @@ export default function NewProfilePage() {
               </div>
             ))}
             {formData.environmentVariables.length === 0 && (
-              <div className="text-gray-500 text-sm">No environment variables configured</div>
+              <div className="text-gray-500 dark:text-gray-400 text-sm">No environment variables configured</div>
             )}
           </div>
         </div>
@@ -275,14 +275,14 @@ export default function NewProfilePage() {
           <button
             type="submit"
             disabled={loading}
-            className="flex-1 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 text-white py-2 px-4 rounded-lg transition-colors"
+            className="flex-1 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 dark:disabled:bg-blue-700 text-white py-2 px-4 rounded-lg transition-colors"
           >
             {loading ? 'Creating...' : 'Create Profile'}
           </button>
           <button
             type="button"
             onClick={handleCancel}
-            className="flex-1 bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded-lg transition-colors"
+            className="flex-1 bg-gray-500 hover:bg-gray-600 dark:bg-gray-600 dark:hover:bg-gray-700 text-white py-2 px-4 rounded-lg transition-colors"
           >
             Cancel
           </button>

--- a/src/app/profiles/page.tsx
+++ b/src/app/profiles/page.tsx
@@ -50,7 +50,7 @@ export default function ProfilesPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="text-lg">Loading profiles...</div>
+        <div className="text-lg text-gray-900 dark:text-white">Loading profiles...</div>
       </div>
     );
   }
@@ -58,7 +58,7 @@ export default function ProfilesPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="flex justify-between items-center mb-8">
-        <h1 className="text-3xl font-bold">Profiles</h1>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Profiles</h1>
         <Link
           href="/profiles/new"
           className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg transition-colors"
@@ -69,7 +69,7 @@ export default function ProfilesPage() {
 
       {profiles.length === 0 ? (
         <div className="text-center py-12">
-          <div className="text-gray-500 mb-4">No profiles found</div>
+          <div className="text-gray-500 dark:text-gray-400 mb-4">No profiles found</div>
           <Link
             href="/profiles/new"
             className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-lg transition-colors"
@@ -82,28 +82,28 @@ export default function ProfilesPage() {
           {profiles.map((profile) => (
             <div
               key={profile.id}
-              className={`bg-white rounded-lg shadow-md p-6 border-2 ${
-                profile.isDefault ? 'border-blue-500' : 'border-gray-200'
+              className={`bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 border-2 ${
+                profile.isDefault ? 'border-blue-500' : 'border-gray-200 dark:border-gray-700'
               }`}
             >
               <div className="flex items-start justify-between mb-4">
                 <div className="flex items-center space-x-3">
                   <span className="text-2xl">{profile.icon || '⚙️'}</span>
                   <div>
-                    <h3 className="font-semibold text-lg">{profile.name}</h3>
+                    <h3 className="font-semibold text-lg text-gray-900 dark:text-white">{profile.name}</h3>
                     {profile.description && (
-                      <p className="text-gray-600 text-sm">{profile.description}</p>
+                      <p className="text-gray-600 dark:text-gray-300 text-sm">{profile.description}</p>
                     )}
                   </div>
                 </div>
                 {profile.isDefault && (
-                  <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
+                  <span className="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 text-xs px-2 py-1 rounded-full">
                     Default
                   </span>
                 )}
               </div>
 
-              <div className="text-sm text-gray-500 mb-4">
+              <div className="text-sm text-gray-500 dark:text-gray-400 mb-4">
                 <div>Repositories: {profile.repositoryCount}</div>
                 {profile.lastUsed && (
                   <div>Last used: {new Date(profile.lastUsed).toLocaleDateString()}</div>
@@ -113,21 +113,21 @@ export default function ProfilesPage() {
               <div className="flex space-x-2">
                 <Link
                   href={`/profiles/${profile.id}/edit`}
-                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-2 rounded text-center text-sm transition-colors"
+                  className="flex-1 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 px-3 py-2 rounded text-center text-sm transition-colors"
                 >
                   Edit
                 </Link>
                 {!profile.isDefault && (
                   <button
                     onClick={() => handleSetDefault(profile.id)}
-                    className="flex-1 bg-green-100 hover:bg-green-200 text-green-700 px-3 py-2 rounded text-sm transition-colors"
+                    className="flex-1 bg-green-100 dark:bg-green-900 hover:bg-green-200 dark:hover:bg-green-800 text-green-700 dark:text-green-200 px-3 py-2 rounded text-sm transition-colors"
                   >
                     Set Default
                   </button>
                 )}
                 <button
                   onClick={() => handleDeleteProfile(profile.id)}
-                  className="bg-red-100 hover:bg-red-200 text-red-700 px-3 py-2 rounded text-sm transition-colors"
+                  className="bg-red-100 dark:bg-red-900 hover:bg-red-200 dark:hover:bg-red-800 text-red-700 dark:text-red-200 px-3 py-2 rounded text-sm transition-colors"
                   disabled={profile.isDefault}
                 >
                   Delete


### PR DESCRIPTION
## Summary
ダークモードでテキストが白い背景に白文字で見えなくなる問題を修正しました。

## Changes
- **agents ページ**: バッジとテキスト色にダークモード対応を追加
- **profiles ページ**: カード背景とテキスト色を修正
- **offline ページ**: 背景とテキスト色にダークモード対応
- **プロファイル作成ページ**: フォーム要素にダークモード対応

## 修正内容
- バッジコンポーネントに `dark:bg-*` と `dark:text-*` クラスを追加
- テーブルヘッダーとセルに適切なダークモード色を設定
- 入力フィールドに `dark:bg-gray-700` と `dark:text-white` を追加
- ボタンとラベルにダークモード色バリアントを追加
- 背景コンテナに `dark:bg-gray-800` などを設定

## Test plan
- [ ] ダークモードでページが正常に表示されることを確認
- [ ] テキストが読みやすく表示されることを確認
- [ ] ライトモードでの既存表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)