### PR TITLE
ブラウザがバックグラウンドになった時の定期更新停止機能を追加

### DIFF
--- a/src/app/hooks/usePageVisibility.tsx
+++ b/src/app/hooks/usePageVisibility.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * Page Visibility API を使用してブラウザがバックグラウンドかどうかを追跡するカスタムフック
+ * @returns {boolean} ページが表示されている場合は true、バックグラウンドの場合は false
+ */
+export function usePageVisibility(): boolean {
+  const [isVisible, setIsVisible] = useState<boolean>(true);
+
+  useEffect(() => {
+    // 初期状態を設定
+    setIsVisible(!document.hidden);
+
+    const handleVisibilityChange = () => {
+      setIsVisible(!document.hidden);
+    };
+
+    // visibilitychange イベントリスナーを追加
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    // クリーンアップ
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return isVisible;
+}
+
+/**
+ * バックグラウンド制御機能付きの setInterval フック
+ * ページがバックグラウンドになったときに自動的にインターバルを停止し、
+ * フォアグラウンドに戻ったときに再開する
+ * 
+ * @param callback 実行する関数
+ * @param delay インターバルの間隔（ミリ秒）
+ * @param immediate 最初に即座に実行するかどうか（デフォルト: true）
+ * @returns インターバルの状態とコントロール機能
+ */
+export function useBackgroundAwareInterval(
+  callback: () => void,
+  delay: number,
+  immediate: boolean = true
+): {
+  isRunning: boolean;
+  start: () => void;
+  stop: () => void;
+  restart: () => void;
+} {
+  const [intervalId, setIntervalId] = useState<NodeJS.Timeout | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const isVisible = usePageVisibility();
+
+  const start = () => {
+    if (intervalId) return; // 既に動作中の場合は何もしない
+    
+    if (immediate) {
+      callback();
+    }
+    
+    const id = setInterval(callback, delay);
+    setIntervalId(id);
+    setIsRunning(true);
+  };
+
+  const stop = () => {
+    if (intervalId) {
+      clearInterval(intervalId);
+      setIntervalId(null);
+      setIsRunning(false);
+    }
+  };
+
+  const restart = () => {
+    stop();
+    start();
+  };
+
+  // ページの表示状態が変化したときの処理
+  useEffect(() => {
+    if (isVisible && !intervalId && isRunning) {
+      // ページがフォアグラウンドに戻り、インターバルが停止していて実行中の状態の場合は再開
+      start();
+    } else if (!isVisible && intervalId) {
+      // ページがバックグラウンドになった場合はインターバルを停止
+      clearInterval(intervalId);
+      setIntervalId(null);
+    }
+  }, [isVisible]);
+
+  // コンポーネントのアンマウント時にクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
+  }, [intervalId]);
+
+  return { isRunning, start, stop, restart };
+}


### PR DESCRIPTION
## Summary
- Page Visibility APIを使用してブラウザタブがバックグラウンドになった際の定期更新停止機能を実装
- チャット画面（AgentAPIChat）とセッション一覧画面（SessionListView）の定期更新をバックグラウンド対応に変更
- 不要なAPIリクエストを削減してパフォーマンスとバッテリー寿命を改善

## 実装内容
- `usePageVisibility` hook: Page Visibility APIを使用してページの表示状態を追跡
- `useBackgroundAwareInterval` hook: バックグラウンド制御機能付きのsetInterval
- AgentAPIChat.tsx: メッセージポーリング（1秒間隔）をバックグラウンド対応に変更
- SessionListView.tsx: ステータス更新（10秒間隔）をバックグラウンド対応に変更

## Test plan
- [x] プロジェクトのビルドが正常に完了することを確認
- [x] 開発サーバーが正常に起動することを確認
- [ ] ブラウザでチャット画面を開き、別タブに切り替えた際に定期更新が停止することを確認
- [ ] 元のタブに戻った際に定期更新が再開することを確認
- [ ] セッション一覧画面でも同様の動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)