### PR TITLE
プロファイル切り替えのクエリパラメータ対応を追加

### DIFF
--- a/src/app/components/TopBar.tsx
+++ b/src/app/components/TopBar.tsx
@@ -38,6 +38,16 @@ export default function TopBar({
   useEffect(() => {
     if (showProfileSwitcher) {
       loadProfiles()
+      
+      // Listen for URL changes (back/forward navigation)
+      const handlePopState = () => {
+        loadProfiles()
+      }
+      
+      window.addEventListener('popstate', handlePopState)
+      return () => {
+        window.removeEventListener('popstate', handlePopState)
+      }
     }
   }, [showProfileSwitcher])
 
@@ -46,16 +56,18 @@ export default function TopBar({
     const profilesList = ProfileManager.getProfiles()
     setProfiles(profilesList)
     
-    const defaultProfile = ProfileManager.getDefaultProfile()
-    if (defaultProfile) {
-      const defaultProfileItem = profilesList.find(p => p.id === defaultProfile.id)
-      setCurrentProfile(defaultProfileItem || null)
+    // Check URL parameters first, then fall back to default profile
+    const currentProfileId = ProfileManager.getCurrentProfileId()
+    if (currentProfileId) {
+      const currentProfileItem = profilesList.find(p => p.id === currentProfileId)
+      setCurrentProfile(currentProfileItem || null)
     } else if (profilesList.length > 0) {
       setCurrentProfile(profilesList[0])
     }
   }
 
   const handleProfileSwitch = (profileId: string) => {
+    ProfileManager.setProfileInUrl(profileId)
     ProfileManager.setDefaultProfile(profileId)
     const selectedProfile = profiles.find(p => p.id === profileId)
     setCurrentProfile(selectedProfile || null)

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -426,7 +426,29 @@ export function getAgentAPIProxyConfigFromStorage(repoFullname?: string, profile
       }
     }
     
-    // If no profile settings found, fall back to default profile
+    // If no profile settings found, check for current profile (including URL parameters)
+    if (!settings) {
+      const currentProfileId = ProfileManager.getCurrentProfileId();
+      if (currentProfileId) {
+        const profile = ProfileManager.getProfile(currentProfileId);
+        if (profile) {
+          settings = {
+            agentApiProxy: profile.agentApiProxy,
+            environmentVariables: profile.environmentVariables
+          };
+          
+          // Mark profile as used
+          ProfileManager.markProfileUsed(currentProfileId);
+          
+          // Add repository to profile history if repoFullname is provided
+          if (repoFullname) {
+            ProfileManager.addRepositoryToProfile(currentProfileId, repoFullname);
+          }
+        }
+      }
+    }
+    
+    // If still no profile settings found, fall back to default profile
     if (!settings) {
       const defaultProfile = ProfileManager.getDefaultProfile();
       if (defaultProfile) {

--- a/src/utils/profileManager.ts
+++ b/src/utils/profileManager.ts
@@ -152,6 +152,16 @@ export class ProfileManager {
     }
 
     try {
+      // Check for profile in URL parameters first
+      const urlParams = new URLSearchParams(window.location.search);
+      const profileIdFromUrl = urlParams.get('profile');
+      if (profileIdFromUrl) {
+        const profile = this.getProfile(profileIdFromUrl);
+        if (profile) {
+          return profile;
+        }
+      }
+
       const defaultProfileId = localStorage.getItem(DEFAULT_PROFILE_KEY);
       if (defaultProfileId) {
         const profile = this.getProfile(defaultProfileId);
@@ -175,6 +185,46 @@ export class ProfileManager {
       console.error('Failed to get default profile:', err);
       return this.createDefaultProfile();
     }
+  }
+
+  static getCurrentProfileId(): string | null {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    // Check URL parameters first
+    const urlParams = new URLSearchParams(window.location.search);
+    const profileIdFromUrl = urlParams.get('profile');
+    if (profileIdFromUrl) {
+      const profile = this.getProfile(profileIdFromUrl);
+      if (profile) {
+        return profileIdFromUrl;
+      }
+    }
+
+    // Fall back to default profile
+    const defaultProfile = this.getDefaultProfile();
+    return defaultProfile?.id || null;
+  }
+
+  static setProfileInUrl(profileId: string): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    url.searchParams.set('profile', profileId);
+    window.history.replaceState({}, '', url.toString());
+  }
+
+  static removeProfileFromUrl(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete('profile');
+    window.history.replaceState({}, '', url.toString());
   }
 
   static markProfileUsed(profileId: string): void {


### PR DESCRIPTION
- URLクエリパラメータ(?profile=<id>)でプロファイルを切り替え可能に
- ブックマークでプロファイルを使い分けられるように改善
- ProfileManager.getCurrentProfileId()でURL優先のプロファイル取得
- ProfileManager.setProfileInUrl()でURL更新機能を追加
- TopBarでブラウザ履歴ナビゲーション対応
- AgentAPIProxyClientでURL指定プロファイル対応

🤖 Generated with [Claude Code](https://claude.ai/code)