### PR TITLE
Add single profile mode Docker build workflow and Helm chart support

### DIFF
--- a/.github/workflows/docker-single-profile.yaml
+++ b/.github/workflows/docker-single-profile.yaml
@@ -1,0 +1,72 @@
+name: Docker Build (Single Profile Mode)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g., v1.0.0-single)'
+        required: false
+        default: 'single-profile-latest'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'bun.lockb'
+      - 'Dockerfile'
+      - '.github/workflows/docker-single-profile.yaml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-single-profile,onlatest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=${{ github.event.inputs.tag || 'single-profile-latest' }}
+            type=raw,value=single-profile-{{date 'YYYYMMDD-HHmmss'}}
+            type=sha,prefix=single-profile-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_SINGLE_PROFILE_MODE=true
+            SINGLE_PROFILE_MODE=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/helm/agentapi-ui/templates/deployment.yaml
+++ b/helm/agentapi-ui/templates/deployment.yaml
@@ -34,7 +34,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.singleProfileMode.enabled }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.singleProfileSuffix }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/helm/agentapi-ui/values.yaml
+++ b/helm/agentapi-ui/values.yaml
@@ -9,6 +9,8 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Tag suffix for single profile mode images
+  singleProfileSuffix: "-single-profile"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- Created dedicated GitHub Actions workflow for single profile mode Docker builds
- Helm chart automatically uses single profile images when `singleProfileMode.enabled` is true
- Single profile mode images are built with environment variables pre-configured

## Implementation Details

### GitHub Actions Workflow (`docker-single-profile.yaml`)
- Builds Docker images with `SINGLE_PROFILE_MODE=true` and `NEXT_PUBLIC_SINGLE_PROFILE_MODE=true` build args
- Tags images with `-single-profile` suffix for easy identification
- Can be triggered manually via workflow_dispatch or automatically on main branch changes

### Helm Chart Updates
- Added `image.singleProfileSuffix` to configure the suffix (default: `-single-profile`)
- Updated deployment template to automatically use single profile images when `singleProfileMode.enabled` is true
- No additional configuration needed - just set `singleProfileMode.enabled: true` and the chart will use the correct image

## Usage

When deploying with single profile mode:
```yaml
singleProfileMode:
  enabled: true
  proxyUrl: "http://agentapi:8080"
# The chart will automatically use the -single-profile tagged image
```

## Test plan
- [ ] Verify GitHub Actions workflow builds successfully
- [ ] Test Helm chart deployment with `singleProfileMode.enabled: false` (uses regular image)
- [ ] Test Helm chart deployment with `singleProfileMode.enabled: true` (uses -single-profile image)
- [ ] Confirm single profile mode images have environment variables pre-configured

🤖 Generated with [Claude Code](https://claude.ai/code)