### PR TITLE
OAuth認証のリダイレクトURL設定の修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ COOKIE_ENCRYPTION_SECRET=your-32-byte-hex-secret-here-64-characters-long-for-aes
 # Next.js Configuration
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your-nextauth-secret-here
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 # Environment
 NODE_ENV=development

--- a/src/app/login/github/page.tsx
+++ b/src/app/login/github/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Github } from 'lucide-react'
+import { getRedirectUri } from '@/lib/oauth-utils'
 
 export default function GitHubLoginPage() {
   const [isLoading, setIsLoading] = useState(false)
@@ -19,7 +20,7 @@ export default function GitHubLoginPage() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          redirect_uri: `${window.location.origin}/api/auth/github/callback`
+          redirect_uri: getRedirectUri()
         }),
       })
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Github } from 'lucide-react'
+import { getRedirectUri } from '@/lib/oauth-utils'
 
 export default function LoginPage() {
   const router = useRouter()
@@ -50,7 +51,7 @@ export default function LoginPage() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          redirect_uri: `${window.location.origin}/api/auth/github/callback`
+          redirect_uri: getRedirectUri()
         }),
       })
 

--- a/src/lib/oauth-utils.ts
+++ b/src/lib/oauth-utils.ts
@@ -1,0 +1,15 @@
+export function getRedirectUri(): string {
+  // クライアントサイドでのみ実行されることを確認
+  if (typeof window === 'undefined') {
+    // サーバーサイドの場合は環境変数から取得
+    return process.env.NEXT_PUBLIC_BASE_URL ? 
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/github/callback` : 
+      'http://localhost:3000/api/auth/github/callback';
+  }
+
+  // window.location.originのフォールバック処理
+  const origin = window.location.origin || 
+    `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}`;
+
+  return `${origin}/api/auth/github/callback`;
+}


### PR DESCRIPTION
## 概要
OAuth認証時に`https://cc.takutakahashi.dev/undefined`にリダイレクトされる問題を修正しました。

## 修正内容
- `window.location.origin`が`undefined`になる問題への対処
- `oauth-utils`ヘルパー関数を追加してリダイレクトURLを安全に取得
- 環境変数`NEXT_PUBLIC_BASE_URL`のサポートを追加
- サーバーサイドレンダリング時のフォールバック処理を実装

## 変更ファイル
- `src/lib/oauth-utils.ts` - 新規作成: リダイレクトURL取得のヘルパー関数
- `src/app/login/github/page.tsx` - ヘルパー関数を使用するように修正
- `src/app/login/page.tsx` - ヘルパー関数を使用するように修正
- `.env.example` - `NEXT_PUBLIC_BASE_URL`環境変数を追加

## テスト計画
- [ ] OAuth認証フローが正常に動作することを確認
- [ ] リダイレクトURLが適切に設定されることを確認
- [ ] サーバーサイドレンダリング時も正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)