### PR TITLE
Add push notification support for agent turn completion

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,6 +8,7 @@
   "orientation": "portrait",
   "scope": "/",
   "start_url": "/",
+  "gcm_sender_id": "103953800507",
   "icons": [
     {
       "src": "/icon-192x192.png",

--- a/src/utils/pushNotification.ts
+++ b/src/utils/pushNotification.ts
@@ -1,0 +1,74 @@
+const VAPID_PUBLIC_KEY = 'BGzUvb_nB64C8JP8vxV7VRAgOVuD38wnCgM2KPd4_TPgsqRtr6VGadc66ka7lET0cEYlbh_IOooLO_qnXx8fnD0';
+
+export class PushNotificationManager {
+  private registration: ServiceWorkerRegistration | null = null;
+
+  async initialize(): Promise<boolean> {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+      console.warn('Push notifications are not supported');
+      return false;
+    }
+
+    try {
+      // Service Worker登録を取得
+      this.registration = await navigator.serviceWorker.ready;
+      
+      // 通知許可を求める
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') {
+        console.warn('Notification permission denied');
+        return false;
+      }
+
+      // プッシュ購読を確認/作成
+      let subscription = await this.registration.pushManager.getSubscription();
+      if (!subscription) {
+        subscription = await this.registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: this.urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
+        });
+      }
+
+      console.log('Push subscription created:', subscription);
+      return true;
+    } catch (error) {
+      console.error('Failed to initialize push notifications:', error);
+      return false;
+    }
+  }
+
+  async sendLocalNotification(title: string, body: string): Promise<void> {
+    if (!this.registration) {
+      // フォールバック: ブラウザ標準通知
+      if (Notification.permission === 'granted') {
+        new Notification(title, { body, icon: '/icon-192x192.png' });
+      }
+      return;
+    }
+
+    // Service Worker経由で通知
+    await this.registration.showNotification(title, {
+      body,
+      icon: '/icon-192x192.png',
+      badge: '/icon-192x192.png',
+      tag: 'agent-response'
+    });
+  }
+
+  private urlBase64ToUint8Array(base64String: string): Uint8Array {
+    const padding = '='.repeat((4 - base64String.length % 4) % 4);
+    const base64 = (base64String + padding)
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+
+    const rawData = window.atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+
+    for (let i = 0; i < rawData.length; ++i) {
+      outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+  }
+}
+
+export const pushNotificationManager = new PushNotificationManager();


### PR DESCRIPTION
## Summary
- Add push notification support for PWA to notify users when agent completes responses
- Implement VAPID key-based push messaging for background notifications
- Support both browser tabs and installed PWA notifications

## Changes
- Generate VAPID keys for secure push notifications
- Add `gcm_sender_id` to manifest.json for push messaging support
- Create PushNotificationManager utility class with VAPID authentication
- Add agent status change detection (running → stable) in AgentAPIChat
- Send local notifications when agent completes responses

## Test plan
- [ ] Test notification permission request on first load
- [ ] Verify notifications appear when agent status changes from running to stable
- [ ] Test PWA installation and background notifications on mobile
- [ ] Confirm notifications work in both foreground and background states

🤖 Generated with [Claude Code](https://claude.ai/code)