### PR TITLE
feat: プロファイルに GITHUB_TOKEN チェックボックスを追加

### DIFF
--- a/src/app/components/EditProfileModal.tsx
+++ b/src/app/components/EditProfileModal.tsx
@@ -382,6 +382,25 @@ export default function EditProfileModal({ isOpen, onClose, profileId, onProfile
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-600 dark:text-white"
                       placeholder="API キーを入力"
                     />
+                    <div className="mt-2">
+                      <label className="flex items-center">
+                        <input
+                          type="checkbox"
+                          checked={formData.agentApiProxy?.useAsGithubToken || false}
+                          onChange={(e) => setFormData(prev => ({
+                            ...prev,
+                            agentApiProxy: { ...prev.agentApiProxy, useAsGithubToken: e.target.checked }
+                          }))}
+                          className="mr-2"
+                        />
+                        <span className="text-sm text-gray-700 dark:text-gray-300">
+                          このキーを GITHUB_TOKEN として使用する
+                        </span>
+                      </label>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
+                        チェックすると、セッション開始時に GITHUB_TOKEN 環境変数として設定されます
+                      </p>
+                    </div>
                   </div>
 
                   <div>

--- a/src/app/components/EditProfileModal.tsx
+++ b/src/app/components/EditProfileModal.tsx
@@ -387,10 +387,39 @@ export default function EditProfileModal({ isOpen, onClose, profileId, onProfile
                         <input
                           type="checkbox"
                           checked={formData.agentApiProxy?.useAsGithubToken || false}
-                          onChange={(e) => setFormData(prev => ({
-                            ...prev,
-                            agentApiProxy: { ...prev.agentApiProxy, useAsGithubToken: e.target.checked }
-                          }))}
+                          onChange={(e) => {
+                            const isChecked = e.target.checked
+                            setFormData(prev => {
+                              const newFormData = {
+                                ...prev,
+                                agentApiProxy: { ...prev.agentApiProxy, useAsGithubToken: isChecked }
+                              }
+                              
+                              // チェックが入った場合、GITHUB_TOKEN を環境変数に追加
+                              if (isChecked && prev.agentApiProxy?.apiKey) {
+                                const envVars = prev.environmentVariables || []
+                                const hasGithubToken = envVars.some(env => env.key === 'GITHUB_TOKEN')
+                                
+                                if (!hasGithubToken) {
+                                  newFormData.environmentVariables = [
+                                    ...envVars,
+                                    {
+                                      key: 'GITHUB_TOKEN',
+                                      value: prev.agentApiProxy.apiKey,
+                                      description: 'AgentAPI キーを GITHUB_TOKEN として使用'
+                                    }
+                                  ]
+                                }
+                              }
+                              // チェックが外れた場合、GITHUB_TOKEN を環境変数から削除
+                              else if (!isChecked) {
+                                const envVars = prev.environmentVariables || []
+                                newFormData.environmentVariables = envVars.filter(env => env.key !== 'GITHUB_TOKEN')
+                              }
+                              
+                              return newFormData
+                            })
+                          }}
                           className="mr-2"
                         />
                         <span className="text-sm text-gray-700 dark:text-gray-300">

--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -240,6 +240,11 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
         return acc
       }, {} as Record<string, string>)
       
+      // Debug logs
+      console.log('Debug: envVars state:', envVars)
+      console.log('Debug: validEnvVars:', validEnvVars)
+      console.log('Debug: environment object:', environment)
+      
       // Filter out empty metadata variables
       const validMetadataVars = metadataVars.filter(metaVar => metaVar.key.trim() && metaVar.value.trim())
       const metadata = validMetadataVars.reduce((acc, metaVar) => {
@@ -273,6 +278,8 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
         metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         tags: Object.keys(tags).length > 0 ? tags : undefined
       }
+      
+      console.log('Debug: sessionData being sent:', sessionData)
       
       await agentAPI.start!({
         environment: sessionData.environment,

--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -165,8 +165,22 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
         // Profile の環境変数をフォームに反映（フィルターからの値が優先）
         if (envVars.length === 1 && !envVars[0].key && !envVars[0].value) {
           const profileEnvVars = currentProfile.environmentVariables || []
-          if (profileEnvVars.length > 0) {
-            setEnvVars(profileEnvVars.map(envVar => ({ 
+          
+          // GITHUB_TOKEN として API キーを使用する設定が有効な場合、環境変数に追加
+          const envVarsToSet = [...profileEnvVars]
+          if (currentProfile.agentApiProxy?.useAsGithubToken && currentProfile.agentApiProxy?.apiKey) {
+            // 既存の GITHUB_TOKEN がない場合のみ追加
+            if (!envVarsToSet.some(env => env.key === 'GITHUB_TOKEN')) {
+              envVarsToSet.push({
+                key: 'GITHUB_TOKEN',
+                value: currentProfile.agentApiProxy.apiKey,
+                description: 'AgentAPI キーを GITHUB_TOKEN として使用'
+              })
+            }
+          }
+          
+          if (envVarsToSet.length > 0) {
+            setEnvVars(envVarsToSet.map(envVar => ({ 
               key: envVar.key || '', 
               value: envVar.value || '' 
             })))

--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -163,41 +163,13 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
       
       if (currentProfile) {
         // Profile の環境変数をフォームに反映（フィルターからの値が優先）
-        const profileEnvVars = currentProfile.environmentVariables || []
-        
-        // GITHUB_TOKEN として API キーを使用する設定が有効な場合、環境変数に追加
-        const envVarsToSet = [...profileEnvVars]
-        if (currentProfile.agentApiProxy?.useAsGithubToken && currentProfile.agentApiProxy?.apiKey) {
-          // 既存の GITHUB_TOKEN がない場合のみ追加
-          if (!envVarsToSet.some(env => env.key === 'GITHUB_TOKEN')) {
-            envVarsToSet.push({
-              key: 'GITHUB_TOKEN',
-              value: currentProfile.agentApiProxy.apiKey,
-              description: 'AgentAPI キーを GITHUB_TOKEN として使用'
-            })
-          }
-        }
-        
-        // フィルターからの環境変数がない場合のみプロファイルの環境変数を適用
         if (envVars.length === 1 && !envVars[0].key && !envVars[0].value) {
-          if (envVarsToSet.length > 0) {
-            setEnvVars(envVarsToSet.map(envVar => ({ 
+          const profileEnvVars = currentProfile.environmentVariables || []
+          if (profileEnvVars.length > 0) {
+            setEnvVars(profileEnvVars.map(envVar => ({ 
               key: envVar.key || '', 
               value: envVar.value || '' 
             })))
-          }
-        } else {
-          // フィルターからの環境変数がある場合、GITHUB_TOKEN のみ追加チェック
-          if (currentProfile.agentApiProxy?.useAsGithubToken && currentProfile.agentApiProxy?.apiKey) {
-            const currentEnvVars = [...envVars]
-            // 既存の GITHUB_TOKEN がない場合のみ追加
-            if (!currentEnvVars.some(env => env.key === 'GITHUB_TOKEN')) {
-              currentEnvVars.push({
-                key: 'GITHUB_TOKEN',
-                value: currentProfile.agentApiProxy.apiKey
-              })
-              setEnvVars(currentEnvVars)
-            }
           }
         }
       }
@@ -240,11 +212,6 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
         return acc
       }, {} as Record<string, string>)
       
-      // Debug logs
-      console.log('Debug: envVars state:', envVars)
-      console.log('Debug: validEnvVars:', validEnvVars)
-      console.log('Debug: environment object:', environment)
-      
       // Filter out empty metadata variables
       const validMetadataVars = metadataVars.filter(metaVar => metaVar.key.trim() && metaVar.value.trim())
       const metadata = validMetadataVars.reduce((acc, metaVar) => {
@@ -278,8 +245,6 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
         metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         tags: Object.keys(tags).length > 0 ? tags : undefined
       }
-      
-      console.log('Debug: sessionData being sent:', sessionData)
       
       await agentAPI.start!({
         environment: sessionData.environment,

--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -163,27 +163,41 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
       
       if (currentProfile) {
         // Profile の環境変数をフォームに反映（フィルターからの値が優先）
-        if (envVars.length === 1 && !envVars[0].key && !envVars[0].value) {
-          const profileEnvVars = currentProfile.environmentVariables || []
-          
-          // GITHUB_TOKEN として API キーを使用する設定が有効な場合、環境変数に追加
-          const envVarsToSet = [...profileEnvVars]
-          if (currentProfile.agentApiProxy?.useAsGithubToken && currentProfile.agentApiProxy?.apiKey) {
-            // 既存の GITHUB_TOKEN がない場合のみ追加
-            if (!envVarsToSet.some(env => env.key === 'GITHUB_TOKEN')) {
-              envVarsToSet.push({
-                key: 'GITHUB_TOKEN',
-                value: currentProfile.agentApiProxy.apiKey,
-                description: 'AgentAPI キーを GITHUB_TOKEN として使用'
-              })
-            }
+        const profileEnvVars = currentProfile.environmentVariables || []
+        
+        // GITHUB_TOKEN として API キーを使用する設定が有効な場合、環境変数に追加
+        const envVarsToSet = [...profileEnvVars]
+        if (currentProfile.agentApiProxy?.useAsGithubToken && currentProfile.agentApiProxy?.apiKey) {
+          // 既存の GITHUB_TOKEN がない場合のみ追加
+          if (!envVarsToSet.some(env => env.key === 'GITHUB_TOKEN')) {
+            envVarsToSet.push({
+              key: 'GITHUB_TOKEN',
+              value: currentProfile.agentApiProxy.apiKey,
+              description: 'AgentAPI キーを GITHUB_TOKEN として使用'
+            })
           }
-          
+        }
+        
+        // フィルターからの環境変数がない場合のみプロファイルの環境変数を適用
+        if (envVars.length === 1 && !envVars[0].key && !envVars[0].value) {
           if (envVarsToSet.length > 0) {
             setEnvVars(envVarsToSet.map(envVar => ({ 
               key: envVar.key || '', 
               value: envVar.value || '' 
             })))
+          }
+        } else {
+          // フィルターからの環境変数がある場合、GITHUB_TOKEN のみ追加チェック
+          if (currentProfile.agentApiProxy?.useAsGithubToken && currentProfile.agentApiProxy?.apiKey) {
+            const currentEnvVars = [...envVars]
+            // 既存の GITHUB_TOKEN がない場合のみ追加
+            if (!currentEnvVars.some(env => env.key === 'GITHUB_TOKEN')) {
+              currentEnvVars.push({
+                key: 'GITHUB_TOKEN',
+                value: currentProfile.agentApiProxy.apiKey
+              })
+              setEnvVars(currentEnvVars)
+            }
           }
         }
       }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -5,6 +5,7 @@ export interface AgentApiProxySettings {
   enabled: boolean
   timeout: number
   apiKey: string
+  useAsGithubToken?: boolean
 }
 
 export interface EnvironmentVariable {


### PR DESCRIPTION
## Summary
- プロファイルの API Key 設定に「このキーを GITHUB_TOKEN として使用する」チェックボックスを追加
- チェックが入っている場合、セッション開始時に GITHUB_TOKEN 環境変数として自動的に設定される機能を実装
- これにより、GitHub API を使用するエージェントで API キーを毎回手動で設定する必要がなくなります

## Test plan
- [x] プロファイル編集画面で API Key 設定の下にチェックボックスが表示されることを確認
- [x] チェックボックスの状態が適切に保存・読み込みされることを確認
- [x] チェックが入っている場合、新規セッション作成時に GITHUB_TOKEN が環境変数に自動設定されることを確認
- [x] 既存の GITHUB_TOKEN がある場合は上書きされないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)