### PR TITLE
すべてのモーダルにESCキーとモーダル外クリックでの閉じる機能を実装

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -297,6 +297,29 @@ export default function AgentAPIChat() {
     }
   }, []);
 
+  // ESCキーでモーダルを閉じる
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (showTemplateModal) {
+          setShowTemplateModal(false)
+        } else if (showPRLinks) {
+          setShowPRLinks(false)
+        } else if (showClaudeLogins) {
+          setShowClaudeLogins(false)
+        }
+      }
+    }
+
+    if (showTemplateModal || showPRLinks || showClaudeLogins) {
+      document.addEventListener('keydown', handleKeyDown)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [showTemplateModal, showPRLinks, showClaudeLogins]);
+
   // Listen for profile changes and recreate client
   useEffect(() => {
     const handleProfileChange = (event: CustomEvent) => {
@@ -981,7 +1004,14 @@ export default function AgentAPIChat() {
 
       {/* Template Selection Modal */}
       {showTemplateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div 
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setShowTemplateModal(false)
+            }
+          }}
+        >
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
             <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between">
@@ -1064,7 +1094,14 @@ export default function AgentAPIChat() {
 
       {/* PR Links Modal */}
       {showPRLinks && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div 
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setShowPRLinks(false)
+            }
+          }}
+        >
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
             <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between">
@@ -1154,7 +1191,14 @@ export default function AgentAPIChat() {
 
       {/* Claude Login URLs Modal */}
       {showClaudeLogins && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div 
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setShowClaudeLogins(false)
+            }
+          }}
+        >
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
             <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between">

--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -156,6 +156,23 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
     }
   }, [isOpen, currentFilters, initialRepository, initializeFromFilters])
 
+  // ESCキーでモーダルを閉じる
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen) {
+        handleClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen])
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     
@@ -246,7 +263,14 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+    <div 
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          handleClose()
+        }
+      }}
+    >
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between">

--- a/src/app/components/NewSessionModal.tsx
+++ b/src/app/components/NewSessionModal.tsx
@@ -59,6 +59,27 @@ export default function NewSessionModal({
     return () => window.removeEventListener('resize', checkMobile)
   }, [])
 
+  // ESCキーでモーダルを閉じる
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (showTemplateModal) {
+          setShowTemplateModal(false)
+        } else if (isOpen) {
+          handleClose()
+        }
+      }
+    }
+
+    if (isOpen || showTemplateModal) {
+      document.addEventListener('keydown', handleKeyDown)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, showTemplateModal])
+
   useEffect(() => {
     if (isOpen) {
       ProfileManager.migrateExistingSettings()
@@ -437,7 +458,14 @@ export default function NewSessionModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div 
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          handleClose()
+        }
+      }}
+    >
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-lg mx-4">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
@@ -714,7 +742,14 @@ export default function NewSessionModal({
       
       {/* Template Selection Modal */}
       {showTemplateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60] p-4">
+        <div 
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60] p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setShowTemplateModal(false)
+            }
+          }}
+        >
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
             <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between">

--- a/src/app/components/SessionFilterSidebar.tsx
+++ b/src/app/components/SessionFilterSidebar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { FilterGroup, SessionFilter } from '../../lib/filter-utils'
 
 interface SessionFilterSidebarProps {
@@ -19,6 +19,23 @@ export default function SessionFilterSidebar({
   onToggleVisibility
 }: SessionFilterSidebarProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
+
+  // ESCキーでサイドバーを閉じる
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isVisible && onToggleVisibility) {
+        onToggleVisibility()
+      }
+    }
+
+    if (isVisible) {
+      document.addEventListener('keydown', handleKeyDown)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isVisible, onToggleVisibility])
 
   const toggleGroup = (groupKey: string) => {
     const newExpanded = new Set(expandedGroups)

--- a/src/app/components/TagFilterSidebar.tsx
+++ b/src/app/components/TagFilterSidebar.tsx
@@ -33,6 +33,23 @@ export default function TagFilterSidebar({
     fetchTags()
   }, [])
 
+  // ESCキーでサイドバーを閉じる
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isVisible && onToggleVisibility) {
+        onToggleVisibility()
+      }
+    }
+
+    if (isVisible) {
+      document.addEventListener('keydown', handleKeyDown)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isVisible, onToggleVisibility])
+
   const fetchTags = async () => {
     try {
       setLoading(true)


### PR DESCRIPTION
## 概要
すべてのモーダルコンポーネントにESCキーとモーダル外クリックでの閉じる機能を実装しました。

## 変更内容
- **NewSessionModal**: ESCキーとモーダル外クリックで閉じる機能を追加
  - メインモーダルとテンプレート選択モーダル両方に対応
  - 複数のモーダルが重なっている場合の優先順位制御も実装
- **NewConversationModal**: ESCキーとモーダル外クリックで閉じる機能を追加
- **AgentAPIChat**: 3つのモーダルにESCキーとモーダル外クリックで閉じる機能を追加
  - テンプレート選択モーダル
  - PRリンクモーダル
  - Claude ログインモーダル
- **SessionFilterSidebar**: ESCキーでサイドバーを閉じる機能を追加
- **TagFilterSidebar**: ESCキーでサイドバーを閉じる機能を追加

## テスト計画
- [ ] 各モーダルでESCキーを押して正常に閉じることを確認
- [ ] 各モーダルで背景オーバーレイをクリックして正常に閉じることを確認
- [ ] 複数のモーダルが重なっている場合の動作確認
- [ ] サイドバーでESCキーを押して正常に閉じることを確認
- [ ] モーダル内の要素をクリックしても閉じないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)