### PR TITLE
feat: image, chart のバージョンにvプレフィックスを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Bun image as base
-FROM oven/bun:1.2.11-alpine AS base
+FROM oven/bun:v1.2.11-alpine AS base
 
 # Set working directory
 WORKDIR /app
@@ -18,7 +18,7 @@ RUN bun install --frozen-lockfile
 RUN bun run build
 
 # Production stage
-FROM oven/bun:1.2.11-debian AS runner
+FROM oven/bun:v1.2.11-debian AS runner
 WORKDIR /app
 
 # Create non-root user

--- a/helm/agentapi-ui/Chart.yaml
+++ b/helm/agentapi-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentapi-ui
 description: A Helm chart for agentapi-ui Next.js application
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: v0.1.0
+appVersion: "v0.1.0"
 home: https://github.com/coder/agentapi-ui
 sources:
   - https://github.com/coder/agentapi-ui

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentapi-ui",
-  "version": "0.1.0",
+  "version": "v0.1.0",
   "private": true,
   "packageManager": "bun@1.2.16",
   "scripts": {


### PR DESCRIPTION
## 概要
- Chart.yaml、package.json、Dockerfile内のバージョン番号にvプレフィックスを追加しました

## 変更内容
- **Chart.yaml**: version と appVersion に v プレフィックスを追加 (0.1.0 → v0.1.0)
- **package.json**: version に v プレフィックスを追加 (0.1.0 → v0.1.0)
- **Dockerfile**: bun イメージのバージョンに v プレフィックスを追加 (1.2.11 → v1.2.11)

## テスト計画
- [ ] ビルドが正常に動作することを確認
- [ ] Helm チャートがv付きバージョンで正常にデプロイされることを確認
- [ ] Docker イメージがv付きバージョンで正常にビルドされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)