### PR TITLE
初期メッセージのキャッシュ機能を追加

### DIFF
--- a/src/utils/initialMessageCache.ts
+++ b/src/utils/initialMessageCache.ts
@@ -1,0 +1,44 @@
+export class InitialMessageCache {
+  private static readonly STORAGE_KEY = 'agentapi_initial_message_cache'
+  private static readonly MAX_CACHE_SIZE = 2
+
+  static getCachedMessages(): string[] {
+    try {
+      const cached = localStorage.getItem(this.STORAGE_KEY)
+      if (!cached) return []
+      const messages = JSON.parse(cached)
+      return Array.isArray(messages) ? messages : []
+    } catch {
+      return []
+    }
+  }
+
+  static addMessage(message: string): void {
+    if (!message.trim()) return
+
+    try {
+      const messages = this.getCachedMessages()
+      
+      // 既に同じメッセージが存在する場合は、それを削除してから先頭に追加
+      const filteredMessages = messages.filter(m => m !== message)
+      
+      // 新しいメッセージを先頭に追加
+      const updatedMessages = [message, ...filteredMessages]
+      
+      // 最大数を超えた場合は古いものを削除
+      const limitedMessages = updatedMessages.slice(0, this.MAX_CACHE_SIZE)
+      
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(limitedMessages))
+    } catch (error) {
+      console.error('Failed to cache initial message:', error)
+    }
+  }
+
+  static clearCache(): void {
+    try {
+      localStorage.removeItem(this.STORAGE_KEY)
+    } catch (error) {
+      console.error('Failed to clear initial message cache:', error)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- localStorage を使用して直近2つの初期メッセージをキャッシュする機能を追加
- NewSessionModalで過去のメッセージから選択可能なUIを実装
- リポジトリ間違えた時などの再入力を簡単にするための改善

## Test plan
- [ ] NewSessionModalを開いて初期メッセージを入力し、セッションを作成
- [ ] 再度NewSessionModalを開いて、初期メッセージ欄をフォーカスすると過去のメッセージが表示されることを確認
- [ ] 過去のメッセージをクリックして選択できることを確認
- [ ] 最大2つまでキャッシュされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)