### PR TITLE
セッション一覧から「アクティブなセッション」ラベルを削除

### DIFF
--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -617,9 +617,6 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
           {/* 既存セッション */}
           {filteredSessions.length > 0 && (
             <div>
-              <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-4">
-                アクティブなセッション ({filteredSessions.length})
-              </h4>
               <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg divide-y divide-gray-200 dark:divide-gray-700">
                 {paginatedSessions.map((session) => (
                   <div


### PR DESCRIPTION
## 概要
- SessionListView コンポーネントから「アクティブなセッション」の見出しを削除しました

## 変更内容
- src/app/components/SessionListView.tsx の621行目にあった「アクティブなセッション」のラベル表示を削除

## テスト計画
- [ ] セッション一覧ページでセッションが正しく表示されることを確認
- [ ] セッション数の表示が正しいことを確認
- [ ] セッションの並び順やフィルタリングが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)