### PR TITLE
OAuth認証のレスポンスフィールド名を修正

### DIFF
--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
     headers.append('Set-Cookie', `oauth_state=${data.state}; Path=/; HttpOnly; SameSite=Lax; Max-Age=900`)
 
     return NextResponse.json({
-      auth_url: data.authorization_url,
+      auth_url: data.auth_url,
       state: data.state
     }, { headers })
   } catch (error) {

--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
     headers.append('Set-Cookie', `oauth_state=${data.state}; Path=/; HttpOnly; SameSite=Lax; Max-Age=900`)
 
     return NextResponse.json({
-      authorization_url: data.authorization_url,
+      auth_url: data.authorization_url,
       state: data.state
     }, { headers })
   } catch (error) {

--- a/src/app/login/github/page.tsx
+++ b/src/app/login/github/page.tsx
@@ -32,7 +32,7 @@ export default function GitHubLoginPage() {
       const data = await response.json()
       
       // GitHubの認証ページにリダイレクト
-      window.location.href = data.authorization_url
+      window.location.href = data.auth_url
     } catch (err) {
       setError(err instanceof Error ? err.message : '予期しないエラーが発生しました')
       setIsLoading(false)


### PR DESCRIPTION
## 概要
OAuth認証のレスポンスフィールド名を`authorization_url`から`auth_url`に変更しました。

## 変更内容
- `/src/app/api/auth/github/authorize/route.ts`: レスポンスフィールド名を`auth_url`に変更
- `/src/app/login/github/page.tsx`: フロントエンドでの参照を`auth_url`に変更

## 理由
期待される仕様に合わせて、レスポンスフィールド名を統一するため。

## テスト計画
- [x] リントチェックの実行
- [x] TypeScriptの型チェック
- [ ] OAuth認証フローの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)