### PR TITLE
feat: Single Profile ModeとAgentAPI Proxy URLをHelmで設定可能に

### DIFF
--- a/helm/agentapi-ui/README.md
+++ b/helm/agentapi-ui/README.md
@@ -65,6 +65,42 @@ helm install agentapi-ui ./helm/agentapi-ui \
   --set cookieEncryptionSecret.secretKey=my-cookie-key
 ```
 
+### Single Profile Mode の設定
+
+Single Profile Modeを有効にすると、プロファイル切り替えUIが無効になり、単一のプロファイルとして動作します。
+
+#### 1. Single Profile Mode の有効化
+
+```yaml
+singleProfileMode:
+  enabled: true  # Single Profile Mode を有効化
+  proxyUrl: "http://agentapi-proxy:8080"  # AgentAPI Proxy の URL
+  publicProxyUrl: ""  # クライアントサイド用URL（省略可能、proxyUrlが使用される）
+```
+
+#### 2. カスタム設定でのインストール
+
+```bash
+helm install agentapi-ui ./helm/agentapi-ui \
+  --set singleProfileMode.enabled=true \
+  --set singleProfileMode.proxyUrl=http://my-proxy:8080 \
+  --set singleProfileMode.publicProxyUrl=http://my-public-proxy:8080
+```
+
+#### 3. Single Profile Mode で必要なシークレット
+
+Single Profile Mode を使用する場合は、Cookie暗号化シークレットも必要です：
+
+```bash
+# Cookie暗号化用の32バイト（64文字の16進数）キーを生成
+COOKIE_ENCRYPTION_SECRET=$(openssl rand -hex 32)
+
+# 暗号化キーと一緒にシークレットを作成
+kubectl create secret generic agentapi-ui-encryption \
+  --from-literal=encryption-key=$(openssl rand -base64 32) \
+  --from-literal=cookie-encryption-secret=$COOKIE_ENCRYPTION_SECRET
+```
+
 ### その他の設定
 
 その他の設定オプションについては、`values.yaml`ファイルを参照してください。

--- a/helm/agentapi-ui/templates/deployment.yaml
+++ b/helm/agentapi-ui/templates/deployment.yaml
@@ -63,6 +63,16 @@ spec:
                   name: {{ .Values.cookieEncryptionSecret.secretName }}
                   key: {{ .Values.cookieEncryptionSecret.secretKey }}
           {{- end }}
+          {{- if .Values.singleProfileMode.enabled }}
+            - name: SINGLE_PROFILE_MODE
+              value: "true"
+            - name: NEXT_PUBLIC_SINGLE_PROFILE_MODE
+              value: "true"
+            - name: AGENTAPI_PROXY_URL
+              value: {{ .Values.singleProfileMode.proxyUrl | quote }}
+            - name: NEXT_PUBLIC_AGENTAPI_PROXY_URL
+              value: {{ .Values.singleProfileMode.publicProxyUrl | default .Values.singleProfileMode.proxyUrl | quote }}
+          {{- end }}
           {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
           {{- end }}

--- a/helm/agentapi-ui/values.yaml
+++ b/helm/agentapi-ui/values.yaml
@@ -137,6 +137,15 @@ cookieEncryptionSecret:
   # Key within the secret that contains the cookie encryption secret
   secretKey: "cookie-encryption-secret"
 
+# Single Profile Mode configuration
+singleProfileMode:
+  # Enable single profile mode
+  enabled: false
+  # AgentAPI Proxy URL for single profile mode
+  proxyUrl: "http://localhost:8080"
+  # Public AgentAPI Proxy URL for client-side (optional, defaults to proxyUrl)
+  publicProxyUrl: ""
+
 # ConfigMap data
 configMap:
   data: {}


### PR DESCRIPTION
## 概要
Single Profile ModeとAgentAPI Proxy URLをHelm valuesで設定できるようにしました。

## 変更内容
- **values.yaml**: Single Profile Mode設定セクションを追加
  - `singleProfileMode.enabled`: Single Profile Modeの有効/無効を制御
  - `singleProfileMode.proxyUrl`: AgentAPI ProxyのURL
  - `singleProfileMode.publicProxyUrl`: クライアントサイド用URL（省略可能）
- **deployment.yaml**: Single Profile Mode有効時に必要な環境変数を自動設定
  - `SINGLE_PROFILE_MODE`, `NEXT_PUBLIC_SINGLE_PROFILE_MODE`
  - `AGENTAPI_PROXY_URL`, `NEXT_PUBLIC_AGENTAPI_PROXY_URL`
- **README.md**: Single Profile Modeの設定方法と使用例を文書化

## 使用例
```bash
helm install agentapi-ui ./helm/agentapi-ui \
  --set singleProfileMode.enabled=true \
  --set singleProfileMode.proxyUrl=http://agentapi-proxy:8080
```

## テスト方法
1. Single Profile Mode有効でデプロイ
2. UIでプロファイル切り替えが非表示になることを確認
3. Cookie認証が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)