### PR TITLE
fix: agentapi-proxy の正しいセッション削除エンドポイントを使用

### DIFF
--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -578,41 +578,13 @@ export class AgentAPIProxyClient {
       console.log(`[AgentAPIProxy] Attempting to delete session: ${sessionId}`);
     }
 
-    // Based on agentapi-proxy patterns, try the most likely endpoint first
-    try {
-      // Pattern 1: POST /stop with session_id in body (most likely for agentapi-proxy)
-      await this.makeRequest<void>('/stop', {
-        method: 'POST',
-        body: JSON.stringify({ session_id: sessionId }),
-      });
+    // Use the correct agentapi-proxy endpoint: DELETE /sessions/{sessionId}
+    await this.makeRequest<void>(`/sessions/${sessionId}`, {
+      method: 'DELETE',
+    });
 
-      if (this.debug) {
-        console.log(`[AgentAPIProxy] Successfully stopped session ${sessionId} using /stop endpoint`);
-      }
-      return;
-    } catch (stopError) {
-      if (this.debug) {
-        console.log(`[AgentAPIProxy] Failed to stop session ${sessionId} using /stop endpoint:`, stopError);
-      }
-
-      // Pattern 2: DELETE /{sessionId} (fallback)
-      try {
-        await this.makeRequest<void>(`/${sessionId}`, {
-          method: 'DELETE',
-        });
-
-        if (this.debug) {
-          console.log(`[AgentAPIProxy] Successfully deleted session ${sessionId} using DELETE /${sessionId}`);
-        }
-        return;
-      } catch (deleteError) {
-        if (this.debug) {
-          console.log(`[AgentAPIProxy] Failed to delete session ${sessionId} using DELETE /${sessionId}:`, deleteError);
-        }
-
-        // If both methods fail, throw the more informative error
-        throw deleteError;
-      }
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Successfully deleted session: ${sessionId}`);
     }
   }
 


### PR DESCRIPTION
## 概要
agentapi-proxy の実装を調査した結果、セッション削除の正しいエンドポイントが `DELETE /sessions/{sessionId}` であることが判明し、クライアント実装を修正しました。

## 問題
- セッション削除時に間違ったエンドポイントを使用していた
- `POST /stop` エンドポイント（存在しない）を試行
- `DELETE /{sessionId}` エンドポイント（パスが不完全）を試行
- これにより DELETE リクエストが 404 Not Found になっていた

## 解決策
agentapi-proxy の実装を調査（リポジトリをクローンして確認）し、正しいエンドポイント仕様を特定：

### 正しいエンドポイント
- **パス**: `DELETE /sessions/{sessionId}`  
- **実装場所**: `pkg/proxy/proxy.go:379`
- **ハンドラー**: `deleteSession` 関数

## 変更内容
- ❌ 間違った `/stop` (POST) エンドポイントの試行を削除
- ❌ 間違った `/{sessionId}` (DELETE) エンドポイントの試行を削除  
- ✅ 正しい `/sessions/{sessionId}` (DELETE) エンドポイントを使用
- ✅ 複雑なフォールバック処理を簡略化

## テスト方法
1. セッション削除機能を実行
2. `/api/proxy/sessions/{sessionId}` への DELETE リクエストが正しく送信されることを確認
3. 404 エラーが解消されることを確認

## 参照
- agentapi-proxy 実装: https://github.com/takutakahashi/agentapi-proxy
- 該当ルーター設定: `pkg/proxy/proxy.go:379`

🤖 Generated with [Claude Code](https://claude.ai/code)