### PR TITLE
自動ウェルカムポップアップを廃止し、手動認証ボタンを追加

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -227,15 +227,7 @@ export default function AgentAPIChat() {
                 timestamp: msg.timestamp
               }));
               
-              // Check for "Let's get started" message to show welcome popup
-              const hasLetsGetStartedMessage = messages.length > 0 && messages[0].content && messages[0].content.includes("Let's get started");
-              
-              if (hasLetsGetStartedMessage) {
-                setIsUnauthenticated(true);
-                setShowWelcomePopup(true);
-              } else {
-                setIsUnauthenticated(false);
-              }
+              // Authentication state is now managed by user interaction, not message content
               
               setMessages(convertedMessages);
               setError(null);
@@ -291,9 +283,7 @@ export default function AgentAPIChat() {
   const [prLinks, setPRLinks] = useState<string[]>([]);
   const [showClaudeLogins, setShowClaudeLogins] = useState(false);
   const [claudeLoginUrls, setClaudeLoginUrls] = useState<string[]>([]);
-  const [isUnauthenticated, setIsUnauthenticated] = useState(false);
   const [showAuthGuidance, setShowAuthGuidance] = useState(false);
-  const [showWelcomePopup, setShowWelcomePopup] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const prevMessagesLengthRef = useRef(0);
@@ -326,8 +316,8 @@ export default function AgentAPIChat() {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        if (showWelcomePopup) {
-          setShowWelcomePopup(false)
+        if (false) {
+          // Removed welcome popup logic
         } else if (showTemplateModal) {
           setShowTemplateModal(false)
         } else if (showPRLinks) {
@@ -340,14 +330,14 @@ export default function AgentAPIChat() {
       }
     }
 
-    if (showWelcomePopup || showTemplateModal || showPRLinks || showClaudeLogins || showAuthGuidance) {
+    if (showTemplateModal || showPRLinks || showClaudeLogins || showAuthGuidance) {
       document.addEventListener('keydown', handleKeyDown)
     }
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [showWelcomePopup, showTemplateModal, showPRLinks, showClaudeLogins, showAuthGuidance]);
+  }, [showTemplateModal, showPRLinks, showClaudeLogins, showAuthGuidance]);
 
   // Listen for profile changes and recreate client
   useEffect(() => {
@@ -428,15 +418,7 @@ export default function AgentAPIChat() {
         timestamp: msg.timestamp
       }));
       
-      // Check for "Let's get started" message to show welcome popup
-      const hasLetsGetStartedMessage = messages.length > 0 && messages[0].content && messages[0].content.includes("Let's get started");
-      
-      if (hasLetsGetStartedMessage) {
-        setIsUnauthenticated(true);
-        setShowWelcomePopup(true);
-      } else {
-        setIsUnauthenticated(false);
-      }
+      // Authentication state is now managed by user interaction, not message content
       
       setMessages(convertedMessages);
       
@@ -520,14 +502,14 @@ export default function AgentAPIChat() {
         setClaudeLoginUrls(uniqueClaudeUrls);
         
         // 新しいLogin URLが検出された場合、自動的にポップアップを表示
-        if (!hadUrls && isUnauthenticated && uniqueClaudeUrls.length > 0) {
+        if (!hadUrls && uniqueClaudeUrls.length > 0) {
           setShowClaudeLogins(true);
         }
       }
     }
     
     prevMessagesLengthRef.current = currentLength;
-  }, [messages, shouldAutoScroll, claudeLoginUrls.length, isUnauthenticated]);
+  }, [messages, shouldAutoScroll, claudeLoginUrls.length]);
 
   const sendMessage = useCallback(async (messageType: 'user' | 'raw' = 'user', content?: string) => {
     const messageContent = content || inputValue.trim();
@@ -795,6 +777,17 @@ export default function AgentAPIChat() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
             </button>
+
+            {/* Authentication Button */}
+            <button
+              onClick={() => setShowAuthGuidance(true)}
+              className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+              title="認証を開始"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+              </svg>
+            </button>
           </div>
         </div>
         {error && (
@@ -816,7 +809,7 @@ export default function AgentAPIChat() {
           transform: 'translateZ(0)' // GPU acceleration
         }}
       >
-        {messages.length === 0 && isConnected && !isUnauthenticated && (
+        {messages.length === 0 && isConnected && (
           <div className="text-center text-gray-500 dark:text-gray-400 py-12">
             <div className="mb-3">
               <svg className="w-12 h-12 mx-auto text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -828,38 +821,6 @@ export default function AgentAPIChat() {
           </div>
         )}
 
-        {/* Authentication Guidance */}
-        {isUnauthenticated && (
-          <div className="flex flex-col items-center justify-center py-12 px-6">
-            <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-6 max-w-md w-full">
-              <div className="flex items-center justify-center mb-4">
-                <svg className="w-12 h-12 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-                </svg>
-              </div>
-              <h3 className="text-lg font-semibold text-yellow-900 dark:text-yellow-200 text-center mb-3">認証が必要です</h3>
-              <p className="text-sm text-yellow-800 dark:text-yellow-300 text-center mb-4">
-                Claude Codeエージェントを利用するには認証が必要です。
-              </p>
-              <div className="space-y-3">
-                <button
-                  onClick={() => setShowAuthGuidance(true)}
-                  className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md transition-colors"
-                >
-                  認証方法を確認する
-                </button>
-                {claudeLoginUrls.length > 0 && (
-                  <button
-                    onClick={() => setShowClaudeLogins(true)}
-                    className="w-full px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm rounded-md transition-colors"
-                  >
-                    ログインURLを開く
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
 
         <div className="divide-y divide-gray-200 dark:divide-gray-700">
           {messages.map((message) => (
@@ -1372,90 +1333,6 @@ export default function AgentAPIChat() {
         </div>
       )}
 
-      {/* Welcome Popup Modal */}
-      {showWelcomePopup && (
-        <div 
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) {
-              setShowWelcomePopup(false)
-            }
-          }}
-        >
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                  Welcome to AgentAPI
-                </h2>
-                <button
-                  onClick={() => setShowWelcomePopup(false)}
-                  className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-            
-            <div className="overflow-y-auto max-h-[calc(80vh-8rem)] px-6 py-4">
-              <div className="space-y-6">
-                <div className="text-center">
-                  <div className="mb-4">
-                    <svg className="w-16 h-16 mx-auto text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-1l-4 4z" />
-                    </svg>
-                  </div>
-                  <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-                    Welcome to AgentAPI Chat
-                  </h3>
-                  <p className="text-gray-600 dark:text-gray-400">
-                    Claude Code エージェントを使用して作業を開始しましょう
-                  </p>
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-                    <h4 className="font-medium text-blue-900 dark:text-blue-200 mb-2">
-                      簡単なセットアップ
-                    </h4>
-                    <p className="text-sm text-blue-800 dark:text-blue-300">
-                      認証を行うことで、数分でチャットを開始できます
-                    </p>
-                  </div>
-                  <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
-                    <h4 className="font-medium text-green-900 dark:text-green-200 mb-2">
-                      便利な機能
-                    </h4>
-                    <p className="text-sm text-green-800 dark:text-green-300">
-                      テンプレート、履歴、プルリクエストの自動検出機能
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex flex-col sm:flex-row gap-3 pt-4">
-                  <button
-                    onClick={() => {
-                      setShowWelcomePopup(false);
-                      setShowAuthGuidance(true);
-                    }}
-                    className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md transition-colors"
-                  >
-                    認証方法を確認する
-                  </button>
-                  <button
-                    onClick={() => setShowWelcomePopup(false)}
-                    className="flex-1 px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white text-sm rounded-md transition-colors"
-                  >
-                    閉じる
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Authentication Guidance Modal */}
       {showAuthGuidance && (


### PR DESCRIPTION
## Summary
- "Let's get started"メッセージ検出による自動ポップアップ機能を削除
- ヘッダーに認証開始ボタンを追加（設定ボタンの隣）
- ユーザーが手動で認証ボタンをクリックすることで認証ガイダンスを表示
- 不要な認証状態管理ロジックを削除し、UXを改善

## Test plan
- [x] ビルドが成功することを確認
- [x] TypeScriptの型チェックが通ることを確認
- [x] ESLintでコードスタイルをチェック
- [ ] 認証ボタンが正しく表示されることを確認
- [ ] 認証ボタンをクリックして認証ガイダンスが表示されることを確認
- [ ] 自動ポップアップが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)