### PR TITLE
システムプロンプトと初期メッセージを結合して送信

### DIFF
--- a/src/app/components/NewSessionModal.tsx
+++ b/src/app/components/NewSessionModal.tsx
@@ -120,29 +120,21 @@ export default function NewSessionModal({
         profile = ProfileManager.getProfile(selectedProfileId)
       }
       
-      // システムプロンプトが設定されている場合は最初に送信
+      // システムプロンプトと初期メッセージを結合
+      let combinedMessage = message
       if (profile?.systemPrompt?.trim()) {
-        console.log(`Sending system prompt to session ${session.session_id}`)
-        try {
-          await client.sendSessionMessage(session.session_id, {
-            content: profile.systemPrompt,
-            type: 'system'
-          })
-          console.log('System prompt sent successfully')
-        } catch (systemErr) {
-          console.warn('Failed to send system prompt:', systemErr)
-          // システムプロンプト送信に失敗してもセッション作成は続行
-        }
+        combinedMessage = `${profile.systemPrompt}\n\n---\n\n${message}`
+        console.log(`Combined system prompt with initial message for session ${session.session_id}`)
       }
       
-      // 初期メッセージを送信
-      console.log(`Sending initial message to session ${session.session_id}:`, message)
+      // 結合されたメッセージを送信
+      console.log(`Sending combined message to session ${session.session_id}:`, combinedMessage)
       try {
         await client.sendSessionMessage(session.session_id, {
-          content: message,
+          content: combinedMessage,
           type: 'user'
         })
-        console.log('Initial message sent successfully')
+        console.log('Combined message sent successfully')
         
         // リポジトリ履歴に追加
         if (repo && selectedProfileId) {


### PR DESCRIPTION
## Summary
- システムプロンプトと初期メッセージを結合して一つのメッセージとして送信するように修正
- より自然で効率的なメッセージ送信フローを実現

## 変更内容

### 変更前
- システムプロンプトを `type: 'system'` で先に送信
- その後、初期メッセージを `type: 'user'` で送信

### 変更後
- システムプロンプトと初期メッセージを結合
- 結合形式: `${systemPrompt}\n\n---\n\n${userMessage}`
- 結合されたメッセージを一つの `type: 'user'` メッセージとして送信

## メリット
- メッセージ送信処理の簡素化
- エラーハンドリングが不要（一回の送信のみ）
- ユーザーにとってより自然な会話フロー
- APIコール数の削減

## 動作例
プロファイルにシステムプロンプト「あなたは親切なアシスタントです。」が設定され、初期メッセージが「こんにちは」の場合：

```
あなたは親切なアシスタントです。

---

こんにちは
```

このメッセージが一つのユーザーメッセージとして送信されます。

🤖 Generated with [Claude Code](https://claude.ai/code)