### PR TITLE
feat: Amazon Bedrock プロバイダー設定機能の追加

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -189,6 +189,36 @@ async function handleProxyRequest(
       });
     }
     
+    // Add Bedrock settings as environment variables if available
+    if (decryptedConfig.bedrockSettings) {
+      const bedrockConfig = decryptedConfig.bedrockSettings as Record<string, unknown>;
+      
+      // Only add environment variables if Bedrock is enabled
+      if (bedrockConfig.enabled) {
+        headers.set('X-Env-CLAUDE_CODE_USE_BEDROCK', '1');
+        
+        // Add AWS credentials if configured
+        if (bedrockConfig.awsAccessKeyId) {
+          headers.set('X-Env-AWS_ACCESS_KEY_ID', String(bedrockConfig.awsAccessKeyId));
+        }
+        if (bedrockConfig.awsSecretAccessKey) {
+          headers.set('X-Env-AWS_SECRET_ACCESS_KEY', String(bedrockConfig.awsSecretAccessKey));
+        }
+        if (bedrockConfig.awsSessionToken) {
+          headers.set('X-Env-AWS_SESSION_TOKEN', String(bedrockConfig.awsSessionToken));
+        }
+        if (bedrockConfig.region) {
+          headers.set('X-Env-AWS_REGION', String(bedrockConfig.region));
+        }
+        if (bedrockConfig.modelName) {
+          headers.set('X-Env-ANTHROPIC_MODEL', String(bedrockConfig.modelName));
+        }
+        if (bedrockConfig.endpointUrl) {
+          headers.set('X-Env-AWS_ENDPOINT_URL', String(bedrockConfig.endpointUrl));
+        }
+      }
+    }
+    
     // Add MCP servers configuration if available
     if (decryptedConfig.mcpServers) {
       headers.set('X-MCP-Servers', JSON.stringify(decryptedConfig.mcpServers));

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { SettingsFormData, getDefaultSettings, isSingleProfileModeEnabled } from '../../types/settings'
 import type { EnvironmentVariable } from '../../types/settings'
 import MCPServerSettings from '../../components/MCPServerSettings'
+import BedrockSettingsComponent from '../../components/BedrockSettings'
 
 export default function GlobalSettingsPage() {
   const [settings, setSettings] = useState<SettingsFormData>(getDefaultSettings())
@@ -86,6 +87,13 @@ export default function GlobalSettingsPage() {
         }))
       }
       
