### PR TITLE
セッション画面の初期ステータス取得とポーリング間隔を最適化

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -123,7 +123,12 @@ export default function AgentAPIChat() {
             // Session-based connection: load messages from agentapi-proxy
             try {
               if (!agentAPIRef.current) return;
-              const sessionMessagesResponse = await agentAPIRef.current.getSessionMessages(sessionId, { limit: 100 });
+              
+              // Fetch both messages and initial status
+              const [sessionMessagesResponse, sessionStatus] = await Promise.all([
+                agentAPIRef.current.getSessionMessages(sessionId, { limit: 100 }),
+                agentAPIRef.current.getSessionStatus(sessionId)
+              ]);
               
               // Validate and safely handle session messages response
               if (!isValidSessionMessageResponse(sessionMessagesResponse)) {
@@ -140,6 +145,7 @@ export default function AgentAPIChat() {
               }));
               
               setMessages(convertedMessages);
+              setAgentStatus(sessionStatus); // Set initial status
               setIsConnected(true);
               setError(null);
               return;
@@ -265,8 +271,8 @@ export default function AgentAPIChat() {
     }
   }, [isConnected, sessionId]); // agentAPIを依存配列から除去
 
-  // バックグラウンド対応の定期更新フック
-  const pollingControl = useBackgroundAwareInterval(pollMessages, 2000, true);
+  // バックグラウンド対応の定期更新フック (10秒間隔)
+  const pollingControl = useBackgroundAwareInterval(pollMessages, 10000, true);
 
   // Setup real-time event listening
   useEffect(() => {


### PR DESCRIPTION
## Summary
- セッション画面表示時に初回のステータスを即座に取得
- ポーリング間隔を2秒から10秒に変更してAPIコールを削減
- 初期ロード時の処理を最適化

## Test plan
- [ ] セッション画面を開いた際、ステータスが即座に表示されることを確認
- [ ] その後10秒ごとにステータスが更新されることを確認
- [ ] ブラウザのNetwork タブでAPIコールの頻度が適切であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)