### PR TITLE
OAuth認証のレスポンスフィールド名を修正

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -63,7 +63,7 @@ export default function LoginPage() {
       const data = await response.json()
       
       // GitHubの認証ページにリダイレクト
-      window.location.href = data.authorization_url
+      window.location.href = data.auth_url
     } catch (err) {
       setError(err instanceof Error ? err.message : '予期しないエラーが発生しました')
       setIsGitHubLoading(false)


### PR DESCRIPTION
## 概要
OAuth認証時にagentapi-proxyからのレスポンスでauth_urlフィールドが正しく取得できない問題を修正しました。

## 変更内容
- `src/app/login/page.tsx`で参照していた`data.authorization_url`を`data.auth_url`に変更
- `/api/auth/github/authorize/route.ts`のレスポンス形式と一致するように修正

## 修正前の問題
- `window.location.href = data.authorization_url`としていたが、実際のレスポンスは`{ auth_url: "...", state: "..." }`という形式
- そのため`undefined`が設定されてしまい、OAuth認証フローが動作しなかった

## テスト方法
1. ログイン画面で「Continue with GitHub」ボタンをクリック
2. GitHubの認証画面に正しくリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)