### PR TITLE
ステータスチェックのポーリング間隔を調整

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -249,7 +249,7 @@ export default function AgentAPIChat() {
   }, [isConnected, sessionId, agentAPI]);
 
   // バックグラウンド対応の定期更新フック
-  const pollingControl = useBackgroundAwareInterval(pollMessages, 1000, true);
+  const pollingControl = useBackgroundAwareInterval(pollMessages, 2000, true);
 
   // Setup real-time event listening
   useEffect(() => {


### PR DESCRIPTION
## 概要
APIコールの頻度を削減するため、ステータスチェックのポーリング間隔を調整しました。

## 変更内容
- チャットビューのポーリング間隔を1秒から2秒に変更
- セッション一覧は既に10秒間隔で適切に設定済み

## 改善効果
- 不要なAPIコールを削減
- サーバーへの負荷を軽減
- パフォーマンスの改善

🤖 Generated with [Claude Code](https://claude.ai/code)