### PR TITLE
プロファイル切り替え後のセッション作成バグ修正

### DIFF
--- a/src/app/components/NewSessionModal.tsx
+++ b/src/app/components/NewSessionModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { agentAPI } from '../../lib/api'
+import { createAgentAPIClient } from '../../lib/api'
 import type { AgentAPIProxyClient } from '../../lib/agentapi-proxy-client'
 import { RepositoryHistory } from '../../utils/repositoryHistory'
 import { ProfileManager } from '../../utils/profileManager'
@@ -179,7 +179,7 @@ export default function NewSessionModal({
       setError(null)
       setStatusMessage('セッションを作成中...')
 
-      const client = agentAPI
+      const client = createAgentAPIClient(undefined, selectedProfileId)
       const currentMessage = initialMessage.trim()
       const currentRepository = repository.trim()
       


### PR DESCRIPTION
## 概要
プロファイル切り替え直後にセッションを作成すると、以前のプロファイルの設定でセッションが作成されていた問題を修正しました。

## 問題
- プロファイルを切り替えた後、新しいセッションを作成すると、切り替え前のプロファイルの設定（APIエンドポイント、認証情報、システムプロンプトなど）が使用されていました
- これにより、想定していないプロファイルでセッションが作成されてしまい、ユーザーが期待する動作と異なる結果になっていました

## 修正内容
### 変更ファイル
- `src/app/components/NewSessionModal.tsx`

### 修正詳細
1. **静的なAPIクライアントの問題を解決**
   - 従来: `import { agentAPI } from '../../lib/api'` で静的なクライアントを使用
   - 修正後: `import { createAgentAPIClient } from '../../lib/api'` で動的なクライアント作成関数を使用

2. **プロファイル対応のクライアント作成**
   - 従来: `const client = agentAPI` （固定のクライアント）
   - 修正後: `const client = createAgentAPIClient(undefined, selectedProfileId)` （選択されたプロファイルに基づくクライアント）

## 動作確認
- TypeScriptの型チェック: ✅ パス
- ビルド: ✅ 成功
- 修正により、セッション作成時に選択されたプロファイルの設定が正しく適用されます

## テスト計画
- [ ] プロファイルAを選択した状態でセッションを作成し、プロファイルAの設定が適用されることを確認
- [ ] プロファイルBに切り替えた後、セッションを作成し、プロファイルBの設定が適用されることを確認
- [ ] 異なるAPIエンドポイントを持つプロファイル間での切り替えテスト
- [ ] システムプロンプトが異なるプロファイル間での切り替えテスト

🤖 Generated with [Claude Code](https://claude.ai/code)