### PR TITLE
feat: change API token from X-API-Key to Bearer token format

### DIFF
--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -86,7 +86,7 @@ export class AgentAPIProxyClient {
 
     // Add API Key header if available
     if (this.apiKey) {
-      defaultHeaders['X-API-Key'] = this.apiKey;
+      defaultHeaders['Authorization'] = `Bearer ${this.apiKey}`;
     }
 
     const requestOptions: RequestInit = {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -60,7 +60,7 @@ async function apiRequest<T>(
 
   // Add API key header if API key is available
   if (config.apiKey) {
-    defaultHeaders['X-API-Key'] = config.apiKey
+    defaultHeaders['Authorization'] = `Bearer ${config.apiKey}`
   }
 
   try {


### PR DESCRIPTION
## Summary
- Changed API authentication from custom X-API-Key header to standard Bearer token format
- Updated both general API client (api.ts) and AgentAPI Proxy client (agentapi-proxy-client.ts)
- Maintains compatibility with existing API token management system

## Changes
- `src/lib/api.ts`: Updated `apiRequest` function to use `Authorization: Bearer` header
- `src/lib/agentapi-proxy-client.ts`: Updated `makeRequest` method to use `Authorization: Bearer` header

## Test plan
- [ ] Verify existing API functionality continues to work with Bearer token format
- [ ] Test authentication with different profiles and configurations
- [ ] Confirm session management and message sending work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)