### PR TITLE
feat: OAuth Connect button for remote MCP servers

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -66,7 +66,8 @@ async function handleProxyRequest(
 
     // Check if this is an OAuth endpoint that doesn't require API key
     const path = pathParts.join('/');
-    const isOAuthEndpoint = path.startsWith('oauth/') || path.includes('auth/');
+    // mcp-oauth/* endpoints DO require auth (only the callback redirect is server-side)
+    const isOAuthEndpoint = !path.startsWith('mcp-oauth/') && (path.startsWith('oauth/') || path.includes('auth/'));
     
     // Get API key from cookie (skip for OAuth endpoints)
     let apiKey: string | null = null;

--- a/src/components/settings/MCPOAuthButton.tsx
+++ b/src/components/settings/MCPOAuthButton.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+interface MCPOAuthStatus {
+  connected: boolean
+  expires_at?: string
+  has_refresh_token?: boolean
+}
+
+interface MCPOAuthConnectResponse {
+  authorization_url: string
+  state: string
+}
+
+interface MCPOAuthButtonProps {
+  serverName: string
+  serverUrl: string
+  initialStatus?: {
+    connected: boolean
+    expiresAt?: string
+  }
+}
+
+export function MCPOAuthButton({ serverName, serverUrl, initialStatus }: MCPOAuthButtonProps) {
+  const [status, setStatus] = useState<MCPOAuthStatus>({
+    connected: initialStatus?.connected ?? false,
+    expires_at: initialStatus?.expiresAt,
+  })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/proxy/mcp-oauth/status/${encodeURIComponent(serverName)}`)
+      if (res.ok) {
+        const data: MCPOAuthStatus = await res.json()
+        setStatus(data)
+      }
+    } catch {
+      // silently ignore status fetch errors
+    }
+  }, [serverName])
+
+  useEffect(() => {
+    fetchStatus()
+  }, [fetchStatus])
+
+  const handleConnect = async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch('/api/proxy/mcp-oauth/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          server_name: serverName,
+          mcp_server_url: serverUrl,
+        }),
+      })
+
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({ message: 'Unknown error' }))
+        setError(errData.message || `HTTP ${res.status}`)
+        return
+      }
+
+      const data: MCPOAuthConnectResponse = await res.json()
+
+      // Open the authorization URL in a popup
+      const popup = window.open(
+        data.authorization_url,
+        'mcp-oauth-popup',
+        'width=600,height=700,scrollbars=yes,resizable=yes'
+      )
+
+      if (!popup) {
+        // Fallback: open in new tab if popup was blocked
+        window.open(data.authorization_url, '_blank')
+        setError('Popup was blocked. Please allow popups and try again, or complete the auth in the new tab.')
+        setLoading(false)
+        return
+      }
+
+      // Listen for postMessage from the callback page
+      const handleMessage = (event: MessageEvent) => {
+        if (event.data?.type === 'mcp-oauth-complete') {
+          window.removeEventListener('message', handleMessage)
+          clearInterval(pollInterval)
+          popup.close()
+          if (event.data.success) {
+            fetchStatus()
+          } else {
+            setError(event.data.error || 'OAuth authentication failed')
+          }
+          setLoading(false)
+        }
+      }
+      window.addEventListener('message', handleMessage)
+
+      // Also poll status in case postMessage doesn't arrive (popup closed manually)
+      const pollInterval = setInterval(async () => {
+        if (popup.closed) {
+          clearInterval(pollInterval)
+          window.removeEventListener('message', handleMessage)
+          await fetchStatus()
+          setLoading(false)
+        }
+      }, 1000)
+
+      // Timeout after 5 minutes
+      setTimeout(() => {
+        clearInterval(pollInterval)
+        window.removeEventListener('message', handleMessage)
+        if (!popup.closed) popup.close()
+        setLoading(false)
+        fetchStatus()
+      }, 5 * 60 * 1000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start OAuth flow')
+      setLoading(false)
+    }
+  }
+
+  const handleDisconnect = async () => {
+    if (!confirm(`Disconnect OAuth for "${serverName}"?`)) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/proxy/mcp-oauth/disconnect/${encodeURIComponent(serverName)}`, {
+        method: 'DELETE',
+      })
+      if (res.ok) {
+        setStatus({ connected: false })
+      } else {
+        const errData = await res.json().catch(() => ({ message: 'Unknown error' }))
+        setError(errData.message || `HTTP ${res.status}`)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disconnect')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const isExpired = status.expires_at ? new Date(status.expires_at) < new Date() : false
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        {status.connected && !isExpired ? (
+          <>
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
+              OAuth Connected
+            </span>
+            <button
+              type="button"
+              onClick={handleDisconnect}
+              disabled={loading}
+              className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50"
+            >
+              Disconnect
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={handleConnect}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-medium bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? (
+              <>
+                <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Connecting...
+              </>
+            ) : (
+              <>
+                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                </svg>
+                {isExpired ? 'Reconnect OAuth' : 'Connect OAuth'}
+              </>
+            )}
+          </button>
+        )}
+        {isExpired && status.connected && (
+          <span className="text-xs text-amber-500 dark:text-amber-400">Token expired</span>
+        )}
+      </div>
+      {error && (
+        <p className="text-xs text-red-500 dark:text-red-400">{error}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/settings/MCPOAuthButton.tsx
+++ b/src/components/settings/MCPOAuthButton.tsx
@@ -22,6 +22,18 @@ interface MCPOAuthButtonProps {
   }
 }
 
+/** Extract a human-readable error message from any API error response shape. */
+function extractErrorMessage(data: unknown, statusCode: number): string {
+  if (data && typeof data === 'object') {
+    const d = data as Record<string, unknown>
+    // Try common error field names in order
+    const msg = d.message ?? d.error ?? d.detail ?? d.details
+    if (typeof msg === 'string' && msg) return msg
+  }
+  if (typeof data === 'string' && data) return data
+  return `リクエストに失敗しました (HTTP ${statusCode})`
+}
+
 export function MCPOAuthButton({ serverName, serverUrl, initialStatus }: MCPOAuthButtonProps) {
   const [status, setStatus] = useState<MCPOAuthStatus>({
     connected: initialStatus?.connected ?? false,
@@ -61,8 +73,9 @@ export function MCPOAuthButton({ serverName, serverUrl, initialStatus }: MCPOAut
       })
 
       if (!res.ok) {
-        const errData = await res.json().catch(() => ({ message: 'Unknown error' }))
-        setError(errData.message || `HTTP ${res.status}`)
+        // Parse JSON but fall back to null if the body is not JSON (e.g. HTML error page)
+        const errData = await res.json().catch(() => null)
+        setError(extractErrorMessage(errData, res.status))
         return
       }
 
@@ -78,7 +91,7 @@ export function MCPOAuthButton({ serverName, serverUrl, initialStatus }: MCPOAut
       if (!popup) {
         // Fallback: open in new tab if popup was blocked
         window.open(data.authorization_url, '_blank')
-        setError('Popup was blocked. Please allow popups and try again, or complete the auth in the new tab.')
+        setError('ポップアップがブロックされました。ポップアップを許可して再試行するか、新しいタブで認証を完了してください。')
         setLoading(false)
         return
       }
@@ -92,7 +105,7 @@ export function MCPOAuthButton({ serverName, serverUrl, initialStatus }: MCPOAut
           if (event.data.success) {
             fetchStatus()
           } else {
-            setError(event.data.error || 'OAuth authentication failed')
+            setError(event.data.error || 'OAuth 認証に失敗しました')
           }
           setLoading(false)
         }
@@ -118,13 +131,13 @@ export function MCPOAuthButton({ serverName, serverUrl, initialStatus }: MCPOAut
         fetchStatus()
       }, 5 * 60 * 1000)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start OAuth flow')
+      setError(err instanceof Error ? err.message : 'OAuth フローの開始に失敗しました')
       setLoading(false)
     }
   }
 
   const handleDisconnect = async () => {
-    if (!confirm(`Disconnect OAuth for "${serverName}"?`)) return
+    if (!confirm(`"${serverName}" の OAuth 接続を解除しますか？`)) return
     setLoading(true)
     setError(null)
     try {
@@ -134,11 +147,11 @@ export function MCPOAuthButton({ serverName, serverUrl, initialStatus }: MCPOAut
       if (res.ok) {
         setStatus({ connected: false })
       } else {
-        const errData = await res.json().catch(() => ({ message: 'Unknown error' }))
-        setError(errData.message || `HTTP ${res.status}`)
+        const errData = await res.json().catch(() => null)
+        setError(extractErrorMessage(errData, res.status))
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to disconnect')
+      setError(err instanceof Error ? err.message : '切断に失敗しました')
     } finally {
       setLoading(false)
     }

--- a/src/components/settings/MCPServerSettings.tsx
+++ b/src/components/settings/MCPServerSettings.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { APIMCPServerConfig } from '@/types/settings'
+import { APIMCPServerConfig, APIMCPServerOAuthConfig } from '@/types/settings'
+import { MCPOAuthButton } from './MCPOAuthButton'
 
 interface MCPServerSettingsProps {
   servers: Record<string, APIMCPServerConfig> | undefined
@@ -151,6 +152,19 @@ export function MCPServerSettings({ servers, onChange }: MCPServerSettingsProps)
                       </p>
                     ) : null
                   })()}
+                  {config.has_oauth_config && (
+                    <p className="mt-1 text-xs text-blue-500 dark:text-blue-400">
+                      OAuth config: {config.oauth_scopes?.join(', ') || 'configured'}
+                    </p>
+                  )}
+                  {config.type !== 'stdio' && config.url && (
+                    <div className="mt-2">
+                      <MCPOAuthButton
+                        serverName={name}
+                        serverUrl={config.url}
+                      />
+                    </div>
+                  )}
                 </div>
                 <div className="flex gap-2 ml-4">
                   <button
@@ -225,6 +239,12 @@ function MCPServerModal({ server, existingNames, onSave, onClose }: MCPServerMod
     }
     return []
   })
