### PR TITLE
チャット画面トップバーから「AgentAPI」文字を削除

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -620,7 +620,7 @@ export default function AgentAPIChat() {
             </Link>
             <div>
               <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white">
-                <span className="block sm:inline">AgentAPI Chat</span>
+                <span className="block sm:inline">Chat</span>
                 {sessionId && (
                   <span className="ml-0 sm:ml-2 text-sm font-normal text-gray-500 dark:text-gray-400 block sm:inline">
                     #{sessionId.substring(0, 8)}


### PR DESCRIPTION
## 概要
チャット画面のトップバーから不要な「AgentAPI」文字を削除し、「Chat」に変更しました。

## 変更内容
- `src/app/components/AgentAPIChat.tsx` の623行目を修正
- 表示テキストを「AgentAPI Chat」から「Chat」に変更
- スペースを節約し、よりシンプルなUIに改善

## テスト計画
- [ ] チャット画面のトップバーが「Chat」と表示されることを確認
- [ ] レスポンシブデザインが正常に動作することを確認
- [ ] セッションIDの表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)