### PR TITLE
認証案内を一度のみ表示するようにセッションストレージで管理

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -232,7 +232,14 @@ export default function AgentAPIChat() {
               
               if (hasWelcomeMessage) {
                 setIsUnauthenticated(true);
-                setShowAuthGuidance(true);
+                
+                // Check if we've already shown auth guidance for this session
+                const authGuidanceShownKey = `authGuidanceShown_${sessionId}`;
+                const hasShownAuthGuidance = sessionStorage.getItem(authGuidanceShownKey) === 'true';
+                
+                if (!hasShownAuthGuidance) {
+                  setShowAuthGuidance(true);
+                }
               } else {
                 setIsUnauthenticated(false);
                 setShowAuthGuidance(false);
@@ -431,7 +438,14 @@ export default function AgentAPIChat() {
       
       if (hasWelcomeMessage) {
         setIsUnauthenticated(true);
-        setShowAuthGuidance(true);
+        
+        // Check if we've already shown auth guidance for this session
+        const authGuidanceShownKey = `authGuidanceShown_${sessionId}`;
+        const hasShownAuthGuidance = sessionStorage.getItem(authGuidanceShownKey) === 'true';
+        
+        if (!hasShownAuthGuidance) {
+          setShowAuthGuidance(true);
+        }
       } else {
         setIsUnauthenticated(false);
         setShowAuthGuidance(false);
@@ -542,6 +556,13 @@ export default function AgentAPIChat() {
     setIsLoading(true);
     setError(null);
 
+    // Mark auth guidance as shown when user sends a message
+    if (messageType === 'user' && isUnauthenticated && sessionId) {
+      const authGuidanceShownKey = `authGuidanceShown_${sessionId}`;
+      sessionStorage.setItem(authGuidanceShownKey, 'true');
+      setShowAuthGuidance(false);
+    }
+
     try {
       if (sessionId) {
         // Send message via session
@@ -597,7 +618,7 @@ export default function AgentAPIChat() {
     } finally {
       setIsLoading(false);
     }
-  }, [inputValue, isLoading, isConnected, sessionId, agentStatus, currentProfile, loadRecentMessages]);
+  }, [inputValue, isLoading, isConnected, sessionId, agentStatus, currentProfile, loadRecentMessages, isUnauthenticated]);
 
   const sendStopSignal = () => {
     // Send ESC key (raw message)
@@ -634,6 +655,11 @@ export default function AgentAPIChat() {
         return;
       }
       await agentAPIRef.current.delete(sessionId);
+      
+      // Remove auth guidance flag from session storage
+      const authGuidanceShownKey = `authGuidanceShown_${sessionId}`;
+      sessionStorage.removeItem(authGuidanceShownKey);
+      
       // セッション削除後、conversation画面にリダイレクト
       router.push('/chats');
     } catch (err) {


### PR DESCRIPTION
## 概要

認証案内の表示制御をセッションストレージで管理し、一度表示したら再表示しないように改善しました。

## 変更内容

### セッションストレージを使用した表示制御

1. **表示済みフラグの管理**
   - `authGuidanceShown_${sessionId}` のキーでセッションストレージに保存
   - 初回表示時のみ認証案内を表示

2. **メッセージ送信時の処理**
   - ユーザーがメッセージを送信したら自動的に表示済みとマーク
   - 認証案内モーダルを自動的に閉じる

3. **セッション削除時のクリーンアップ**
   - セッション削除時に該当のストレージデータも削除
   - メモリリークを防止

## 実装詳細

```typescript
// 表示判定
const authGuidanceShownKey = `authGuidanceShown_${sessionId}`;
const hasShownAuthGuidance = sessionStorage.getItem(authGuidanceShownKey) === 'true';

if (\!hasShownAuthGuidance) {
  setShowAuthGuidance(true);
}

// メッセージ送信時
if (messageType === 'user' && isUnauthenticated && sessionId) {
  sessionStorage.setItem(authGuidanceShownKey, 'true');
  setShowAuthGuidance(false);
}

// セッション削除時
sessionStorage.removeItem(authGuidanceShownKey);
```

## メリット

- ✅ ユーザーが認証方法を理解した後は再表示されない
- ✅ 同一セッション内での煩わしい再表示を防止
- ✅ セッションごとに独立して管理
- ✅ ブラウザタブを閉じても同じセッションなら表示済み状態を保持

## テスト項目

- [ ] 新規セッションで初回のみ認証案内が表示される
- [ ] メッセージ送信後は同じセッションで再表示されない
- [ ] ページリロードしても表示済み状態が保持される
- [ ] 別のセッションでは改めて表示される
- [ ] セッション削除後、同じIDで新規作成した場合は表示される

🤖 Generated with [Claude Code](https://claude.ai/code)