### PR TITLE
feat: プッシュ通知をユーザーごとに分けて送信する機能を実装

### DIFF
--- a/src/app/api/send-notification/route.ts
+++ b/src/app/api/send-notification/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import webpush from 'web-push';
-import { getSubscriptions } from '../../../lib/subscriptions';
+import { getSubscriptions, getSubscriptionsByUserId, getUserSubscriptions } from '../../../lib/subscriptions';
+import { decryptCookie } from '@/lib/cookie-encryption';
 
 // 環境変数からVAPIDキーを取得（必須）
 const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
@@ -25,6 +26,59 @@ interface NotificationPayload {
   icon?: string;
   badge?: string;
   tag?: string;
+  targetUserId?: string; // 特定のユーザーに送信する場合
+  targetUserType?: 'github' | 'api_key'; // 特定の認証タイプのユーザーに送信する場合
+  senderInfo?: {
+    userId?: string;
+    userName?: string;
+    userType?: 'github' | 'api_key';
+  };
+}
+
+async function getSenderInfo(request: NextRequest): Promise<{ userId?: string; userName?: string; userType?: 'github' | 'api_key' }> {
+  const authToken = request.cookies.get('agentapi_token')?.value;
+  
+  if (!authToken) {
+    return {};
+  }
+
+  try {
+    const decryptedData = decryptCookie(authToken);
+    const sessionData = JSON.parse(decryptedData);
+
+    // GitHub OAuth認証の場合
+    if (sessionData.sessionId && sessionData.accessToken) {
+      try {
+        const response = await fetch('https://api.github.com/user', {
+          headers: {
+            'Authorization': `token ${sessionData.accessToken}`,
+            'User-Agent': 'agentapi-ui'
+          }
+        });
+
+        if (response.ok) {
+          const githubUser = await response.json();
+          return {
+            userId: githubUser.id.toString(),
+            userName: githubUser.login,
+            userType: 'github'
+          };
+        }
+      } catch (error) {
+        console.error('Failed to fetch GitHub user info:', error);
+      }
+    }
+  } catch (error) {
+    console.log('Using API key authentication:', error);
+  }
+
+  // APIキー認証の場合
+  const sessionId = authToken.substring(0, 16);
+  return {
+    userId: sessionId,
+    userName: 'API User',
+    userType: 'api_key'
+  };
 }
 
 export async function POST(request: NextRequest) {
@@ -37,7 +91,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { title, body, url, icon, badge, tag }: NotificationPayload = await request.json();
+    const { title, body, url, icon, badge, tag, targetUserId, targetUserType, senderInfo }: NotificationPayload = await request.json();
 
     if (!title || !body) {
       return NextResponse.json(
@@ -46,7 +100,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const subscriptions = getSubscriptions();
+    // 送信者情報を取得
+    const actualSenderInfo = senderInfo || await getSenderInfo(request);
+
+    // 送信対象のサブスクリプションを決定
+    let subscriptions;
+    if (targetUserId) {
+      // 特定のユーザーに送信
+      subscriptions = getSubscriptionsByUserId(targetUserId);
+    } else if (targetUserType) {
+      // 特定の認証タイプのユーザーに送信
+      subscriptions = getUserSubscriptions(targetUserType);
+    } else {
+      // 全ユーザーに送信
+      subscriptions = getSubscriptions();
+    }
     
     if (subscriptions.length === 0) {
       return NextResponse.json(
@@ -61,7 +129,13 @@ export async function POST(request: NextRequest) {
       url: url || '/',
       icon: icon || '/icon-192x192.png',
       badge: badge || '/icon-192x192.png',
-      tag: tag || 'agentapi-notification'
+      tag: tag || 'agentapi-notification',
+      data: {
+        sender: actualSenderInfo,
+        timestamp: new Date().toISOString(),
+        targetUserId,
+        targetUserType
+      }
     });
 
     const results = await Promise.allSettled(
@@ -87,14 +161,24 @@ export async function POST(request: NextRequest) {
 
     const failed = results.length - successful;
 
-    console.log(`通知送信結果: 成功=${successful}, 失敗=${failed}`);
+    console.log(`通知送信結果: 成功=${successful}, 失敗=${failed}`, {
+      targetUserId,
+      targetUserType,
+      senderUserId: actualSenderInfo.userId,
+      senderUserType: actualSenderInfo.userType
+    });
 
     return NextResponse.json({
       success: true,
       message: `${successful}件の通知を送信しました`,
       sent: successful,
       failed: failed,
-      total: subscriptions.length
+      total: subscriptions.length,
+      target: {
+        userId: targetUserId,
+        userType: targetUserType
+      },
+      sender: actualSenderInfo
     });
 
   } catch (error) {

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,5 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSubscriptions, addSubscription, removeSubscription } from '../../../lib/subscriptions';
+import { decryptCookie } from '@/lib/cookie-encryption';
+
+interface SubscriptionRequest {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+  userId?: string;
+  userType?: 'github' | 'api_key';
+  userName?: string;
+}
 
 interface SubscriptionData {
   endpoint: string;
@@ -7,27 +19,101 @@ interface SubscriptionData {
     p256dh: string;
     auth: string;
   };
+  userId?: string;
+  userType?: 'github' | 'api_key';
+  userName?: string;
+  createdAt?: Date;
+}
+
+async function getUserInfo(request: NextRequest): Promise<{ userId?: string; userType?: 'github' | 'api_key'; userName?: string }> {
+  const authToken = request.cookies.get('agentapi_token')?.value;
+  
+  if (!authToken) {
+    return {};
+  }
+
+  try {
+    const decryptedData = decryptCookie(authToken);
+    const sessionData = JSON.parse(decryptedData);
+
+    // GitHub OAuth認証の場合
+    if (sessionData.sessionId && sessionData.accessToken) {
+      try {
+        const response = await fetch('https://api.github.com/user', {
+          headers: {
+            'Authorization': `token ${sessionData.accessToken}`,
+            'User-Agent': 'agentapi-ui'
+          }
+        });
+
+        if (response.ok) {
+          const githubUser = await response.json();
+          return {
+            userId: githubUser.id.toString(),
+            userType: 'github',
+            userName: githubUser.login
+          };
+        }
+      } catch (error) {
+        console.error('Failed to fetch GitHub user info:', error);
+      }
+    }
+  } catch (error) {
+    // デクリプションに失敗した場合はAPIキー認証とみなす
+    console.log('Using API key authentication:', error);
+  }
+
+  // APIキー認証の場合は一意のセッションIDを生成
+  const sessionId = authToken.substring(0, 16); // トークンの一部を使用
+  return {
+    userId: sessionId,
+    userType: 'api_key',
+    userName: 'API User'
+  };
 }
 
 export async function POST(request: NextRequest) {
   try {
-    const subscription: SubscriptionData = await request.json();
+    const subscriptionRequest: SubscriptionRequest = await request.json();
 
-    if (!subscription || !subscription.endpoint || !subscription.keys) {
+    if (!subscriptionRequest || !subscriptionRequest.endpoint || !subscriptionRequest.keys) {
       return NextResponse.json(
         { error: '無効なサブスクリプションデータです' },
         { status: 400 }
       );
     }
 
+    // ユーザー情報を取得
+    const userInfo = await getUserInfo(request);
+    
+    // サブスクリプションデータを構築
+    const subscription: SubscriptionData = {
+      endpoint: subscriptionRequest.endpoint,
+      keys: subscriptionRequest.keys,
+      userId: subscriptionRequest.userId || userInfo.userId,
+      userType: subscriptionRequest.userType || userInfo.userType,
+      userName: subscriptionRequest.userName || userInfo.userName,
+      createdAt: new Date()
+    };
+
     addSubscription(subscription);
-    console.log('サブスクリプションが保存されました:', subscription.endpoint);
+    console.log('サブスクリプションが保存されました:', {
+      endpoint: subscription.endpoint.substring(0, 50) + '...',
+      userId: subscription.userId,
+      userType: subscription.userType,
+      userName: subscription.userName
+    });
 
     const allSubscriptions = getSubscriptions();
     return NextResponse.json({ 
       success: true, 
       message: 'サブスクリプションが正常に保存されました',
-      subscriptionCount: allSubscriptions.length
+      subscriptionCount: allSubscriptions.length,
+      userInfo: {
+        userId: subscription.userId,
+        userType: subscription.userType,
+        userName: subscription.userName
+      }
     });
 
   } catch (error) {
@@ -45,7 +131,11 @@ export async function GET() {
     subscriptionCount: allSubscriptions.length,
     subscriptions: allSubscriptions.map(sub => ({
       endpoint: sub.endpoint.substring(0, 50) + '...',
-      hasKeys: !!sub.keys.p256dh && !!sub.keys.auth
+      hasKeys: !!sub.keys.p256dh && !!sub.keys.auth,
+      userId: sub.userId,
+      userType: sub.userType,
+      userName: sub.userName,
+      createdAt: sub.createdAt
     }))
   });
 }

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -4,6 +4,10 @@ interface SubscriptionData {
     p256dh: string;
     auth: string;
   };
+  userId?: string; // ユーザー識別子（GitHubユーザーIDまたはセッションID）
+  userType?: 'github' | 'api_key'; // 認証タイプ
+  userName?: string; // ユーザー名（表示用）
+  createdAt?: Date; // サブスクリプション作成日時
 }
 
 // サーバーレス環境対応: メモリベースの保存
@@ -24,6 +28,18 @@ function saveSubscriptions(subscriptions: SubscriptionData[]): void {
 
 export function getSubscriptions(): SubscriptionData[] {
   return loadSubscriptions();
+}
+
+export function getSubscriptionsByUserId(userId: string): SubscriptionData[] {
+  return loadSubscriptions().filter(sub => sub.userId === userId);
+}
+
+export function getUserSubscriptions(userType?: 'github' | 'api_key'): SubscriptionData[] {
+  const subscriptions = loadSubscriptions();
+  if (userType) {
+    return subscriptions.filter(sub => sub.userType === userType);
+  }
+  return subscriptions;
 }
 
 export function addSubscription(subscription: SubscriptionData): void {

--- a/src/utils/pushNotification.ts
+++ b/src/utils/pushNotification.ts
@@ -101,17 +101,30 @@ export class PushNotificationManager {
   }
 
   async sendSubscriptionToServer(subscription: PushSubscription): Promise<void> {
+    // ユーザー情報を含めたサブスクリプションデータを送信
+    const subscriptionData = {
+      ...subscription.toJSON(),
+      // ユーザー情報はサーバー側で自動取得されるため、クライアントからは送信しない
+      // 必要に応じて明示的に送信したい場合は以下を有効化
+      // userId: 'user-id',
+      // userType: 'github' | 'api_key',
+      // userName: 'user-name'
+    };
+
     const response = await fetch('/api/subscribe', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(subscription.toJSON()),
+      body: JSON.stringify(subscriptionData),
     });
 
     if (!response.ok) {
       throw new Error('サブスクリプション送信に失敗しました');
     }
+
+    const result = await response.json();
+    console.log('サブスクリプション送信結果:', result);
 
     // 成功時に設定を更新
     pushNotificationSettings.setEndpoint(subscription.endpoint);
@@ -137,12 +150,21 @@ export class PushNotificationManager {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ title, body }),
+      body: JSON.stringify({ 
+        title, 
+        body,
+        // 自分自身にのみテスト通知を送信する場合は以下を有効化
+        // targetUserId: 'current-user-id',
+        // targetUserType: 'github' | 'api_key'
+      }),
     });
 
     if (!response.ok) {
       throw new Error('テスト通知送信に失敗しました');
     }
+
+    const result = await response.json();
+    console.log('テスト通知送信結果:', result);
   }
 
   getSubscriptionStatus(): { isSubscribed: boolean; endpoint?: string } {


### PR DESCRIPTION
## 概要

プッシュ通知の送信先をユーザーごとに分けられる機能を実装しました。これにより、特定のユーザーや認証タイプに対象を絞った通知の送信が可能になります。

## 主な変更点

- **サブスクリプションスキーマの拡張**
  - `userId`: ユーザー識別子（GitHubユーザーIDまたはセッションID）
  - `userType`: 認証タイプ（`github`  < /dev/null |  `api_key`）
  - `userName`: ユーザー名（表示用）
  - `createdAt`: サブスクリプション作成日時

- **自動ユーザー識別**
  - GitHub OAuth認証時：GitHubユーザーAPIから取得
  - APIキー認証時：認証トークンから一意のセッションIDを生成

- **送信対象の指定機能**
  - `targetUserId`: 特定ユーザーに送信
  - `targetUserType`: 特定の認証タイプのユーザーに送信
  - 未指定の場合は従来通り全ユーザーに送信

- **ペイロードの拡張**
  - 送信者情報（`sender`）をペイロードに含める
  - タイムスタンプと対象情報を追加

## 互換性

- 既存のブロードキャスト機能は維持
- 既存のフロントエンド実装に変更不要
- 新機能はオプション扱いで段階的に活用可能

## テストプラン

- [x] TypeScriptコンパイル
- [x] ESLint（警告レベル）
- [x] ビルド成功
- [ ] 実際のプッシュ通知送信テスト
- [ ] 複数ユーザー環境でのユーザー分離テスト

🤖 Generated with [Claude Code](https://claude.ai/code)