### PR TITLE
プロファイル切り替え時のセッション一覧リロード機能を修正

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -90,7 +90,7 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [agentAPI])
 
   const fetchSessionStatuses = useCallback(async () => {
     if (sessions.length === 0) return


### PR DESCRIPTION
## 修正内容

プロファイル切り替え時にセッション一覧が新しいプロファイルの設定で正しくリロードされない問題を修正しました。

## 問題

`fetchSessions`関数の依存関係が空配列`[]`だったため、プロファイル切り替え時に新しいAPIクライアントが作成されても、古いクライアントを参照し続けていました。

## 修正

- `fetchSessions`関数の依存関係に`agentAPI`を追加
- これによりプロファイル切り替え時に新しいAPIクライアントが使用されるようになります

## 動作確認

1. 異なるプロファイルを設定
2. プロファイル切り替えUIでプロファイルを変更
3. セッション一覧が新しいプロファイルの設定（APIエンドポイント、認証情報など）を使用してリロードされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)