### PR TITLE
feat: Helmチャートで暗号化キーをKubernetesシークレットから取得できるように設定

### DIFF
--- a/helm/agentapi-ui/README.md
+++ b/helm/agentapi-ui/README.md
@@ -12,19 +12,27 @@ helm install agentapi-ui ./helm/agentapi-ui
 
 ### 暗号化キーの設定
 
-このアプリケーションは、セキュアなデータの暗号化のために暗号化キーを必要とします。暗号化キーはKubernetesシークレットから取得するように設定されています。
+このアプリケーションは、セキュアなデータの暗号化のために2つの暗号化キーを必要とします：
+- **ENCRYPTION_KEY**: 一般的なデータ暗号化用
+- **COOKIE_ENCRYPTION_SECRET**: Cookie内のAPIキー暗号化用（64文字の16進数文字列）
+
+両方の暗号化キーはKubernetesシークレットから取得するように設定されています。
 
 #### 1. シークレットの作成
 
-まず、暗号化キーを含むKubernetesシークレットを作成します：
+まず、両方の暗号化キーを含むKubernetesシークレットを作成します：
 
 ```bash
 # ランダムな32バイト（256ビット）のキーを生成
 ENCRYPTION_KEY=$(openssl rand -base64 32)
 
+# Cookie暗号化用の32バイト（64文字の16進数）キーを生成
+COOKIE_ENCRYPTION_SECRET=$(openssl rand -hex 32)
+
 # シークレットを作成
 kubectl create secret generic agentapi-ui-encryption \
-  --from-literal=encryption-key=$ENCRYPTION_KEY
+  --from-literal=encryption-key=$ENCRYPTION_KEY \
+  --from-literal=cookie-encryption-secret=$COOKIE_ENCRYPTION_SECRET
 ```
 
 #### 2. Helmの設定
@@ -32,20 +40,29 @@ kubectl create secret generic agentapi-ui-encryption \
 `values.yaml`で暗号化キーの設定をカスタマイズできます：
 
 ```yaml
+# 一般的な暗号化キーの設定
 encryptionKey:
   enabled: true  # 暗号化キーをシークレットから取得する機能を有効化
   secretName: "agentapi-ui-encryption"  # シークレット名
   secretKey: "encryption-key"  # シークレット内のキー名
+
+# Cookie暗号化キーの設定
+cookieEncryptionSecret:
+  enabled: true  # Cookie暗号化キーをシークレットから取得する機能を有効化
+  secretName: "agentapi-ui-encryption"  # シークレット名
+  secretKey: "cookie-encryption-secret"  # シークレット内のキー名
 ```
 
 #### 3. カスタム値でのインストール
 
-異なるシークレット名を使用する場合は、インストール時に値を指定できます：
+異なるシークレット名やキー名を使用する場合は、インストール時に値を指定できます：
 
 ```bash
 helm install agentapi-ui ./helm/agentapi-ui \
   --set encryptionKey.secretName=my-custom-secret \
-  --set encryptionKey.secretKey=my-encryption-key
+  --set encryptionKey.secretKey=my-encryption-key \
+  --set cookieEncryptionSecret.secretName=my-custom-secret \
+  --set cookieEncryptionSecret.secretKey=my-cookie-key
 ```
 
 ### その他の設定

--- a/helm/agentapi-ui/README.md
+++ b/helm/agentapi-ui/README.md
@@ -1,0 +1,65 @@
+# agentapi-ui Helm Chart
+
+このHelm ChartはAgentAPI UIアプリケーションをKubernetesにデプロイするためのものです。
+
+## インストール
+
+```bash
+helm install agentapi-ui ./helm/agentapi-ui
+```
+
+## 設定
+
+### 暗号化キーの設定
+
+このアプリケーションは、セキュアなデータの暗号化のために暗号化キーを必要とします。暗号化キーはKubernetesシークレットから取得するように設定されています。
+
+#### 1. シークレットの作成
+
+まず、暗号化キーを含むKubernetesシークレットを作成します：
+
+```bash
+# ランダムな32バイト（256ビット）のキーを生成
+ENCRYPTION_KEY=$(openssl rand -base64 32)
+
+# シークレットを作成
+kubectl create secret generic agentapi-ui-encryption \
+  --from-literal=encryption-key=$ENCRYPTION_KEY
+```
+
+#### 2. Helmの設定
+
+`values.yaml`で暗号化キーの設定をカスタマイズできます：
+
+```yaml
+encryptionKey:
+  enabled: true  # 暗号化キーをシークレットから取得する機能を有効化
+  secretName: "agentapi-ui-encryption"  # シークレット名
+  secretKey: "encryption-key"  # シークレット内のキー名
+```
+
+#### 3. カスタム値でのインストール
+
+異なるシークレット名を使用する場合は、インストール時に値を指定できます：
+
+```bash
+helm install agentapi-ui ./helm/agentapi-ui \
+  --set encryptionKey.secretName=my-custom-secret \
+  --set encryptionKey.secretKey=my-encryption-key
+```
+
+### その他の設定
+
+その他の設定オプションについては、`values.yaml`ファイルを参照してください。
+
+## アップグレード
+
+```bash
+helm upgrade agentapi-ui ./helm/agentapi-ui
+```
+
+## アンインストール
+
+```bash
+helm uninstall agentapi-ui
+```

