### PR TITLE
fix: GitHub OAuth ユーザーでチームが表示されない問題を修正

### DIFF
--- a/src/app/api/user/info/route.ts
+++ b/src/app/api/user/info/route.ts
@@ -27,6 +27,23 @@ export async function GET(request: NextRequest) {
           debug: true,
         })
         proxyUserInfo = await client.getUserInfo()
+      } else {
+        // GitHub OAuth ユーザーの場合、セッション cookie から GitHub アクセストークンを取り出して
+        // プロキシの認証に使用する
+        try {
+          const decryptedData = decryptCookie(authToken)
+          const sessionData = JSON.parse(decryptedData)
+          if (sessionData.accessToken) {
+            const client = new AgentAPIProxyClient({
+              baseURL: process.env.AGENTAPI_PROXY_URL || 'http://localhost:8080',
+              apiKey: sessionData.accessToken,
+              debug: true,
+            })
+            proxyUserInfo = await client.getUserInfo()
+          }
+        } catch {
+          // GitHub OAuth セッションデータのデコードに失敗した場合は無視
+        }
       }
     } catch (err) {
       console.error('Failed to get user info from agentapi-proxy:', err)


### PR DESCRIPTION
## 問題

GitHub OAuth でログインしているユーザーで、TopBar のチーム選択ドロップダウンが表示されない。

## 原因

`src/app/api/user/info/route.ts` の Next.js API ルートで、プロキシの `/user/info` を呼ぶ際の認証処理に問題があった。

### 仕組み

- **API キー認証ユーザー**: `agentapi_token` cookie は `encryptApiKey()`（`COOKIE_ENCRYPTION_SECRET`）で暗号化されている
- **GitHub OAuth ユーザー**: `agentapi_token` cookie は `encryptCookie()`（`COOKIE_SECRET`）で暗号化されている

`getApiKeyFromCookie()` は `COOKIE_ENCRYPTION_SECRET` を使って復号するため、GitHub OAuth ユーザーの cookie を復号しようとすると**失敗して `null` を返す**。

その結果、GitHub OAuth ユーザーの場合はプロキシの `/user/info` が一切呼ばれず、`proxyUserInfo = undefined` → `userInfo.proxy?.teams` が undefined → `setAvailableTeams` が呼ばれない → チームドロップダウンが非表示になっていた。

## 修正内容

`getApiKeyFromCookie()` が null を返した場合（GitHub OAuth ユーザー）は、セッション cookie の暗号化データを `decryptCookie()` で復号して GitHub アクセストークンを取り出し、それをプロキシの Bearer トークンとして使用する。

プロキシは GitHub Bearer トークンで認証して GitHub ユーザーのチーム情報を返す（`user_type: github` のケースでは teams が正しく設定される）。

## テスト方法

- [ ] GitHub OAuth でログインし、チームに所属しているユーザーで TopBar にチーム選択ドロップダウンが表示されることを確認
- [ ] API キー認証ユーザーで引き続きチームが表示されることを確認（サービスアカウントの場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)