### PR TITLE
GET/HEAD リクエストでボディが送信される問題を修正

### DIFF
--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -310,12 +310,15 @@ export class AgentAPIProxyClient {
 
   private async makeProxyRequest<T>(
     endpoint: string,
-    options: RequestInit = {}
+    options: RequestInit = {},
+    includeEncryptedConfig = false
   ): Promise<T> {
-    // Prepare the request body with encrypted config if available
+    // Prepare the request body with encrypted config only when explicitly requested
     let body = options.body;
     
-    if (this.encryptedConfig && options.method !== 'GET' && options.method !== 'HEAD') {
+    // Only add encrypted config for specific endpoints that require authentication
+    if (this.encryptedConfig && includeEncryptedConfig && options.method && 
+        options.method.toUpperCase() !== 'GET' && options.method.toUpperCase() !== 'HEAD') {
       try {
         const existingBody = body ? JSON.parse(body as string) : {};
         body = JSON.stringify({


### PR DESCRIPTION
## 概要
AgentAPIProxyClient の makeProxyRequest メソッドで、GET リクエストにもボディが送信されてしまい、「Request with GET/HEAD method cannot have body」エラーが発生していた問題を修正しました。

## 問題
- `/api/proxy/search?limit=1000` のようなGETリクエストでも encryptedConfig がボディに自動追加されていた
- ブラウザの fetch API がGET/HEADメソッドでのボディ送信を禁止しているためエラーが発生

## 修正内容
- `includeEncryptedConfig` パラメータを追加し、明示的に指定された場合のみ暗号化設定を追加するように変更
- GET/HEAD メソッドの判定ロジックを改善し、未定義の場合はGETとして扱うよう修正
- 不要なリクエストボディの送信を防止

## テスト計画
- [ ] 修正後にGETリクエストでエラーが発生しないことを確認
- [ ] lint と TypeScript チェックが通ることを確認 ✅
- [ ] 既存の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)