+  const [oauthConfig, setOauthConfig] = useState<APIMCPServerOAuthConfig>(
+    server.config.oauth_config || {}
+  )
+  const [showOAuthSection, setShowOAuthSection] = useState(
+    !!(server.config.has_oauth_config || server.config.oauth_config)
+  )
   const [error, setError] = useState<string | null>(null)
 
   const handleTypeChange = (type: APIMCPServerConfig['type']) => {
@@ -316,6 +336,18 @@ function MCPServerModal({ server, existingNames, onSave, onClose }: MCPServerMod
       })
       if (Object.keys(headers).length > 0) {
         finalConfig.headers = headers
+      }
+      // OAuth config (optional, for pre-configured OAuth clients)
+      if (showOAuthSection) {
+        const oauth: APIMCPServerOAuthConfig = {}
+        if (oauthConfig.client_id?.trim()) oauth.client_id = oauthConfig.client_id.trim()
+        if (oauthConfig.client_secret?.trim()) oauth.client_secret = oauthConfig.client_secret.trim()
+        if (oauthConfig.scopes?.length) oauth.scopes = oauthConfig.scopes
+        if (oauthConfig.auth_url?.trim()) oauth.auth_url = oauthConfig.auth_url.trim()
+        if (oauthConfig.token_url?.trim()) oauth.token_url = oauthConfig.token_url.trim()
+        if (Object.keys(oauth).length > 0) {
+          finalConfig.oauth_config = oauth
+        }
       }
     }
 
