### PR TITLE
OAuth認証レスポンス処理の改善

### DIFF
--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
     headers.append('Set-Cookie', `oauth_state=${data.state}; Path=/; HttpOnly; SameSite=Lax; Max-Age=900`)
 
     return NextResponse.json({
-      authorization_url: data.authorization_url,
+      auth_url: data.authorization_url,
       state: data.state
     }, { headers })
   } catch (error) {

--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -19,6 +19,7 @@ export async function POST(request: NextRequest) {
         ? `https://${request.headers.get('host')}` 
         : 'http://localhost:3000')
     const proxyEndpoint = baseUrl.endsWith('/api/proxy') ? baseUrl : `${baseUrl}/api/proxy`
+    console.log('OAuth authorize request to:', `${proxyEndpoint}/oauth/authorize`)
     const response = await fetch(`${proxyEndpoint}/oauth/authorize`, {
       method: 'POST',
       headers: {
@@ -29,6 +30,28 @@ export async function POST(request: NextRequest) {
       }),
     })
 
+    console.log('OAuth authorize response status:', response.status)
+    console.log('OAuth authorize response headers:', Object.fromEntries(response.headers.entries()))
+
+    // Check if response is a redirect
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location')
+      if (location) {
+        console.log('OAuth authorize returned redirect to:', location)
+        // Extract state from the redirect URL if present
+        const urlParams = new URLSearchParams(new URL(location).search)
+        const state = urlParams.get('state') || crypto.randomUUID()
+        
+        const headers = new Headers()
+        headers.append('Set-Cookie', `oauth_state=${state}; Path=/; HttpOnly; SameSite=Lax; Max-Age=900`)
+        
+        return NextResponse.json({
+          auth_url: location,
+          state: state
+        }, { headers })
+      }
+    }
+
     if (!response.ok) {
       const errorData = await response.text()
       console.error('OAuth authorize error:', errorData)
@@ -38,15 +61,58 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    const contentType = response.headers.get('content-type')
+    if (!contentType?.includes('application/json')) {
+      const textData = await response.text()
+      console.error('OAuth authorize returned non-JSON response:', textData)
+      return NextResponse.json(
+        { error: 'Invalid response format from OAuth provider' },
+        { status: 500 }
+      )
+    }
+
     const data = await response.json()
+    
+    // デバッグ: レスポンスの内容をログ出力
+    console.log('OAuth authorize response from agentapi-proxy:', JSON.stringify(data, null, 2))
+    
+    // レスポンスフィールドの互換性を確保
+    // agentapi-proxyは異なるフィールド名を使用する可能性がある
+    // ネストされた構造も考慮
+    const authUrl = data.authorization_url || 
+                    data.auth_url || 
+                    data.authUrl || 
+                    data.url || 
+                    data.authorize_url ||
+                    data.data?.authorization_url ||
+                    data.data?.auth_url ||
+                    data.data?.url
+    
+    const state = data.state || data.data?.state
+    
+    if (!authUrl) {
+      console.error('No authorization URL found in response. Available fields:', Object.keys(data))
+      return NextResponse.json(
+        { error: 'Invalid response from OAuth provider - no authorization URL' },
+        { status: 500 }
+      )
+    }
+    
+    if (!state) {
+      console.error('No state found in response. Available fields:', Object.keys(data))
+      return NextResponse.json(
+        { error: 'Invalid response from OAuth provider - no state' },
+        { status: 500 }
+      )
+    }
     
     // stateを一時的にセッションストレージに保存するためのCookieを設定
     const headers = new Headers()
-    headers.append('Set-Cookie', `oauth_state=${data.state}; Path=/; HttpOnly; SameSite=Lax; Max-Age=900`)
+    headers.append('Set-Cookie', `oauth_state=${state}; Path=/; HttpOnly; SameSite=Lax; Max-Age=900`)
 
     return NextResponse.json({
-      auth_url: data.authorization_url,
-      state: data.state
+      auth_url: authUrl,
+      state: state
     }, { headers })
   } catch (error) {
     console.error('OAuth authorize error:', error)

--- a/src/app/login/github/page.tsx
+++ b/src/app/login/github/page.tsx
@@ -32,7 +32,7 @@ export default function GitHubLoginPage() {
       const data = await response.json()
       
       // GitHubの認証ページにリダイレクト
-      window.location.href = data.authorization_url
+      window.location.href = data.auth_url
     } catch (err) {
       setError(err instanceof Error ? err.message : '予期しないエラーが発生しました')
       setIsLoading(false)


### PR DESCRIPTION
## Summary
- agentapi-proxyのOAuth認証エンドポイントとの互換性を改善
- 様々なレスポンス形式に対応してエラーを防止
- デバッグ機能を追加して問題の診断を容易に

## 変更内容

### 1. `/api/auth/github/authorize/route.ts`
- 複数のフィールド名パターンに対応（authorization_url, auth_url, authUrl, url等）
- ネストされたレスポンス構造（data.authorization_url等）もサポート
- HTTPリダイレクトレスポンス（3xx）の処理を追加
- レスポンス内容のデバッグログを追加
- JSON以外のレスポンス形式のエラーハンドリング

### 2. `/api/auth/github/callback/route.ts`
- レスポンスフィールドの互換性を向上（session_id/sessionId, access_token/accessToken/token）
- 必須フィールドの検証とエラーハンドリング
- デバッグログを追加

### 3. `/api/proxy/[...path]/route.ts`
- OAuth authorizeエンドポイントのリダイレクトを手動制御（redirect: 'manual'）
- リダイレクトレスポンスから認証URLとstateを抽出
- authorization_urlとauth_urlの両方のフィールド名で返却（互換性のため）

## Test plan
- [ ] ローカル環境でGitHub OAuth認証フローをテスト
- [ ] agentapi-proxyが異なるレスポンス形式を返す場合でも正常に動作することを確認
- [ ] デバッグログで実際のレスポンス内容を確認
- [ ] エラーケースでも適切なエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)