### PR TITLE
feat: テキストエリア入力時に自動的にエージェントを停止

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -1019,6 +1019,12 @@ export default function AgentAPIChat() {
               onBlur={() => {
                 setTimeout(() => setShowTemplates(false), 150);
               }}
+              onInput={(e) => {
+                // エージェントが実行中で、テキストエリアに文字が入力されたらESCを送信
+                if (agentStatus?.status === 'running' && e.currentTarget.value.trim()) {
+                  sendStopSignal();
+                }
+              }}
               placeholder={
                 !isConnected 
                   ? "Connecting..." 


### PR DESCRIPTION
## Summary
- エージェント実行中にテキストエリアに文字が入力されたら、自動的にraw ESCキーを送信してエージェントを停止する機能を追加

## 変更内容
- `AgentAPIChat.tsx`の`<textarea>`要素に`onInput`イベントハンドラを追加
- エージェントが`running`状態で、かつテキストエリアに文字が入力された場合に`sendStopSignal()`を呼び出し
- これにより、ユーザーが新しいコマンドを入力したいときに自動的にエージェントが停止される

## Test plan
- [ ] エージェント実行中にテキストエリアに文字を入力すると、自動的にエージェントが停止することを確認
- [ ] エージェントが`stable`状態の場合は、テキスト入力してもESCが送信されないことを確認
- [ ] 通常のメッセージ送信機能が影響を受けていないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)