### PR TITLE
feat: Helm Chart にリソース制限を追加

### DIFF
--- a/helm/agentapi-ui/values.yaml
+++ b/helm/agentapi-ui/values.yaml
@@ -60,17 +60,13 @@ ingress:
   #    hosts:
   #      - agentapi-ui.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
## 概要
- Helm Chart の values.yaml にリソース制限を追加
- CPU: limits 500m, requests 100m
- Memory: limits 512Mi, requests 128Mi

## 変更内容
- `values.yaml` のリソース設定を有効化
- コンテナのリソース使用量を制限し、クラスタの安定性を向上

## テスト計画
- [ ] Helm Chart の構文チェック
- [ ] デプロイメントテスト
- [ ] リソース制限の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)