### PR TITLE
プロファイルごとのシステムプロンプト機能を実装

### DIFF
--- a/src/app/components/NewSessionModal.tsx
+++ b/src/app/components/NewSessionModal.tsx
@@ -111,8 +111,31 @@ export default function NewSessionModal({
         await new Promise(resolve => setTimeout(resolve, retryInterval))
       }
 
-      // Agent Availableになったら初期メッセージを送信
+      // Agent Availableになったらメッセージを送信
       onSessionStatusUpdate(sessionId, 'sending-message')
+      
+      // 選択されたプロファイルからシステムプロンプトを取得
+      let profile = null
+      if (selectedProfileId) {
+        profile = ProfileManager.getProfile(selectedProfileId)
+      }
+      
+      // システムプロンプトが設定されている場合は最初に送信
+      if (profile?.systemPrompt?.trim()) {
+        console.log(`Sending system prompt to session ${session.session_id}`)
+        try {
+          await client.sendSessionMessage(session.session_id, {
+            content: profile.systemPrompt,
+            type: 'system'
+          })
+          console.log('System prompt sent successfully')
+        } catch (systemErr) {
+          console.warn('Failed to send system prompt:', systemErr)
+          // システムプロンプト送信に失敗してもセッション作成は続行
+        }
+      }
+      
+      // 初期メッセージを送信
       console.log(`Sending initial message to session ${session.session_id}:`, message)
       try {
         await client.sendSessionMessage(session.session_id, {

--- a/src/app/profiles/[id]/edit/page.tsx
+++ b/src/app/profiles/[id]/edit/page.tsx
@@ -37,6 +37,7 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
         name: loadedProfile.name,
         description: loadedProfile.description,
         icon: loadedProfile.icon,
+        systemPrompt: loadedProfile.systemPrompt,
         agentApiProxy: { ...loadedProfile.agentApiProxy },
         environmentVariables: [...loadedProfile.environmentVariables],
         isDefault: loadedProfile.isDefault,
@@ -155,6 +156,22 @@ export default function EditProfilePage({ params }: EditProfilePageProps) {
                 placeholder="Enter profile description"
                 rows={3}
               />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                System Prompt
+              </label>
+              <textarea
+                value={formData.systemPrompt || ''}
+                onChange={(e) => setFormData(prev => ({ ...prev, systemPrompt: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                placeholder="Enter system prompt that will be sent at the beginning of each session"
+                rows={4}
+              />
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                This prompt will be sent automatically when starting a new session with this profile.
+              </p>
             </div>
 
             <div>

--- a/src/app/profiles/new/page.tsx
+++ b/src/app/profiles/new/page.tsx
@@ -112,6 +112,22 @@ export default function NewProfilePage() {
             </div>
 
             <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                System Prompt
+              </label>
+              <textarea
+                value={formData.systemPrompt || ''}
+                onChange={(e) => setFormData(prev => ({ ...prev, systemPrompt: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                placeholder="Enter system prompt that will be sent at the beginning of each session"
+                rows={4}
+              />
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                This prompt will be sent automatically when starting a new session with this profile.
+              </p>
+            </div>
+
+            <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Icon
               </label>

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -6,6 +6,7 @@ export interface Profile {
   name: string;
   description?: string;
   icon?: string;
+  systemPrompt?: string;
   agentApiProxy: AgentApiProxySettings;
   repositoryHistory: RepositoryHistoryItem[];
   environmentVariables: EnvironmentVariable[];
@@ -28,6 +29,7 @@ export interface CreateProfileRequest {
   name: string;
   description?: string;
   icon?: string;
+  systemPrompt?: string;
   agentApiProxy: AgentApiProxySettings;
   environmentVariables: EnvironmentVariable[];
   isDefault?: boolean;
@@ -37,6 +39,7 @@ export interface UpdateProfileRequest {
   name?: string;
   description?: string;
   icon?: string;
+  systemPrompt?: string;
   agentApiProxy?: Partial<AgentApiProxySettings>;
   environmentVariables?: EnvironmentVariable[];
   isDefault?: boolean;

--- a/src/utils/profileManager.ts
+++ b/src/utils/profileManager.ts
@@ -50,6 +50,7 @@ export class ProfileManager {
       name: profileData.name,
       description: profileData.description,
       icon: profileData.icon,
+      systemPrompt: profileData.systemPrompt,
       agentApiProxy: profileData.agentApiProxy,
       repositoryHistory: [],
       environmentVariables: profileData.environmentVariables,


### PR DESCRIPTION
## Summary
- プロファイルごとにシステムプロンプトを設定できる機能を追加
- セッション開始時に自動的にシステムプロンプトを送信
- プロファイル作成・編集画面でシステムプロンプトを管理可能

## 変更内容
- `Profile` 型にsystemPromptフィールドを追加
- プロファイル作成・編集画面にシステムプロンプト入力欄を追加
- セッション開始時のシステムプロンプト自動送信機能を実装
- ProfileManagerでシステムプロンプトの永続化に対応

## 動作フロー
1. プロファイル作成/編集時にシステムプロンプトを設定
2. セッション開始時に選択されたプロファイルを確認
3. システムプロンプトが設定されている場合、最初にシステムメッセージとして送信
4. その後、ユーザーの初期メッセージを送信

🤖 Generated with [Claude Code](https://claude.ai/code)