+      if (decryptedJson.bedrockSettings) {
+        setSettings(prev => ({
+          ...prev,
+          bedrockSettings: decryptedJson.bedrockSettings
+        }))
+      }
+      
       setDecryptError(null)
     } catch (err) {
       console.error('Failed to decrypt settings:', err)
@@ -112,6 +120,7 @@ export default function GlobalSettingsPage() {
           const settingsData = {
             baseUrl: `${window.location.protocol}//${window.location.host}/api/proxy`,
             mcpServers: settings.mcpServers,
+            bedrockSettings: settings.bedrockSettings,
             environmentVariables: settings.environmentVariables.reduce((acc, env) => {
               if (env.key) acc[env.key] = env.value
               return acc
@@ -299,6 +308,16 @@ export default function GlobalSettingsPage() {
               </button>
             </div>
           )}
+
+          {/* Amazon Bedrock Settings */}
+          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+            <BedrockSettingsComponent
+              settings={settings.bedrockSettings || { enabled: false }}
+              onChange={(bedrockSettings) => setSettings(prev => ({ ...prev, bedrockSettings }))}
+              title="Amazon Bedrock Settings"
+              description="Configure Amazon Bedrock provider settings for Claude API access. These settings are encrypted and stored securely."
+            />
+          </div>
 
           {/* MCP Servers Section */}
           <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">

--- a/src/components/BedrockSettings.tsx
+++ b/src/components/BedrockSettings.tsx
@@ -1,0 +1,224 @@
+'use client'
+
+import React, { useState } from 'react'
+import { BedrockSettings as BedrockSettingsType } from '../types/settings'
+
+interface BedrockSettingsProps {
+  settings: BedrockSettingsType
+  onChange: (settings: BedrockSettingsType) => void
+  title?: string
+  description?: string
+}
+
+const AWS_REGIONS = [
+  { value: 'us-east-1', label: 'US East (N. Virginia)' },
+  { value: 'us-west-2', label: 'US West (Oregon)' },
+  { value: 'eu-west-1', label: 'Europe (Ireland)' },
+  { value: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
+  { value: 'ap-southeast-1', label: 'Asia Pacific (Singapore)' },
+  { value: 'ap-southeast-2', label: 'Asia Pacific (Sydney)' }
+]
+
+const BEDROCK_MODELS = [
+  { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet' },
+  { value: 'claude-3-opus-20240229', label: 'Claude 3 Opus' },
+  { value: 'claude-3-haiku-20240307', label: 'Claude 3 Haiku' },
+  { value: 'claude-3-sonnet-20240229', label: 'Claude 3 Sonnet' }
+]
+
+export default function BedrockSettings({ 
+  settings, 
+  onChange, 
+  title = "Amazon Bedrock Settings",
+  description = "Configure Amazon Bedrock provider settings for Claude API access"
+}: BedrockSettingsProps) {
+  const [showAdvanced, setShowAdvanced] = useState(false)
+
+  const handleChange = (field: keyof BedrockSettingsType, value: string | boolean | number) => {
+    onChange({
+      ...settings,
+      [field]: value
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-medium text-gray-900 dark:text-white">{title}</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{description}</p>
+      </div>
+
+      {/* Enable/Disable Toggle */}
+      <div className="flex items-center space-x-3">
+        <input
+          type="checkbox"
+          id="bedrock-enabled"
+          checked={settings.enabled}
+          onChange={(e) => handleChange('enabled', e.target.checked)}
+          className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+        />
+        <label htmlFor="bedrock-enabled" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Enable Amazon Bedrock
+        </label>
+      </div>
+
+      {/* Settings Form - only show when enabled */}
+      {settings.enabled && (
+        <div className="space-y-4 p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800">
+          
+          {/* AWS Credentials */}
+          <div className="space-y-4">
+            <h4 className="text-md font-medium text-gray-900 dark:text-white">AWS Credentials</h4>
+            
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  AWS Access Key ID
+                </label>
+                <input
+                  type="text"
+                  value={settings.awsAccessKeyId || ''}
+                  onChange={(e) => handleChange('awsAccessKeyId', e.target.value)}
+                  placeholder="AKIAIOSFODNN7EXAMPLE"
+                  className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                />
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  AWS Secret Access Key
+                </label>
+                <input
+                  type="password"
+                  value={settings.awsSecretAccessKey || ''}
+                  onChange={(e) => handleChange('awsSecretAccessKey', e.target.value)}
+                  placeholder="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                  className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                />
+              </div>
+            </div>
+
+            {/* Session Token - Optional */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                AWS Session Token (optional)
+              </label>
+              <input
+                type="text"
+                value={settings.awsSessionToken || ''}
+                onChange={(e) => handleChange('awsSessionToken', e.target.value)}
+                placeholder="For temporary credentials or STS"
+                className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+          </div>
+
+          {/* AWS Region and Model */}
+          <div className="space-y-4">
+            <h4 className="text-md font-medium text-gray-900 dark:text-white">Configuration</h4>
+            
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  AWS Region
+                </label>
+                <select
+                  value={settings.region || ''}
+                  onChange={(e) => handleChange('region', e.target.value)}
+                  className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                >
+                  <option value="">Select a region</option>
+                  {AWS_REGIONS.map((region) => (
+                    <option key={region.value} value={region.value}>
+                      {region.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Model Name
+                </label>
+                <select
+                  value={settings.modelName || ''}
+                  onChange={(e) => handleChange('modelName', e.target.value)}
+                  className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                >
+                  <option value="">Select a model</option>
+                  {BEDROCK_MODELS.map((model) => (
+                    <option key={model.value} value={model.value}>
+                      {model.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          {/* Advanced Settings */}
+          <div className="space-y-4">
+            <button
+              type="button"
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="flex items-center space-x-2 text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              <span>{showAdvanced ? '▼' : '▶'}</span>
+              <span>Advanced Settings</span>
+            </button>
+
+            {showAdvanced && (
+              <div className="space-y-4 p-4 border border-gray-200 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Custom Endpoint URL (optional)
+                  </label>
+                  <input
+                    type="url"
+                    value={settings.endpointUrl || ''}
+                    onChange={(e) => handleChange('endpointUrl', e.target.value)}
+                    placeholder="https://bedrock-runtime.us-east-1.amazonaws.com"
+                    className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Timeout (ms)
+                  </label>
+                  <input
+                    type="number"
+                    value={settings.timeout || 30000}
+                    onChange={(e) => handleChange('timeout', parseInt(e.target.value) || 30000)}
+                    min="1000"
+                    step="1000"
+                    className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Information Banner */}
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+            <div className="flex items-start space-x-3">
+              <div className="flex-shrink-0">
+                <svg className="h-5 w-5 text-blue-600 dark:text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="text-sm">
+                <p className="text-blue-800 dark:text-blue-200 font-medium">
+                  Environment Variables
+                </p>
+                <p className="text-blue-600 dark:text-blue-300 mt-1">
+                  When enabled, this will set <code className="bg-blue-100 dark:bg-blue-800 px-1 rounded">CLAUDE_CODE_USE_BEDROCK=1</code> and configure AWS credentials as environment variables.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/BedrockSettings.tsx
+++ b/src/components/BedrockSettings.tsx
@@ -10,21 +10,6 @@ interface BedrockSettingsProps {
   description?: string
 }
 
-const AWS_REGIONS = [
-  { value: 'us-east-1', label: 'US East (N. Virginia)' },
-  { value: 'us-west-2', label: 'US West (Oregon)' },
-  { value: 'eu-west-1', label: 'Europe (Ireland)' },
-  { value: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
-  { value: 'ap-southeast-1', label: 'Asia Pacific (Singapore)' },
-  { value: 'ap-southeast-2', label: 'Asia Pacific (Sydney)' }
-]
-
-const BEDROCK_MODELS = [
-  { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet' },
-  { value: 'claude-3-opus-20240229', label: 'Claude 3 Opus' },
-  { value: 'claude-3-haiku-20240307', label: 'Claude 3 Haiku' },
-  { value: 'claude-3-sonnet-20240229', label: 'Claude 3 Sonnet' }
-]
 
 export default function BedrockSettings({ 
   settings, 
@@ -122,36 +107,29 @@ export default function BedrockSettings({
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   AWS Region
                 </label>
-                <select
+                <input
+                  type="text"
                   value={settings.region || ''}
                   onChange={(e) => handleChange('region', e.target.value)}
+                  placeholder="us-east-1"
                   className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-                >
-                  <option value="">Select a region</option>
-                  {AWS_REGIONS.map((region) => (
-                    <option key={region.value} value={region.value}>
-                      {region.label}
-                    </option>
-                  ))}
-                </select>
+                />
               </div>
               
               <div>
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   Model Name
                 </label>
-                <select
+                <input
+                  type="text"
                   value={settings.modelName || ''}
                   onChange={(e) => handleChange('modelName', e.target.value)}
+                  placeholder="claude-3-5-sonnet-20241022"
                   className="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-                >
-                  <option value="">Select a model</option>
-                  {BEDROCK_MODELS.map((model) => (
-                    <option key={model.value} value={model.value}>
-                      {model.label}
-                    </option>
-                  ))}
-                </select>
+                />
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  モデル名または推論プロファイルのARNを入力してください
+                </p>
               </div>
             </div>
           </div>

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -24,6 +24,7 @@ export interface RepositorySettings {
 export interface GlobalSettings {
   environmentVariables: EnvironmentVariable[]
   mcpServers: MCPServerConfig[]
+  bedrockSettings?: BedrockSettings
   singleProfileMode: boolean
   created_at: string
   updated_at: string
@@ -32,6 +33,7 @@ export interface GlobalSettings {
 export interface SettingsFormData {
   environmentVariables: EnvironmentVariable[]
   mcpServers: MCPServerConfig[]
+  bedrockSettings?: BedrockSettings
 }
 
 // Single Profile Mode settings
@@ -51,10 +53,24 @@ export interface GitHubOAuthSettings {
   updated_at: string
 }
 
+export interface BedrockSettings {
+  enabled: boolean
+  awsAccessKeyId?: string
+  awsSecretAccessKey?: string
+  awsSessionToken?: string
+  region?: string
+  modelName?: string
+  endpointUrl?: string
+  timeout?: number
+}
+
 // Default settings
 export const getDefaultSettings = (): SettingsFormData => ({
   environmentVariables: [],
-  mcpServers: []
+  mcpServers: [],
+  bedrockSettings: {
+    enabled: false
+  }
 })
 
 // Default Single Profile Mode settings
@@ -313,7 +329,8 @@ const mergeWithDefaults = (partialSettings: Partial<SettingsFormData> | null | u
       : defaultSettings.environmentVariables,
     mcpServers: Array.isArray(partialSettings?.mcpServers)
       ? partialSettings.mcpServers
-      : defaultSettings.mcpServers
+      : defaultSettings.mcpServers,
+    bedrockSettings: partialSettings?.bedrockSettings || defaultSettings.bedrockSettings
   }
 }
 
@@ -331,7 +348,8 @@ const mergeSettings = (globalSettings: SettingsFormData, repoSettings: SettingsF
       ...(repoSettings.mcpServers || []).filter(repoServer => 
         !(globalSettings.mcpServers || []).some(globalServer => globalServer.id === repoServer.id)
       )
-    ]
+    ],
+    bedrockSettings: repoSettings.bedrockSettings || globalSettings.bedrockSettings
   }
 }
 


### PR DESCRIPTION
## Summary

- BedrockSettings型定義を追加（全設定項目をオプショナルに）
- BedrockSettings UIコンポーネントを実装
- グローバル設定ページにBedrock設定を統合
- 環境変数マッピングを実装（CLAUDE_CODE_USE_BEDROCK=1, AWS認証情報, ANTHROPIC_MODEL等）

## 実装内容

### 1. 型定義の追加
- `BedrockSettings`インターフェースを`src/types/settings.ts`に追加
- 有効/無効フラグ以外のすべての設定項目をオプショナルに設定

### 2. UIコンポーネントの実装
- `src/components/BedrockSettings.tsx`を作成
- AWS認証情報、リージョン、モデル選択のフォーム
- 高度な設定（エンドポイントURL、タイムアウト）
- 条件付き表示（有効化時のみ設定フォームを表示）

### 3. グローバル設定への統合
- `src/app/settings/page.tsx`にBedrock設定を追加
- 暗号化された設定の保存・読み込み処理を更新

### 4. 環境変数マッピング
- `src/app/api/proxy/[...path]/route.ts`でBedrock設定を処理
- 有効時のみ環境変数を設定：
  - `CLAUDE_CODE_USE_BEDROCK=1`
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`
  - `AWS_SESSION_TOKEN`
  - `AWS_REGION`
  - `ANTHROPIC_MODEL`
  - `AWS_ENDPOINT_URL`

## 仕様
- 設定項目は有効無効のフラグを除きすべてオプショナル
- 設定された項目のみが環境変数を上書き
- 無効フラグがたったときはなにも送信しない
- 有効フラグが立ったときは`CLAUDE_CODE_USE_BEDROCK=1`の環境変数を送信
- `modelName`は`ANTHROPIC_MODEL`環境変数とマッピング

## Test plan
- [x] ビルドが成功することを確認
- [x] リントが通ることを確認
- [x] TypeScriptの型チェックが通ることを確認
- [ ] 設定画面でBedrock設定が表示されることを確認
- [ ] 設定の保存・読み込みが正常に動作することを確認
- [ ] 環境変数が正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)