### PR TITLE
remove: MCP config送信機能の削除

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -219,10 +219,6 @@ async function handleProxyRequest(
       }
     }
     
-    // Add MCP servers configuration if available
-    if (decryptedConfig.mcpServers) {
-      headers.set('X-MCP-Servers', JSON.stringify(decryptedConfig.mcpServers));
-    }
     
     // Add base URL override if available
     if (decryptedConfig.baseUrl) {


### PR DESCRIPTION
## Summary

- セッション開始時のMCP設定送信コードを削除
- プロキシAPI経由のMCP設定送信コードを削除  
- 未使用のcollectMCPConfigurations関数を削除
- 未使用のMCPServerConfig型定義を削除

## Test plan

- [x] lintエラーの解消を確認
- [x] ビルドが成功することを確認
- [x] 関連するTypeScriptエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)