### PR TITLE
Claude Code ログイン URL ボタンの実装

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -843,6 +843,20 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                           </a>
                         ) : null}
                         
+                        {session.metadata?.claude_login_url ? (
+                          <a
+                            href={String(session.metadata.claude_login_url).replace(/\s+/g, '')}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-blue-300 dark:border-blue-600 hover:bg-blue-50 dark:hover:bg-blue-700 text-blue-700 dark:text-blue-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"
+                          >
+                            <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                            <span className="hidden sm:inline">ログイン</span>
+                          </a>
+                        ) : null}
+                        
                         <button
                           onClick={() => deleteSession(session.session_id)}
                           disabled={deletingSession === session.session_id}


### PR DESCRIPTION
## 概要

Claude Code のログイン URL を UI から簡単にアクセスできるようにボタンを追加しました。

## 実装内容

### SessionListView.tsx
- `session.metadata.claude_login_url` が設定されている場合に「ログイン」ボタンを表示
- PR ボタンと同様のデザインで一貫性を保持（青色系のカラーテーマを使用）
- URL の改行を自動的に除去する機能を実装（`.replace(/\s+/g, '')` を使用）

### AgentAPIChat.tsx  
- `extractClaudeLoginUrls()` 関数を追加して Claude OAuth URL を自動検出
- チャット内容から `https://claude.ai/oauth/authorize?...` パターンの URL を抽出
- virtual tty での改行問題に対応（改行ありなしの両方のパターンで検索）
- ヘッダーに Claude ログインボタンを追加（検出数をバッジで表示）
- モーダルで検出された URL 一覧を表示し、各 URL に対してログインボタンを配置

## 機能詳細

- **URL 抽出パターン**: `https://claude.ai/oauth/authorize?` で始まる OAuth URL を検出
- **改行対応**: virtual tty で URL が改行される問題に対応し、空白文字を除去
- **バリデーション**: `client_id` と `response_type=code` を含む有効な OAuth URL のみを抽出  
- **UI 一貫性**: 既存の PR ボタンと同様のデザインパターンを採用
- **レスポンシブ対応**: モバイル・デスクトップ両対応

## テスト方法

1. セッションの metadata に `claude_login_url` を設定
2. チャット内で Claude OAuth URL を含むメッセージを送信
3. ボタンが正しく表示され、URL が開くことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)