### PR TITLE
feat(slackbot): SlackBot フォームに「クローンするリポジトリ」フィールドを追加

### DIFF
--- a/src/app/components/SlackbotFormModal.tsx
+++ b/src/app/components/SlackbotFormModal.tsx
@@ -535,7 +535,7 @@ export default function SlackbotFormModal({
                   {/* Repository */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      クローンするリポジトリ
+                      初期リポジトリ
                     </label>
                     <input
                       type="text"

--- a/src/app/components/SlackbotFormModal.tsx
+++ b/src/app/components/SlackbotFormModal.tsx
@@ -46,6 +46,7 @@ export default function SlackbotFormModal({
   // Session config
   const [envPairs, setEnvPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [tagPairs, setTagPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
+  const [repoFullName, setRepoFullName] = useState('')
 
   // Memory key
   const [memoryKeyPairs, setMemoryKeyPairs] = useState<MemoryKeyPair[]>([{ key: '', value: '' }])
@@ -84,6 +85,14 @@ export default function SlackbotFormModal({
         setShowAdvanced(true)
       } else {
         setTagPairs([{ key: '', value: '' }])
+      }
+
+      // Restore repo_full_name from session params
+      if (sc?.params?.repo_full_name) {
+        setRepoFullName(sc.params.repo_full_name)
+        setShowAdvanced(true)
+      } else {
+        setRepoFullName('')
       }
 
       // Restore memory key pairs from existing memory_key
@@ -131,6 +140,7 @@ export default function SlackbotFormModal({
       setShowCustomMemory(false)
       setShowBotTokenSection(false)
       setShowAdvanced(false)
+      setRepoFullName('')
     }
     setError(null)
   }, [editingSlackbot, isOpen])
@@ -230,11 +240,17 @@ export default function SlackbotFormModal({
       // Build memory_key from pairs (Go template values like {{ .bot_id }} are resolved server-side at runtime)
       const memoryKey = memoryKeyPairsToRecord(memoryKeyPairs)
 
+      // Build session params (only include non-empty values)
+      const sessionParams = {
+        ...(repoFullName.trim() ? { repo_full_name: repoFullName.trim() } : {}),
+      }
+
       const sessionConfig = {
         ...(initialMessageTemplate.trim() ? { initial_message_template: initialMessageTemplate.trim() } : {}),
         ...(reuseMessageTemplate.trim() ? { reuse_message_template: reuseMessageTemplate.trim() } : {}),
         ...(Object.keys(environment).length > 0 ? { environment } : {}),
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
+        ...(Object.keys(sessionParams).length > 0 ? { params: sessionParams } : {}),
       }
 
       if (isEditing && editingSlackbot) {
@@ -513,6 +529,23 @@ export default function SlackbotFormModal({
                     />
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                       既存セッションを再利用する際に送信されるメッセージ。Goテンプレート形式。例: <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">{'{{ .event.text }}'}</code>
+                    </p>
+                  </div>
+
+                  {/* Repository */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      クローンするリポジトリ
+                    </label>
+                    <input
+                      type="text"
+                      value={repoFullName}
+                      onChange={(e) => setRepoFullName(e.target.value)}
+                      placeholder="例: myorg/myrepo"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
+                    />
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      セッション起動時に自動でクローンする GitHub リポジトリ（<code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">org/repo</code> 形式）。設定するとメッセージ内のリポジトリ自動検出より優先されます。
                     </p>
                   </div>
 

--- a/src/types/slackbot.ts
+++ b/src/types/slackbot.ts
@@ -7,6 +7,8 @@ export type SlackBotStatus = 'active' | 'paused';
 export interface SlackBotSessionParams {
   agent_type?: string;
   oneshot?: boolean;
+  /** クローンする GitHub リポジトリ（例: "org/repo"）。設定するとセッション起動時に自動クローンされる。メッセージ内の自動検出より優先される */
+  repo_full_name?: string;
 }
 
 // Session configuration for SlackBot


### PR DESCRIPTION
## Summary

- SlackBot 作成・編集フォームの詳細設定に「クローンするリポジトリ」入力フィールドを追加
- `session_config.params.repo_full_name` を UI から設定できるようにした
- バックエンド PR: takutakahashi/agentapi-proxy#723

## 変更内容

- `src/types/slackbot.ts`: `SlackBotSessionParams` に `repo_full_name` フィールドを追加
- `src/app/components/SlackbotFormModal.tsx`:
  - `repoFullName` state を追加
  - 詳細設定セクションに「クローンするリポジトリ」入力フィールドを追加（メッセージテンプレートの直後）
  - 編集時に既存の `repo_full_name` を復元する処理を実装
  - フォームリセット時に state をクリア
  - 送信時に `session_config.params.repo_full_name` として API へ送信

## UI の変更箇所

詳細設定セクション内に以下のフィールドが追加される：

```
クローンするリポジトリ
[__________________________]  ← テキスト入力（例: myorg/myrepo）
セッション起動時に自動でクローンする GitHub リポジトリ（org/repo 形式）...
```

## 動作

- 空欄の場合は `params` を送信しない（既存の動作を維持）
- 入力がある場合、`session_config.params.repo_full_name` として API に送信
- 編集モードでは既存の設定値が自動で入力欄に反映される
- 設定値がある場合、詳細設定セクションが自動で展開される

## Test plan

- [ ] SlackBot 作成フォームで「クローンするリポジトリ」フィールドに `myorg/myrepo` を入力して作成
- [ ] 作成した SlackBot の詳細設定が正しく反映されることを確認
- [ ] 編集フォームを開いた際に設定済みのリポジトリが入力欄に表示されることを確認
- [ ] 空欄で保存した場合は `repo_full_name` が送信されないことを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)