### PR TITLE
fix: プロファイル切り替え時に色が正しく更新されない問題を修正

### DIFF
--- a/src/app/components/TopBar.tsx
+++ b/src/app/components/TopBar.tsx
@@ -32,7 +32,7 @@ export default function TopBar({
   children
 }: TopBarProps) {
   const router = useRouter()
-  const { setMainColor } = useTheme()
+  const { updateThemeFromProfile } = useTheme()
   const [profiles, setProfiles] = useState<ProfileListItem[]>([])
   const [currentProfile, setCurrentProfile] = useState<ProfileListItem | null>(null)
   const [showProfileDropdown, setShowProfileDropdown] = useState(false)
@@ -56,12 +56,9 @@ export default function TopBar({
     
     // Update theme when profile is loaded
     if (selectedProfile) {
-      const fullProfile = ProfileManager.getProfile(selectedProfile.id)
-      if (fullProfile?.mainColor) {
-        setMainColor(fullProfile.mainColor)
-      }
+      updateThemeFromProfile(selectedProfile.id)
     }
-  }, [setMainColor])
+  }, [updateThemeFromProfile])
 
   useEffect(() => {
     if (showProfileSwitcher) {
@@ -87,12 +84,7 @@ export default function TopBar({
     setShowProfileDropdown(false)
     
     // Update theme when profile switches
-    if (selectedProfile) {
-      const fullProfile = ProfileManager.getProfile(selectedProfile.id)
-      if (fullProfile?.mainColor) {
-        setMainColor(fullProfile.mainColor)
-      }
-    }
+    updateThemeFromProfile(profileId)
     
     window.dispatchEvent(new CustomEvent('profileChanged', { detail: { profileId } }))
   }


### PR DESCRIPTION
## 概要
- プロファイルをA → B → Aと切り替えた際に、Bの色のままになってしまう問題を修正しました
- TopBarコンポーネントでThemeContextの`updateThemeFromProfile`メソッドを使用するように変更

## 変更内容
- `TopBar.tsx`で`setMainColor`の代わりに`updateThemeFromProfile`を使用
- プロファイル読み込み時とプロファイル切り替え時の両方で一貫した色更新処理を実装

## テスト計画
- [x] プロファイルAからBに切り替えて色が変わることを確認
- [x] プロファイルBからAに戻して正しい色に戻ることを確認
- [x] lint、型チェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)