### PR TITLE
サイドバーの高さをウィンドウサイズに合わせるよう修正

### DIFF
--- a/src/app/components/SessionFilterSidebar.tsx
+++ b/src/app/components/SessionFilterSidebar.tsx
@@ -122,7 +122,7 @@ export default function SessionFilterSidebar({
       {/* Sidebar */}
       <div className={`
         fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
-        md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-auto
+        md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
         ${isVisible ? 'translate-x-0' : '-translate-x-full'}
       `}>
         <div className="p-4">

--- a/src/app/components/TagFilterSidebar.tsx
+++ b/src/app/components/TagFilterSidebar.tsx
@@ -138,7 +138,7 @@ export default function TagFilterSidebar({
       {/* Sidebar */}
       <div className={`
         fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
-        md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-auto
+        md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
         ${isVisible ? 'translate-x-0' : '-translate-x-full'}
       `}>
         <div className="p-4">


### PR DESCRIPTION
## Summary
- サイドバーの高さがウィンドウサイズに合わせられていない問題を修正
- デスクトップビューでサイドバーがウィンドウの高さ（100vh）に合わせられるように改善

## Changes
- SessionFilterSidebarとTagFilterSidebarのCSSクラスを修正
- `md:h-auto` を `md:h-screen` に変更

## Test plan
- [x] デスクトップビューでサイドバーの高さがウィンドウサイズと同じになることを確認
- [x] モバイルビューでの表示に影響がないことを確認
- [x] サイドバーのスクロール機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)