### PR TITLE
feat: サイクルセッション設定をセッション作成画面の詳細設定に追加

### DIFF
--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -37,6 +37,9 @@ export default function NewSessionPage() {
   const [selectedAgentType, setSelectedAgentType] = useState<AgentApiType>('default')
   const [availableManagers, setAvailableManagers] = useState<AvailableManager[]>([])
   const [selectedManagerId, setSelectedManagerId] = useState<string>('')
+  const [cycleEnabled, setCycleEnabled] = useState(false)
+  const [cycleMessage, setCycleMessage] = useState('')
+  const [cycleMaxCount, setCycleMaxCount] = useState(0)
 
   useEffect(() => {
     loadTemplates()
@@ -149,6 +152,14 @@ export default function NewSessionPage() {
       // セッションマネージャーが指定されている場合は送信
       if (managerId) {
         params.manager_id = managerId
+      }
+
+      // サイクルセッションが有効な場合はcycle_messageを送信
+      if (cycleEnabled && cycleMessage.trim()) {
+        params.cycle_message = cycleMessage.trim()
+        if (cycleMaxCount > 0) {
+          params.cycle_max_count = cycleMaxCount
+        }
       }
 
       console.log('[NewSessionPage] Final params:', params)
@@ -444,6 +455,11 @@ export default function NewSessionPage() {
                     {availableManagers.find(m => m.id === selectedManagerId)?.name ?? 'カスタム'}
                   </span>
                 )}
+                {cycleEnabled && cycleMessage.trim() && (
+                  <span className="px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-400 text-xs rounded-full">
+                    サイクル{cycleMaxCount > 0 ? ` (${cycleMaxCount}回)` : ''}
+                  </span>
+                )}
               </button>
 
               {showAdvancedSettings && (
@@ -511,6 +527,75 @@ export default function NewSessionPage() {
                       </div>
                     </div>
                   )}
+                  {/* サイクルセッション */}
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <p className="text-xs font-medium text-gray-600 dark:text-gray-400">サイクルセッション</p>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                          {cycleEnabled ? '有効' : '無効'}
+                        </span>
+                        <button
+                          type="button"
+                          role="switch"
+                          aria-checked={cycleEnabled}
+                          onClick={() => setCycleEnabled(!cycleEnabled)}
+                          disabled={isCreating}
+                          className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${
+                            cycleEnabled ? 'bg-purple-600' : 'bg-gray-300 dark:bg-gray-600'
+                          }`}
+                        >
+                          <span
+                            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                              cycleEnabled ? 'translate-x-4' : 'translate-x-0'
+                            }`}
+                          />
+                        </button>
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">
+                      Claudeが停止するたびに指定したメッセージを自動送信し、タスクを繰り返します。
+                      <code className="mx-1 px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs">/tmp/check/CYCLE_OK</code>
+                      ファイルが作成されると停止します。
+                    </p>
+                    {cycleEnabled && (
+                      <div className="space-y-3 pl-1">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                            サイクルメッセージ <span className="text-red-500">*</span>
+                          </label>
+                          <textarea
+                            value={cycleMessage}
+                            onChange={(e) => setCycleMessage(e.target.value)}
+                            placeholder="例: タスクを続けてください。完了したら /tmp/check/CYCLE_OK を作成してください。"
+                            rows={3}
+                            disabled={isCreating}
+                            className="w-full px-3 py-2 text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 dark:bg-gray-700 dark:text-white resize-y"
+                          />
+                          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                            Claudeが停止するたびに送信されるメッセージです。
+                          </p>
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                            最大サイクル数
+                          </label>
+                          <input
+                            type="number"
+                            min={0}
+                            value={cycleMaxCount}
+                            onChange={(e) => setCycleMaxCount(Math.max(0, parseInt(e.target.value) || 0))}
+                            disabled={isCreating}
+                            className="w-32 px-3 py-2 text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 dark:bg-gray-700 dark:text-white"
+                          />
+                          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                            0 の場合は無制限。<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">/tmp/check/CYCLE_COUNT</code> で進捗を確認できます。
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
                   {/* エージェントタイプ */}
                   <div>
                     <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">エージェントタイプ</p>


### PR DESCRIPTION
## Summary

agentapi-proxy [PR#698](https://github.com/takutakahashi/agentapi-proxy/pull/698) で実装されたサイクルセッション機能（`cycle_message` / `cycle_max_count`）を、セッション作成UIから有効化できるようにした。

### 変更内容

- セッション作成画面（`/sessions/new`）の「その他の設定」（高度な機能）セクションに**サイクルセッション**設定を追加
- ON/OFFトグルスイッチで有効化
- 有効時に表示されるフィールド:
  - **サイクルメッセージ** (`cycle_message`): Claudeが停止するたびに自動送信されるメッセージ
  - **最大サイクル数** (`cycle_max_count`): 0=無制限、N=N回まで
- 有効時はボタンに「サイクル (N回)」バッジを表示
- セッション作成APIの `params` に `cycle_message` / `cycle_max_count` を含めてリクエスト送信

### 動作説明

サイクルセッションを有効にすると、Claudeが停止するたびに指定したメッセージが自動送信され、タスクが繰り返されます。セッション内で `/tmp/check/CYCLE_OK` ファイルが作成されると自動停止します。

## Test plan

- [x] ビルド成功（`bun run build`）
- [x] TypeScript / ESLint エラーなし（既存の警告のみ）
- [ ] セッション作成画面でサイクルセッショントグルをONにしてメッセージを入力できること
- [ ] セッション作成時に `cycle_message` / `cycle_max_count` がAPIリクエストに含まれること
- [ ] `cycleEnabled=false` または `cycleMessage` が空の場合はパラメータが送信されないこと

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)