### PR TITLE
WITH_API_MOCK 環境変数でモックレスポンス機能を実装

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -394,6 +394,33 @@ async function handleMockRequest(
       }
       break;
       
+    case 'search':
+      if (method === 'GET' || method === 'POST') {
+        return NextResponse.json({
+          results: [
+            {
+              id: 'search_1',
+              title: 'How to implement authentication in Next.js',
+              snippet: 'Authentication in Next.js can be implemented using NextAuth.js or custom JWT tokens...',
+              url: 'https://example.com/auth-nextjs',
+              relevance: 0.95,
+              timestamp: new Date().toISOString()
+            },
+            {
+              id: 'search_2',
+              title: 'Best practices for React state management',
+              snippet: 'State management in React has evolved significantly. Modern approaches include Context API, Zustand, and Redux Toolkit...',
+              url: 'https://example.com/react-state',
+              relevance: 0.87,
+              timestamp: new Date().toISOString()
+            }
+          ],
+          total: 2,
+          query: request.nextUrl.searchParams.get('q') || 'mock query'
+        });
+      }
+      break;
+      
     default:
       // For any other endpoint, return a generic success response
       return NextResponse.json({ 


### PR DESCRIPTION
## Summary

WITH_API_MOCK 環境変数が設定されている場合に、/api/proxy 以下でモックレスポンスを返すように実装しました。プレビュー環境でバックエンドAPIなしでUIの動作確認ができます。

### 実装内容
- `WITH_API_MOCK=true` 環境変数の条件分岐処理
- 主要なエンドポイントのモック実装:
  - `GET /status`: エージェントステータス (`stable`) を返す
  - `GET /messages`: サンプルメッセージ履歴を返す
  - `POST /message`: メッセージ送信のモックレスポンス
  - `GET /events`: Server-Sent Events のモックストリーム（リアルタイム通信をシミュレート）
- その他のエンドポイントに対してはジェネリックなモックレスポンスを返す

### 使用方法
環境変数 `WITH_API_MOCK=true` を設定してアプリケーションを起動するだけで、モックAPIが有効になります。

## Test plan
- [x] TypeScript型チェック通過
- [x] ビルド成功確認
- [x] リント警告のみ（既存の問題で今回の実装に関係なし）
- [ ] プレビュー環境でのモック動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)