### PR TITLE
feat: implement GitHub authentication per profile

### DIFF
--- a/src/app/components/EditProfileModal.tsx
+++ b/src/app/components/EditProfileModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { ProfileManager } from '../../utils/profileManager';
 import { Profile, UpdateProfileRequest } from '../../types/profile';
 import { OrganizationHistory, OrganizationRepositoryHistory } from '../../utils/organizationHistory';
+import { GitHubAuthSettings } from '../../components/profiles/GitHubAuthSettings';
 
 const EMOJI_OPTIONS = ['⚙️', '🔧', '💼', '🏠', '🏢', '🚀', '💻', '🔬', '🎯', '⭐', '🌟', '💡'];
 
@@ -551,6 +552,10 @@ export default function EditProfileModal({ isOpen, onClose, profileId, onProfile
                   )}
                 </div>
               )}
+
+              <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6">
+                <GitHubAuthSettings profile={profile} onProfileUpdated={loadProfile} />
+              </div>
 
               <div className="flex space-x-4 pt-4">
                 <button

--- a/src/components/profiles/GitHubAuthSettings.tsx
+++ b/src/components/profiles/GitHubAuthSettings.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { Profile } from '../../types/profile';
+import React, { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
+import { Profile, GitHubUser } from '../../types/profile';
 import { githubAuthService } from '../../services/githubAuthService';
 
 interface GitHubAuthSettingsProps {
@@ -9,16 +10,18 @@ interface GitHubAuthSettingsProps {
   onProfileUpdated?: () => void;
 }
 
+interface AuthStatus {
+  type: 'github' | 'none';
+  authenticated: boolean;
+  user?: GitHubUser;
+}
+
 export const GitHubAuthSettings: React.FC<GitHubAuthSettingsProps> = ({ profile, onProfileUpdated }) => {
   const [isConnecting, setIsConnecting] = useState(false);
-  const [authStatus, setAuthStatus] = useState<{ type: 'github' | 'none'; authenticated: boolean; user?: any }>({ type: 'none', authenticated: false });
+  const [authStatus, setAuthStatus] = useState<AuthStatus>({ type: 'none', authenticated: false });
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    checkAuthStatus();
-  }, [profile.id]);
-
-  const checkAuthStatus = async () => {
+  const checkAuthStatus = useCallback(async () => {
     setLoading(true);
     try {
       const status = await githubAuthService.checkAuthStatus(profile.id);
@@ -28,7 +31,11 @@ export const GitHubAuthSettings: React.FC<GitHubAuthSettingsProps> = ({ profile,
     } finally {
       setLoading(false);
     }
-  };
+  }, [profile.id]);
+
+  useEffect(() => {
+    checkAuthStatus();
+  }, [checkAuthStatus]);
 
   const handleConnect = async () => {
     setIsConnecting(true);
@@ -92,9 +99,11 @@ export const GitHubAuthSettings: React.FC<GitHubAuthSettingsProps> = ({ profile,
             <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4">
               <div className="flex items-center space-x-3">
                 {authStatus.user.avatarUrl && (
-                  <img 
+                  <Image
                     src={authStatus.user.avatarUrl} 
                     alt={authStatus.user.login}
+                    width={40}
+                    height={40}
                     className="w-10 h-10 rounded-full"
                   />
                 )}

--- a/src/components/profiles/GitHubAuthSettings.tsx
+++ b/src/components/profiles/GitHubAuthSettings.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Profile } from '../../types/profile';
+import { githubAuthService } from '../../services/githubAuthService';
+
+interface GitHubAuthSettingsProps {
+  profile: Profile;
+  onProfileUpdated?: () => void;
+}
+
+export const GitHubAuthSettings: React.FC<GitHubAuthSettingsProps> = ({ profile, onProfileUpdated }) => {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [authStatus, setAuthStatus] = useState<{ type: 'github' | 'none'; authenticated: boolean; user?: any }>({ type: 'none', authenticated: false });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    checkAuthStatus();
+  }, [profile.id]);
+
+  const checkAuthStatus = async () => {
+    setLoading(true);
+    try {
+      const status = await githubAuthService.checkAuthStatus(profile.id);
+      setAuthStatus(status);
+    } catch (error) {
+      console.error('Failed to check auth status:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConnect = async () => {
+    setIsConnecting(true);
+    try {
+      await githubAuthService.startGitHubAuth(profile.id);
+      
+      // Wait for authentication to complete
+      const authenticated = await githubAuthService.waitForAuth(profile.id);
+      
+      if (authenticated) {
+        await checkAuthStatus();
+        onProfileUpdated?.();
+        alert('GitHub連携が完了しました');
+      } else {
+        alert('GitHub連携がタイムアウトしました');
+      }
+    } catch (error) {
+      console.error('GitHub連携に失敗しました:', error);
+      alert('GitHub連携に失敗しました');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    if (confirm('GitHub連携を解除しますか？')) {
+      try {
+        await githubAuthService.disconnect(profile.id);
+        setAuthStatus({ type: 'none', authenticated: false });
+        onProfileUpdated?.();
+        alert('GitHub連携を解除しました');
+      } catch (error) {
+        console.error('Failed to disconnect:', error);
+        alert('連携解除に失敗しました');
+      }
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">GitHub連携設定</h3>
+        <div className="text-gray-500 dark:text-gray-400">読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">GitHub連携設定</h3>
+      
+      {authStatus.type === 'none' ? (
+        <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
+          <p className="text-gray-600 dark:text-gray-300 mb-4">
+            このプロファイルでは認証が設定されていません
+          </p>
+        </div>
+      ) : authStatus.type === 'github' && (
+        <>
+          {authStatus.authenticated && authStatus.user ? (
+            <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4">
+              <div className="flex items-center space-x-3">
+                {authStatus.user.avatarUrl && (
+                  <img 
+                    src={authStatus.user.avatarUrl} 
+                    alt={authStatus.user.login}
+                    className="w-10 h-10 rounded-full"
+                  />
+                )}
+                <div className="flex-1">
+                  <p className="font-medium text-gray-900 dark:text-white">
+                    {authStatus.user.name || authStatus.user.login}
+                  </p>
+                  {authStatus.user.email && (
+                    <p className="text-sm text-gray-500 dark:text-gray-400">{authStatus.user.email}</p>
+                  )}
+                </div>
+                <button
+                  onClick={handleDisconnect}
+                  className="bg-red-100 dark:bg-red-900 hover:bg-red-200 dark:hover:bg-red-800 text-red-700 dark:text-red-200 px-3 py-2 rounded text-sm transition-colors"
+                >
+                  連携解除
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-4">
+              <p className="text-gray-700 dark:text-gray-300 mb-4">
+                GitHub認証が必要です
+              </p>
+              <button
+                onClick={handleConnect}
+                disabled={isConnecting}
+                className="bg-gray-900 hover:bg-gray-800 text-white px-4 py-2 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center space-x-2"
+              >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+                </svg>
+                <span>{isConnecting ? '接続中...' : 'GitHubで認証'}</span>
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -15,6 +15,7 @@ import {
 } from '../types/agentapi';
 import { loadGlobalSettings, getDefaultProxySettings } from '../types/settings';
 import { ProfileManager } from '../utils/profileManager';
+import { GitHubUser } from '../types/profile';
 
 // Define local AgentStatus type
 interface AgentStatus {
@@ -384,13 +385,13 @@ export class AgentAPIProxyClient {
   /**
    * Get authentication info for the current session
    */
-  async getAuthInfo(): Promise<{ type: 'github' | 'none'; authenticated: boolean; user?: any }> {
+  async getAuthInfo(): Promise<{ type: 'github' | 'none'; authenticated: boolean; user?: GitHubUser }> {
     try {
-      return await this.makeRequest<{ type: 'github' | 'none'; authenticated: boolean; user?: any }>('/auth/info');
+      return await this.makeRequest<{ type: 'github' | 'none'; authenticated: boolean; user?: GitHubUser }>('/auth/info');
     } catch (error) {
-      // If the endpoint doesn't exist or returns an error, assume no auth
+      // If the endpoint doesn't exist (404) or returns an error, assume no auth (older agentapi-proxy)
       if (this.debug) {
-        console.log('[AgentAPIProxy] Auth info not available:', error);
+        console.log('[AgentAPIProxy] Auth info not available (likely older proxy version):', error);
       }
       return { type: 'none', authenticated: false };
     }

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -382,6 +382,37 @@ export class AgentAPIProxyClient {
   }
 
   /**
+   * Get authentication info for the current session
+   */
+  async getAuthInfo(): Promise<{ type: 'github' | 'none'; authenticated: boolean; user?: any }> {
+    try {
+      return await this.makeRequest<{ type: 'github' | 'none'; authenticated: boolean; user?: any }>('/auth/info');
+    } catch (error) {
+      // If the endpoint doesn't exist or returns an error, assume no auth
+      if (this.debug) {
+        console.log('[AgentAPIProxy] Auth info not available:', error);
+      }
+      return { type: 'none', authenticated: false };
+    }
+  }
+
+  /**
+   * Get GitHub OAuth URL for authentication
+   */
+  async getGitHubAuthUrl(profileId: string): Promise<string> {
+    try {
+      const response = await this.makeRequest<{ authUrl: string }>('/auth/github/url', {
+        method: 'POST',
+        body: JSON.stringify({ profileId })
+      });
+      return response.authUrl;
+    } catch (error) {
+      console.error('[AgentAPIProxy] Failed to get GitHub auth URL:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Set debug mode
    */
   setDebug(debug: boolean): void {

--- a/src/services/githubAuthService.ts
+++ b/src/services/githubAuthService.ts
@@ -30,17 +30,15 @@ export class GitHubAuthService {
       
       // Update profile with auth info if authenticated
       if (authInfo.authenticated && authInfo.type === 'github' && authInfo.user) {
-        const profile = ProfileManager.getProfile(profileId);
-        if (profile) {
-          profile.githubAuth = {
+        ProfileManager.updateProfile(profileId, {
+          githubAuth: {
             enabled: true,
             user: authInfo.user,
             scopes: authInfo.scopes || [],
             organizations: authInfo.organizations || [],
             repositories: authInfo.repositories || []
-          };
-          ProfileManager.updateProfile(profile);
-        }
+          }
+        });
       }
       
       return authInfo;
@@ -79,11 +77,9 @@ export class GitHubAuthService {
   }
 
   async disconnect(profileId: string): Promise<void> {
-    const profile = ProfileManager.getProfile(profileId);
-    if (profile) {
-      profile.githubAuth = undefined;
-      ProfileManager.updateProfile(profile);
-    }
+    ProfileManager.updateProfile(profileId, {
+      githubAuth: undefined
+    });
   }
 
   isTokenExpired(tokenExpiresAt?: string): boolean {

--- a/src/services/githubAuthService.ts
+++ b/src/services/githubAuthService.ts
@@ -2,6 +2,15 @@ import { ProfileManager } from '../utils/profileManager';
 import { createAgentAPIProxyClientFromStorage } from '../lib/agentapi-proxy-client';
 import { GitHubUser } from '../types/profile';
 
+interface AuthInfoResponse {
+  type: 'github' | 'none';
+  authenticated: boolean;
+  user?: GitHubUser;
+  scopes?: string[];
+  organizations?: string[];
+  repositories?: string[];
+}
+
 export class GitHubAuthService {
   private static instance: GitHubAuthService;
 
@@ -17,7 +26,7 @@ export class GitHubAuthService {
   async checkAuthStatus(profileId: string): Promise<{ type: 'github' | 'none'; authenticated: boolean; user?: GitHubUser }> {
     try {
       const client = createAgentAPIProxyClientFromStorage(undefined, profileId);
-      const authInfo = await client.getAuthInfo();
+      const authInfo: AuthInfoResponse = await client.getAuthInfo();
       
       // Update profile with auth info if authenticated
       if (authInfo.authenticated && authInfo.type === 'github' && authInfo.user) {
@@ -26,9 +35,9 @@ export class GitHubAuthService {
           profile.githubAuth = {
             enabled: true,
             user: authInfo.user,
-            scopes: (authInfo as any).scopes || [],
-            organizations: (authInfo as any).organizations || [],
-            repositories: (authInfo as any).repositories || []
+            scopes: authInfo.scopes || [],
+            organizations: authInfo.organizations || [],
+            repositories: authInfo.repositories || []
           };
           ProfileManager.updateProfile(profile);
         }

--- a/src/services/githubAuthService.ts
+++ b/src/services/githubAuthService.ts
@@ -1,0 +1,86 @@
+import { ProfileManager } from '../utils/profileManager';
+import { createAgentAPIProxyClientFromStorage } from '../lib/agentapi-proxy-client';
+import { GitHubUser } from '../types/profile';
+
+export class GitHubAuthService {
+  private static instance: GitHubAuthService;
+
+  private constructor() {}
+
+  static getInstance(): GitHubAuthService {
+    if (!GitHubAuthService.instance) {
+      GitHubAuthService.instance = new GitHubAuthService();
+    }
+    return GitHubAuthService.instance;
+  }
+
+  async checkAuthStatus(profileId: string): Promise<{ type: 'github' | 'none'; authenticated: boolean; user?: GitHubUser }> {
+    try {
+      const client = createAgentAPIProxyClientFromStorage(undefined, profileId);
+      const authInfo = await client.getAuthInfo();
+      
+      // Update profile with auth info if authenticated
+      if (authInfo.authenticated && authInfo.type === 'github' && authInfo.user) {
+        const profile = ProfileManager.getProfile(profileId);
+        if (profile) {
+          profile.githubAuth = {
+            enabled: true,
+            user: authInfo.user,
+            scopes: (authInfo as any).scopes || [],
+            organizations: (authInfo as any).organizations || [],
+            repositories: (authInfo as any).repositories || []
+          };
+          ProfileManager.updateProfile(profile);
+        }
+      }
+      
+      return authInfo;
+    } catch (error) {
+      console.error('Failed to check auth status:', error);
+      return { type: 'none', authenticated: false };
+    }
+  }
+
+  async startGitHubAuth(profileId: string): Promise<string> {
+    try {
+      const client = createAgentAPIProxyClientFromStorage(undefined, profileId);
+      const authUrl = await client.getGitHubAuthUrl(profileId);
+      
+      // Open auth URL in a new window
+      window.open(authUrl, 'github-auth', 'width=500,height=700');
+      
+      return authUrl;
+    } catch (error) {
+      console.error('Failed to start GitHub auth:', error);
+      throw error;
+    }
+  }
+
+  async waitForAuth(profileId: string, maxAttempts = 60, intervalMs = 2000): Promise<boolean> {
+    for (let i = 0; i < maxAttempts; i++) {
+      const authStatus = await this.checkAuthStatus(profileId);
+      if (authStatus.authenticated) {
+        return true;
+      }
+      
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+    
+    return false;
+  }
+
+  async disconnect(profileId: string): Promise<void> {
+    const profile = ProfileManager.getProfile(profileId);
+    if (profile) {
+      profile.githubAuth = undefined;
+      ProfileManager.updateProfile(profile);
+    }
+  }
+
+  isTokenExpired(tokenExpiresAt?: string): boolean {
+    if (!tokenExpiresAt) return true;
+    return new Date(tokenExpiresAt) < new Date();
+  }
+}
+
+export const githubAuthService = GitHubAuthService.getInstance();

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -73,4 +73,5 @@ export interface UpdateProfileRequest {
   environmentVariables?: EnvironmentVariable[];
   messageTemplates?: MessageTemplate[];
   isDefault?: boolean;
+  githubAuth?: GitHubAuthSettings;
 }

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -17,6 +17,26 @@ export interface Profile {
   isDefault: boolean;
   created_at: string;
   updated_at: string;
+  githubAuth?: GitHubAuthSettings;
+}
+
+export interface GitHubAuthSettings {
+  enabled: boolean;
+  accessToken?: string;
+  refreshToken?: string;
+  tokenExpiresAt?: string;
+  user?: GitHubUser;
+  scopes: string[];
+  organizations?: string[];
+  repositories?: string[];
+}
+
+export interface GitHubUser {
+  id: number;
+  login: string;
+  name?: string;
+  email?: string;
+  avatarUrl?: string;
 }
 
 export interface ProfileListItem {


### PR DESCRIPTION
## Summary
- Implemented individual profile settings that fetch authentication type from agentapi-proxy
- Added GitHub authentication button for unauthenticated profiles  
- Extended Profile type with GitHub authentication settings
- Created reusable GitHubAuthService for managing OAuth flows

## Changes Made
- **Extended Profile Type**: Added `GitHubAuthSettings` and `GitHubUser` interfaces to support profile-specific authentication
- **Enhanced AgentAPI Client**: Added `getAuthInfo()` and `getGitHubAuthUrl()` methods to communicate with agentapi-proxy for authentication
- **GitHub Auth Service**: Created centralized service for managing authentication state, OAuth flow, and token handling
- **Auth Settings Component**: Built `GitHubAuthSettings` component that displays auth status and provides "GitHubで認証" button for unauthenticated GitHub profiles
- **Profile Modal Integration**: Integrated authentication settings into the profile edit modal

## Key Features
1. **Profile-Specific Auth**: Each profile can have its own GitHub authentication settings
2. **Auto-Detection**: Automatically detects authentication type from agentapi-proxy
3. **OAuth Flow**: Handles GitHub OAuth authentication in popup window
4. **State Management**: Proper state management with loading states and error handling
5. **UI Integration**: Seamless integration into existing profile management interface

## Test Plan
- [x] Profile type extensions compile correctly
- [x] AgentAPI client methods are properly implemented
- [x] GitHubAuthService handles authentication flows
- [x] GitHubAuthSettings component renders and handles interactions
- [x] Integration with EditProfileModal works properly

🤖 Generated with [Claude Code](https://claude.ai/code)