### PR TITLE
OAuth認証のJSONパースエラーを修正

### DIFF
--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -38,7 +38,17 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const data = await response.json()
+    const responseText = await response.text()
+    let data
+    try {
+      data = JSON.parse(responseText)
+    } catch (parseError) {
+      console.error('OAuth authorize error: [SyntaxError: Failed to parse JSON]', { responseText, parseError })
+      return NextResponse.json(
+        { error: 'Invalid response from OAuth server' },
+        { status: 502 }
+      )
+    }
     
     // stateを一時的にセッションストレージに保存するためのCookieを設定
     const headers = new Headers()

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -41,7 +41,16 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const data = await response.json()
+    const responseText = await response.text()
+    let data
+    try {
+      data = JSON.parse(responseText)
+    } catch (parseError) {
+      console.error('OAuth callback error: [SyntaxError: Failed to parse JSON]', { responseText, parseError })
+      return NextResponse.redirect(
+        new URL('/login/github?error=invalid_response', request.url)
+      )
+    }
     
     // APIキーを暗号化してCookieに保存
     const encryptedApiKey = encryptApiKey(data.access_token)


### PR DESCRIPTION
## 概要

OAuth認証時に発生していた `[SyntaxError: Failed to parse JSON]` エラーを修正しました。

## 変更内容

- OAuth authorize/callbackエンドポイントでレスポンスを直接 `response.json()` でパースする代わりに、まず `response.text()` で取得してからJSONパースを実行
- JSONパース失敗時の適切なエラーハンドリングを追加
- より詳細なエラーログを出力してデバッグを改善

## 修正したファイル

- `src/app/api/auth/github/authorize/route.ts`
- `src/app/api/auth/github/callback/route.ts`

## テスト

- TypeScript型チェック: ✅ 正常
- ESLint: ✅ 正常（警告のみ、既存の問題）

🤖 Generated with [Claude Code](https://claude.ai/code)