### PR TITLE
fix: ログイン時のAPIキー検証エンドポイントを修正

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -38,7 +38,8 @@ export async function POST(request: NextRequest) {
     if (validateWithProxy) {
       const proxyUrl = process.env.AGENTAPI_PROXY_URL || 'http://localhost:8080';
       try {
-        const testResponse = await fetch(`${proxyUrl}/health`, {
+        // Use /status endpoint instead of /health as per AgentAPI OpenAPI spec
+        const testResponse = await fetch(`${proxyUrl}/status`, {
           headers: {
             'Authorization': `Bearer ${apiKey}`,
           },


### PR DESCRIPTION
## 概要
- ログイン時の401エラーを修正
- APIキー検証で使用するエンドポイントを `/health` から `/status` に変更
- AgentAPIのOpenAPI仕様に準拠

## 問題の詳細
ログイン処理中にAPIキーの検証を行う際、存在しない `/health` エンドポイントにリクエストを送信していたため、401エラーが発生していました。

## 変更内容
- `src/app/api/auth/login/route.ts`: APIキー検証時のエンドポイントを `/status` に変更

## テスト方法
1. `SINGLE_PROFILE_MODE=true` で環境を起動
2. `/login` ページでAPIキーを入力
3. 正常にログインできることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)