### PR TITLE
セッション作成時の500エラーで認証エラーを検出しチャットボタンを認証ボタンに差し替え

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -198,6 +198,24 @@ export default function AgentAPIChat() {
   useEffect(() => {
     pushNotificationManager.initialize().catch(console.error);
   }, []);
+
+  // Listen for authentication required events
+  useEffect(() => {
+    const handleAuthRequired = (event: CustomEvent) => {
+      console.log('Authentication required event received:', event.detail);
+      setAuthRequired(true);
+      setShowAuthGuidance(true);
+      if (event.detail.message) {
+        setError(event.detail.message);
+      }
+    };
+
+    window.addEventListener('authenticationRequired', handleAuthRequired as EventListener);
+    
+    return () => {
+      window.removeEventListener('authenticationRequired', handleAuthRequired as EventListener);
+    };
+  }, []);
   
   // Initialize chat when agentAPI is ready - optimized for faster loading
   useEffect(() => {
@@ -284,6 +302,7 @@ export default function AgentAPIChat() {
   const [showClaudeLogins, setShowClaudeLogins] = useState(false);
   const [claudeLoginUrls, setClaudeLoginUrls] = useState<string[]>([]);
   const [showAuthGuidance, setShowAuthGuidance] = useState(false);
+  const [authRequired, setAuthRequired] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const prevMessagesLengthRef = useRef(0);
@@ -1051,14 +1070,28 @@ export default function AgentAPIChat() {
                   </svg>
                 </button>
                 
-                <button
-                  onClick={() => sendMessage()}
-                  disabled={!isConnected || isLoading || !inputValue.trim() || agentStatus?.status === 'running'}
-                  aria-label="Send"
-                  className="px-3 sm:px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed text-sm font-medium"
-                >
-                  {isLoading ? 'Sending...' : 'Comment'}
-                </button>
+                {authRequired ? (
+                  <button
+                    onClick={() => {
+                      setShowAuthGuidance(true);
+                      // 認証後にチャット画面に遷移
+                      router.push('/chat');
+                    }}
+                    className="px-3 sm:px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 text-sm font-medium"
+                    title="認証を開始してチャットに進む"
+                  >
+                    認証
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => sendMessage()}
+                    disabled={!isConnected || isLoading || !inputValue.trim() || agentStatus?.status === 'running'}
+                    aria-label="Send"
+                    className="px-3 sm:px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed text-sm font-medium"
+                  >
+                    {isLoading ? 'Sending...' : 'Comment'}
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/src/app/components/NewSessionModal.tsx
+++ b/src/app/components/NewSessionModal.tsx
@@ -273,6 +273,27 @@ export default function NewSessionModal({
         onSuccess()
       } catch (messageErr) {
         console.error('Failed to send initial message:', messageErr)
+        
+        // 500エラーの場合、認証エラーとして処理
+        if (messageErr instanceof Error && messageErr.message.includes('500')) {
+          console.log('500 error detected during message sending - likely authentication required')
+          // 認証が必要な場合は、セッションを削除して認証を促す
+          try {
+            await client.delete(session.session_id)
+            console.log('Session deleted due to authentication error')
+          } catch (deleteErr) {
+            console.warn('Failed to delete session after auth error:', deleteErr)
+          }
+          
+          // 認証エラーを表示
+          window.dispatchEvent(new CustomEvent('authenticationRequired', {
+            detail: {
+              message: '認証が必要です。チャットボタンが認証ボタンに変わります。',
+              showAuthButton: true
+            }
+          }))
+        }
+        
         onSessionStatusUpdate(sessionId, 'failed')
         onSessionCompleted(sessionId)
       }


### PR DESCRIPTION
## 概要

セッション作成時にメッセージをPOSTして500エラーが発生した場合、認証エラーとして処理し、チャットボタンを認証ボタンに差し替える機能を実装しました。

## 実装内容

### 1. 認証エラーの検出と処理 (NewSessionModal.tsx)

- メッセージ送信時の500エラーを認証エラーとして検出
- 認証が必要な場合は作成済みセッションを削除
- `authenticationRequired`カスタムイベントを発行してUI側に通知

### 2. チャットボタンの認証ボタン差し替え (AgentAPIChat.tsx)

- 認証エラーイベントリスナーを追加
- 認証が必要な場合は`authRequired`状態を`true`に設定
- チャットボタンを「認証」ボタンに差し替え表示
- 認証ボタンクリック時に認証ガイダンスを表示し、通常のチャット画面へ遷移

## 技術的な詳細

- 500エラーの検出: `messageErr instanceof Error && messageErr.message.includes('500')`
- セッション削除: `client.delete(session.session_id)`
- イベント通信: `window.dispatchEvent(new CustomEvent('authenticationRequired'))`
- 条件分岐レンダリング: `{authRequired ? 認証ボタン : チャットボタン}`

## テスト

- lint: 通過
- TypeScript型チェック: 通過

🤖 Generated with [Claude Code](https://claude.ai/code)