--- a/helm/agentapi-ui/templates/deployment.yaml
+++ b/helm/agentapi-ui/templates/deployment.yaml
@@ -56,6 +56,13 @@ spec:
                   name: {{ .Values.encryptionKey.secretName }}
                   key: {{ .Values.encryptionKey.secretKey }}
           {{- end }}
+          {{- if .Values.cookieEncryptionSecret.enabled }}
+            - name: COOKIE_ENCRYPTION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cookieEncryptionSecret.secretName }}
+                  key: {{ .Values.cookieEncryptionSecret.secretKey }}
+          {{- end }}
           {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
           {{- end }}

--- a/helm/agentapi-ui/templates/deployment.yaml
+++ b/helm/agentapi-ui/templates/deployment.yaml
@@ -48,8 +48,15 @@ spec:
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           {{- end }}
-          {{- if .Values.env }}
           env:
+          {{- if .Values.encryptionKey.enabled }}
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.encryptionKey.secretName }}
+                  key: {{ .Values.encryptionKey.secretKey }}
+          {{- end }}
+          {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
           {{- end }}
           resources:

--- a/helm/agentapi-ui/values.yaml
+++ b/helm/agentapi-ui/values.yaml
@@ -119,6 +119,15 @@ env: []
 # - name: API_URL
 #   value: "https://api.example.com"
 
+# Encryption key configuration
+encryptionKey:
+  # Enable encryption key from secret
+  enabled: true
+  # Name of the Kubernetes secret containing the encryption key
+  secretName: "agentapi-ui-encryption"
+  # Key within the secret that contains the encryption key
+  secretKey: "encryption-key"
+
 # ConfigMap data
 configMap:
   data: {}

--- a/helm/agentapi-ui/values.yaml
+++ b/helm/agentapi-ui/values.yaml
@@ -128,6 +128,15 @@ encryptionKey:
   # Key within the secret that contains the encryption key
   secretKey: "encryption-key"
 
+# Cookie encryption secret configuration
+cookieEncryptionSecret:
+  # Enable cookie encryption secret from secret
+  enabled: true
+  # Name of the Kubernetes secret containing the cookie encryption secret
+  secretName: "agentapi-ui-encryption"
+  # Key within the secret that contains the cookie encryption secret
+  secretKey: "cookie-encryption-secret"
+
 # ConfigMap data
 configMap:
   data: {}


### PR DESCRIPTION
## 概要
Helmチャートを更新して、暗号化キーをKubernetesシークレットから安全に取得できるようにしました。

## 変更内容
- **values.yaml**: 暗号化キー設定セクションを追加
  - `encryptionKey.enabled`: 機能の有効/無効を制御
  - `encryptionKey.secretName`: 参照するシークレット名
  - `encryptionKey.secretKey`: シークレット内のキー名
- **deployment.yaml**: シークレットから環境変数`ENCRYPTION_KEY`を設定するように修正
- **README.md**: Helmチャートの使用方法と暗号化キーの設定方法を文書化

## テスト方法
1. 暗号化キーを含むシークレットを作成:
   ```bash
   kubectl create secret generic agentapi-ui-encryption \
     --from-literal=encryption-key=$(openssl rand -base64 32)
   ```
2. Helmチャートをインストール:
   ```bash
   helm install agentapi-ui ./helm/agentapi-ui
   ```
3. ポッドが正常に起動し、暗号化キーが設定されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)