### PR TITLE
fix: PRのURL表示で改行文字を除去するように修正

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -729,7 +729,7 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                         
                         {session.metadata?.pr_url ? (
                           <a
-                            href={String(session.metadata.pr_url)}
+                            href={String(session.metadata.pr_url).replace(/\s+/g, '')}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-purple-300 dark:border-purple-600 hover:bg-purple-50 dark:hover:bg-purple-700 text-purple-700 dark:text-purple-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"


### PR DESCRIPTION
## 概要
- SessionListView.tsxのPR URLリンクで改行文字やスペースを除去する処理を追加
- claude_login_urlと同様の処理をpr_urlにも適用

## 変更内容
- `String(session.metadata.pr_url).replace(/\s+/g, '')` を追加してURLから改行とスペースを除去

## テスト計画
- [x] リンターが通ることを確認
- [x] テストが通ることを確認
- [ ] 改行を含むPR URLが正常にリンクとして機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)