### PR TITLE
fix: 本番ビルドでログアウトボタンが表示されない問題を修正

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,7 +4,8 @@ import { setApiKeyCookie } from '@/lib/cookie-auth';
 export async function POST(request: NextRequest) {
   try {
     // Check if single profile mode is enabled
-    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true';
+    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true' || 
+                              process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true';
     
     if (!singleProfileMode) {
       return NextResponse.json(

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -4,7 +4,8 @@ import { deleteApiKeyCookie } from '@/lib/cookie-auth';
 export async function POST() {
   try {
     // Check if single profile mode is enabled
-    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true';
+    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true' || 
+                              process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true';
     
     if (!singleProfileMode) {
       return NextResponse.json(

--- a/src/app/api/auth/status/route.ts
+++ b/src/app/api/auth/status/route.ts
@@ -5,7 +5,8 @@ import { getEncryptionService } from '@/lib/encryption';
 export async function GET() {
   try {
     // Check if single profile mode is enabled
-    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true';
+    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true' || 
+                              process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true';
     
     if (!singleProfileMode) {
       return NextResponse.json(

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -2,6 +2,6 @@ import { NextResponse } from 'next/server'
 
 export async function GET() {
   return NextResponse.json({
-    singleProfileMode: process.env.SINGLE_PROFILE_MODE === 'true',
+    singleProfileMode: process.env.SINGLE_PROFILE_MODE === 'true' || process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true',
   })
 }

--- a/src/app/api/proxy-health/route.ts
+++ b/src/app/api/proxy-health/route.ts
@@ -16,7 +16,8 @@ export async function GET() {
   };
 
   // Test 1: Check if single profile mode is enabled
-  const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true';
+  const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true' || 
+                        process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true';
   (diagnostics.tests as Record<string, unknown>).singleProfileMode = {
     enabled: singleProfileMode,
     status: singleProfileMode ? 'PASS' : 'FAIL',

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -51,7 +51,8 @@ async function handleProxyRequest(
 ): Promise<NextResponse> {
   try {
     // Check if single profile mode is enabled
-    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true';
+    const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true' || 
+                              process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true';
     
     if (!singleProfileMode) {
       console.error('API proxy request failed: Single profile mode is not enabled. Set SINGLE_PROFILE_MODE=true environment variable.');

--- a/src/lib/runtime-config.ts
+++ b/src/lib/runtime-config.ts
@@ -8,7 +8,8 @@ export async function getRuntimeConfig() {
   if (typeof window === 'undefined') {
     // Server-side
     runtimeConfig = {
-      singleProfileMode: process.env.SINGLE_PROFILE_MODE === 'true',
+      singleProfileMode: process.env.SINGLE_PROFILE_MODE === 'true' || 
+                        process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true',
     }
     return runtimeConfig
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,8 @@ import type { NextRequest } from 'next/server'
 
 export async function middleware(request: NextRequest) {
   // Check if single profile mode is enabled
-  const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true'
+  const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true' || 
+                            process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true'
   
   if (singleProfileMode) {
     const pathname = request.nextUrl.pathname

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -101,7 +101,8 @@ export const isSingleProfileModeEnabled = (): boolean => {
 // Check if Single Profile Mode is enabled via runtime config
 export const isSingleProfileModeEnabledAsync = async (): Promise<boolean> => {
   if (typeof window === 'undefined') {
-    return process.env.SINGLE_PROFILE_MODE === 'true'
+    return process.env.SINGLE_PROFILE_MODE === 'true' || 
+           process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true'
   }
   
   try {


### PR DESCRIPTION
## 概要

本番ビルド時にログアウトボタンが表示されない問題を修正しました。

## 問題の詳細

- **問題**: 本番ビルドでログアウトボタンが表示されない
- **原因**: フロントエンドとバックエンドで異なる環境変数を参照していた
  - フロントエンド (TopBar.tsx): `NEXT_PUBLIC_SINGLE_PROFILE_MODE`
  - バックエンド (API routes): `SINGLE_PROFILE_MODE`
- **結果**: 本番ビルドでは`NEXT_PUBLIC_`プレフィックスが付いていない環境変数はクライアントサイドで利用できないため、設定が一致せず機能しない

## 修正内容

すべてのAPIルートとサーバーサイドコードで、環境変数の参照を統一しました：

```typescript
// 修正前
const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true';

// 修正後
const singleProfileMode = process.env.SINGLE_PROFILE_MODE === 'true' || 
                          process.env.NEXT_PUBLIC_SINGLE_PROFILE_MODE === 'true';
```

## 変更箇所

- **APIルート**: `login`, `logout`, `status`, `config`, `proxy`, `proxy-health`
- **ミドルウェア**: `middleware.ts`
- **設定関連**: `runtime-config.ts`, `settings.ts`

## テスト計画

- [x] プロジェクトの本番ビルドが成功することを確認
- [x] TypeScriptの型チェックが通ることを確認
- [x] ESLintのチェックが通ることを確認
- [ ] シングルプロファイルモードでのログアウトボタンの表示確認
- [ ] ログアウト機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)