### PR TITLE
OAuth エンドポイントのデフォルトを /api/proxy に変更

### DIFF
--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -13,8 +13,12 @@ export async function POST(request: NextRequest) {
     }
 
     // agentapi-proxyのOAuth認証エンドポイントを使用
-    // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
-    const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || '/api/proxy'
+    // デフォルトでローカルの /api/proxy を使用（サーバーサイドでは絶対URLが必要）
+    const baseUrl = process.env.AGENTAPI_PROXY_ENDPOINT || 
+      (process.env.NODE_ENV === 'production' 
+        ? `https://${request.headers.get('host')}` 
+        : 'http://localhost:3000')
+    const proxyEndpoint = baseUrl.endsWith('/api/proxy') ? baseUrl : `${baseUrl}/api/proxy`
     const response = await fetch(`${proxyEndpoint}/oauth/authorize`, {
       method: 'POST',
       headers: {

--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -13,7 +13,8 @@ export async function POST(request: NextRequest) {
     }
 
     // agentapi-proxyのOAuth認証エンドポイントを使用
-    const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || 'http://localhost:8080'
+    // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
+    const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || '/api/proxy'
     const response = await fetch(`${proxyEndpoint}/oauth/authorize`, {
       method: 'POST',
       headers: {

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -24,8 +24,12 @@ export async function GET(request: NextRequest) {
     }
 
     // agentapi-proxyのOAuthコールバックエンドポイントを使用
-    // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
-    const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || '/api/proxy'
+    // デフォルトでローカルの /api/proxy を使用（サーバーサイドでは絶対URLが必要）
+    const baseUrl = process.env.AGENTAPI_PROXY_ENDPOINT || 
+      (process.env.NODE_ENV === 'production' 
+        ? `https://${request.headers.get('host')}` 
+        : 'http://localhost:3000')
+    const proxyEndpoint = baseUrl.endsWith('/api/proxy') ? baseUrl : `${baseUrl}/api/proxy`
     const response = await fetch(`${proxyEndpoint}/oauth/callback?code=${code}&state=${state}`, {
       method: 'GET',
     })

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -24,7 +24,8 @@ export async function GET(request: NextRequest) {
     }
 
     // agentapi-proxyのOAuthコールバックエンドポイントを使用
-    const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || 'http://localhost:8080'
+    // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
+    const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || '/api/proxy'
     const response = await fetch(`${proxyEndpoint}/oauth/callback?code=${code}&state=${state}`, {
       method: 'GET',
     })

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -37,7 +37,8 @@ export async function POST(request: NextRequest) {
     const validateWithProxy = process.env.VALIDATE_API_KEY_WITH_PROXY !== 'false';
     
     if (validateWithProxy) {
-      const proxyUrl = process.env.AGENTAPI_PROXY_URL || 'http://localhost:8080';
+      // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
+      const proxyUrl = process.env.AGENTAPI_PROXY_URL || '/api/proxy';
       try {
         console.log(`[Auth] Validating API key with proxy: ${proxyUrl}`);
         

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -37,8 +37,12 @@ export async function POST(request: NextRequest) {
     const validateWithProxy = process.env.VALIDATE_API_KEY_WITH_PROXY !== 'false';
     
     if (validateWithProxy) {
-      // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
-      const proxyUrl = process.env.AGENTAPI_PROXY_URL || '/api/proxy';
+      // デフォルトでローカルの /api/proxy を使用（サーバーサイドでは絶対URLが必要）
+      const baseUrl = process.env.AGENTAPI_PROXY_URL || 
+        (process.env.NODE_ENV === 'production' 
+          ? `https://${request.headers.get('host')}` 
+          : 'http://localhost:3000')
+      const proxyUrl = baseUrl.endsWith('/api/proxy') ? baseUrl : `${baseUrl}/api/proxy`;
       try {
         console.log(`[Auth] Validating API key with proxy: ${proxyUrl}`);
         

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -24,7 +24,8 @@ export async function POST(request: NextRequest) {
         
         // If it's a GitHub OAuth session, revoke it on the proxy
         if (sessionData.sessionId) {
-          const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || 'http://localhost:8080';
+          // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
+          const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || '/api/proxy';
           await fetch(`${proxyEndpoint}/oauth/logout`, {
             method: 'POST',
             headers: {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -24,8 +24,12 @@ export async function POST(request: NextRequest) {
         
         // If it's a GitHub OAuth session, revoke it on the proxy
         if (sessionData.sessionId) {
-          // デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
-          const proxyEndpoint = process.env.AGENTAPI_PROXY_ENDPOINT || '/api/proxy';
+          // デフォルトでローカルの /api/proxy を使用（サーバーサイドでは絶対URLが必要）
+          const baseUrl = process.env.AGENTAPI_PROXY_ENDPOINT || 
+            (process.env.NODE_ENV === 'production' 
+              ? `https://${request.headers.get('host')}` 
+              : 'http://localhost:3000')
+          const proxyEndpoint = baseUrl.endsWith('/api/proxy') ? baseUrl : `${baseUrl}/api/proxy`;
           await fetch(`${proxyEndpoint}/oauth/logout`, {
             method: 'POST',
             headers: {

--- a/src/app/api/proxy-health/route.ts
+++ b/src/app/api/proxy-health/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getApiKeyFromCookie } from '@/lib/cookie-auth';
 
-const PROXY_URL = process.env.AGENTAPI_PROXY_URL || 'http://localhost:8080';
+// デフォルトで /api/proxy を使用（相対URLで同じオリジンを参照）
+const PROXY_URL = process.env.AGENTAPI_PROXY_URL || '/api/proxy';
 
 export async function GET() {
   const diagnostics: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- Kubernetesなどのコンテナ環境でOAuth認証時に`localhost:8080`への接続が失敗する問題を修正
- `AGENTAPI_PROXY_ENDPOINT`環境変数が未設定の場合、デフォルトで`/api/proxy`を使用するように変更
- OAuth関連の全APIルートを更新

## 変更されたファイル
- `src/app/api/auth/github/authorize/route.ts` - OAuth認証開始エンドポイント
- `src/app/api/auth/github/callback/route.ts` - OAuthコールバックエンドポイント  
- `src/app/api/auth/logout/route.ts` - ログアウトエンドポイント
- `src/app/api/auth/login/route.ts` - ログイン認証エンドポイント
- `src/app/api/proxy-health/route.ts` - プロキシヘルスチェックエンドポイント

## Test plan
- [x] lint チェック実行済み
- [x] TypeScript型チェック実行済み
- [ ] Kubernetesクラスター内でOAuth認証のテスト
- [ ] 既存の`AGENTAPI_PROXY_ENDPOINT`設定が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)