### PR TITLE
fix: チャット画面でフォーカス時のメッセージテンプレート自動表示を無効化

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -744,9 +744,7 @@ export default function AgentAPIChat() {
               onChange={(e) => setInputValue(e.target.value)}
               onKeyPress={handleKeyPress}
               onFocus={() => {
-                if (templates.length > 0 && !inputValue.trim()) {
-                  setShowTemplates(true);
-                }
+                // テンプレートの自動表示を無効化
               }}
               onBlur={() => {
                 setTimeout(() => setShowTemplates(false), 150);


### PR DESCRIPTION
## Summary
- AgentAPIChat.tsxのtextareaコンポーネントで、フォーカス時にメッセージテンプレートが自動的に表示される機能を無効化しました
- ユーザーは必要に応じてテンプレートボタンから手動でアクセスできます

## Test plan
- [ ] チャット画面でテキストエリアにフォーカスを当てても、メッセージテンプレートが自動表示されないことを確認
- [ ] テンプレートボタンからは引き続きテンプレートにアクセスできることを確認
- [ ] メッセージ入力・送信など、他の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)