### PR TITLE
feat: agentapi_tokenクッキーの有効期限を1ヶ月に設定

### DIFF
--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
     const headers = new Headers()
     headers.append(
       'Set-Cookie',
-      `agentapi_token=${encryptedApiKey}; HttpOnly; Secure; SameSite=strict; Path=/; Max-Age=86400`
+      `agentapi_token=${encryptedApiKey}; HttpOnly; Secure; SameSite=strict; Path=/; Max-Age=2592000`
     )
     
     // oauth_state Cookieを削除


### PR DESCRIPTION
## Summary
- GitHub OAuth callbackで設定されるagentapi_tokenクッキーの有効期限を1日から30日に延長
- cookie-auth.tsの他の関数と同じ30日間の有効期限に統一

## 変更内容
- `src/app/api/auth/github/callback/route.ts`: Max-Ageを86400（1日）から2592000（30日）に変更

## Test plan
- [ ] GitHub OAuthでログイン後、ブラウザの開発者ツールでagentapi_tokenクッキーの有効期限が30日後になっていることを確認
- [ ] 既存の認証フローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)