### PR TITLE
エラーログからヘッダー情報の出力を削除

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -53,8 +53,7 @@ async function handleProxyRequest(
     // Log the incoming request for debugging
     console.log(`[API Proxy] ${method} request to:`, pathParts.join('/'), {
       searchParams: request.nextUrl.searchParams.toString(),
-      hasBody: method !== 'GET' && method !== 'HEAD',
-      headers: Object.fromEntries(request.headers.entries())
+      hasBody: method !== 'GET' && method !== 'HEAD'
     });
 
     // Check if single profile mode is enabled

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -161,7 +161,6 @@ export class AgentAPIProxyClient {
 
       if (this.debug) {
         console.log(`[AgentAPIProxy] ${options.method || 'GET'} ${url} (Bearer token)`, {
-          headers: bearerRequestOptions.headers,
           body: options.body,
           attempt,
         });
@@ -184,7 +183,6 @@ export class AgentAPIProxyClient {
 
             if (this.debug) {
               console.log(`[AgentAPIProxy] ${options.method || 'GET'} ${url} (X-API-Key fallback)`, {
-                headers: fallbackRequestOptions.headers,
                 body: options.body,
                 attempt,
               });
@@ -265,7 +263,6 @@ export class AgentAPIProxyClient {
 
     if (this.debug) {
       console.log(`[AgentAPIProxy] ${options.method || 'GET'} ${url} (no auth)`, {
-        headers: requestOptions.headers,
         body: options.body,
         attempt,
       });
@@ -335,8 +332,7 @@ export class AgentAPIProxyClient {
     if (this.debug) {
       console.log(`[AgentAPIProxy] Proxy ${options.method || 'GET'} ${proxyUrl}`, {
         hasEncryptedConfig: !!this.encryptedConfig,
-        bodyLength: typeof body === 'string' ? body.length : 0,
-        headers: options.headers
+        bodyLength: typeof body === 'string' ? body.length : 0
       });
     }
     


### PR DESCRIPTION
## 概要
HTTPリクエストのエラーログからヘッダー情報の出力を削除しました。

## 変更内容
- `src/app/api/proxy/[...path]/route.ts`: リクエストログからヘッダー情報を削除
- `src/lib/agentapi-proxy-client.ts`: デバッグログからヘッダー情報を削除

## 理由
セキュリティ向上のため、HTTPヘッダー情報（認証情報やその他のセンシティブな情報が含まれる可能性がある）をログに出力しないように修正しました。

## テストプラン
- [ ] アプリケーションが正常に動作することを確認
- [ ] エラーログにヘッダー情報が含まれていないことを確認
- [ ] デバッグログが適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)