@@ -482,6 +514,81 @@ function MCPServerModal({ server, existingNames, onSave, onClose }: MCPServerMod
                     + Add Header
                   </button>
                 </div>
+              </div>
+
+              {/* OAuth Config (optional, for pre-registered OAuth clients) */}
+              <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+                <button
+                  type="button"
+                  onClick={() => setShowOAuthSection(!showOAuthSection)}
+                  className="w-full flex items-center justify-between p-3 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-750 rounded-lg transition-colors"
+                >
+                  <span className="flex items-center gap-2">
+                    <svg className="w-4 h-4 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+                    </svg>
+                    OAuth Config
+                    <span className="text-xs text-gray-400 dark:text-gray-500 font-normal">
+                      (optional — leave empty for DCR-capable servers)
+                    </span>
+                  </span>
+                  <svg
+                    className={`w-4 h-4 transition-transform ${showOAuthSection ? 'rotate-180' : ''}`}
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+                {showOAuthSection && (
+                  <div className="px-3 pb-3 space-y-3 border-t border-gray-200 dark:border-gray-700 pt-3">
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      For servers that support Dynamic Client Registration (DCR), you can leave these fields empty.
+                      agentapi-proxy will auto-register a client. For servers requiring a pre-registered client (e.g. Auth0, Azure AD),
+                      enter the client ID and secret here.
+                    </p>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                          Client ID
+                        </label>
+                        <input
+                          type="text"
+                          value={oauthConfig.client_id || ''}
+                          onChange={(e) => setOauthConfig(prev => ({ ...prev, client_id: e.target.value }))}
+                          placeholder="Auto (DCR)"
+                          className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                          Client Secret
+                        </label>
+                        <input
+                          type="password"
+                          value={oauthConfig.client_secret || ''}
+                          onChange={(e) => setOauthConfig(prev => ({ ...prev, client_secret: e.target.value }))}
+                          placeholder="Auto (DCR)"
+                          className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                        Scopes (space-separated)
+                      </label>
+                      <input
+                        type="text"
+                        value={oauthConfig.scopes?.join(' ') || ''}
+                        onChange={(e) => setOauthConfig(prev => ({
+                          ...prev,
+                          scopes: e.target.value ? e.target.value.split(/\s+/).filter(Boolean) : undefined
+                        }))}
+                        placeholder="e.g. read:files write:files"
+                        className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             </>
           )}

--- a/src/components/settings/MCPServerSettings.tsx
+++ b/src/components/settings/MCPServerSettings.tsx
@@ -542,9 +542,10 @@ function MCPServerModal({ server, existingNames, onSave, onClose }: MCPServerMod
                 {showOAuthSection && (
                   <div className="px-3 pb-3 space-y-3 border-t border-gray-200 dark:border-gray-700 pt-3">
                     <p className="text-xs text-gray-500 dark:text-gray-400">
-                      For servers that support Dynamic Client Registration (DCR), you can leave these fields empty.
-                      agentapi-proxy will auto-register a client. For servers requiring a pre-registered client (e.g. Auth0, Azure AD),
-                      enter the client ID and secret here.
+                      For servers that support Dynamic Client Registration (DCR), you can leave these fields empty and agentapi-proxy will auto-register a client.
+                      <br />
+                      <strong className="text-gray-700 dark:text-gray-300">Figma・Linear・Notion などは DCR 非対応のため、Client ID と Client Secret の入力が必要です。</strong>
+                      {' '}各サービスのデベロッパーポータルで OAuth アプリを登録し、Redirect URI に <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">…/mcp-oauth/callback</code> を設定してください。
                     </p>
                     <div className="grid grid-cols-2 gap-2">
                       <div>

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,4 +1,5 @@
 export { BedrockSettings } from './BedrockSettings'
+export { MCPOAuthButton } from './MCPOAuthButton'
 export { SettingsAccordion } from './SettingsAccordion'
 export { GithubTokenSettings } from './GithubTokenSettings'
 export { LogoutButton } from './LogoutButton'

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -16,6 +16,15 @@ export interface BedrockConfig {
   secret_access_key?: string; // AWS シークレットアクセスキー（チーム設定のみ）
 }
 
+// MCP OAuth config (for http/sse servers that require OAuth)
+export interface APIMCPServerOAuthConfig {
+  client_id?: string;      // OAuth client ID (leave empty for DCR-capable servers)
+  client_secret?: string;  // OAuth client secret (leave empty for DCR-capable servers)
+  scopes?: string[];       // Requested OAuth scopes
+  auth_url?: string;       // Override authorization endpoint URL
+  token_url?: string;      // Override token endpoint URL
+}
+
 // API用のMCPサーバー設定（OpenAPI仕様準拠）
 export interface APIMCPServerConfig {
   type: 'stdio' | 'http' | 'sse';
@@ -26,6 +35,9 @@ export interface APIMCPServerConfig {
   env_keys?: string[];                // 環境変数キーのみ（API読み取り時）
   headers?: Record<string, string>;   // http/sse用ヘッダー（書き込み時）
   header_keys?: string[];             // ヘッダーキーのみ（API読み取り時）
+  oauth_config?: APIMCPServerOAuthConfig;  // OAuth config for remote MCP servers
+  has_oauth_config?: boolean;         // Whether OAuth config is set (read-only from API)
+  oauth_scopes?: string[];            // Configured OAuth scopes (read-only from API)
 }
 
 // APIレスポンス用（セキュリティ対策：env/headersは値を含まない）


### PR DESCRIPTION
## Summary

Adds UI support for the [agentapi-proxy MCP OAuth flow](https://github.com/takutakahashi/agentapi-proxy/pull/716):

- **MCPOAuthButton** (`src/components/settings/MCPOAuthButton.tsx`): New component that handles Connect/Disconnect OAuth for http/sse MCP servers
  - POSTs to `/mcp-oauth/connect` to start the flow
  - Opens the `authorization_url` in a popup window
  - Listens for `postMessage` from the OAuth callback page to detect completion
  - Falls back to polling when popup is closed manually
  - Shows "OAuth Connected" badge with expiry info, or "Connect OAuth" / "Reconnect OAuth" button
- **MCPServerSettings**: 
  - Shows the OAuth Connect button under each http/sse server in the list
  - Adds a collapsible **OAuth Config** section in the Add/Edit modal (for pre-registered OAuth clients — leave empty for DCR-capable servers)
- **types/settings.ts**: Added `APIMCPServerOAuthConfig` interface and `oauth_config`, `has_oauth_config`, `oauth_scopes` fields to `APIMCPServerConfig`
- **proxy route fix**: Fixed `isOAuthEndpoint` detection — `mcp-oauth/*` contains the substring `auth/` and was incorrectly treated as an auth endpoint (skipping API-key injection). Fixed with `!path.startsWith('mcp-oauth/')` guard.

## Test plan

- [ ] Add a remote MCP server (http/sse type) in Settings → MCP Servers
- [ ] Click **Connect OAuth** button — verify popup opens with OAuth provider's auth page
- [ ] Complete OAuth in popup — verify popup closes and button changes to "OAuth Connected"
- [ ] Verify `GET /mcp-oauth/status/:serverName` shows `connected: true`
- [ ] Click **Disconnect** — verify status returns to disconnected
- [ ] Verify OAuth Config collapsible section appears in modal for http/sse servers

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)