### PR TITLE
Profile の環境変数をセッション作成時のリクエストペイロードに含める

### DIFF
--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -148,10 +148,30 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
         setRepository(initialRepository)
       }
       
-      // 現在のプロファイルを取得
-      const defaultProfile = ProfileManager.getDefaultProfile()
-      if (defaultProfile) {
-        setCurrentProfileId(defaultProfile.id)
+      // 現在のプロファイルを取得（現在のプロファイル -> デフォルトプロファイルの順）
+      let currentProfile = null
+      const currentProfileId = ProfileManager.getCurrentProfileId()
+      if (currentProfileId) {
+        currentProfile = ProfileManager.getProfile(currentProfileId)
+        setCurrentProfileId(currentProfileId)
+      } else {
+        currentProfile = ProfileManager.getDefaultProfile()
+        if (currentProfile) {
+          setCurrentProfileId(currentProfile.id)
+        }
+      }
+      
+      if (currentProfile) {
+        // Profile の環境変数をフォームに反映（フィルターからの値が優先）
+        if (envVars.length === 1 && !envVars[0].key && !envVars[0].value) {
+          const profileEnvVars = currentProfile.environmentVariables || []
+          if (profileEnvVars.length > 0) {
+            setEnvVars(profileEnvVars.map(envVar => ({ 
+              key: envVar.key || '', 
+              value: envVar.value || '' 
+            })))
+          }
+        }
       }
     }
   }, [isOpen, currentFilters, initialRepository, initializeFromFilters])


### PR DESCRIPTION
## 概要

Profile 設定の環境変数がセッション作成時のリクエストペイロードに含まれていない問題を修正しました。

## 問題の詳細

現在、Profile で設定した環境変数は UI 上で表示・編集できますが、実際にセッションを作成する際のリクエストペイロードに含まれていませんでした。これにより、Profile の環境変数がエージェントのセッションで利用できない状態でした。

## 修正内容

### 1. NewSessionModal の修正
- セッション作成時に Profile の環境変数を取得
- 環境変数オブジェクトに Profile の設定を含める
- リポジトリ情報（REPOSITORY）との競合を回避

### 2. NewConversationModal の修正  
- Profile の環境変数を環境変数フォームの初期値として使用
- フィルターからの値が優先される仕組みを維持

### 3. agentapi-proxy-client の修正
- profileId が指定されている場合、Profile の環境変数を自動的にマージ
- セッション固有の環境変数が Profile の環境変数より優先される
- デバッグログでマージ情報を出力

## テスト計画

- [ ] Profile で環境変数を設定後、セッション作成時に環境変数が正しく送信されることを確認
- [ ] セッション固有の環境変数が Profile の環境変数より優先されることを確認
- [ ] NewConversationModal で Profile の環境変数が初期値として表示されることを確認
- [ ] 既存の機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)