### PR TITLE
feat: セッション一覧サイドバーの改善

### DIFF
--- a/src/app/components/SessionListSidebar.tsx
+++ b/src/app/components/SessionListSidebar.tsx
@@ -200,25 +200,16 @@ export default function SessionListSidebar({
             })}
           </ul>
         )}
+
       </div>
 
-      {/* Footer */}
-      <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-800">
-        {!loading && sessions.length > 0 && (
-          <p className="text-[10px] text-gray-400 dark:text-gray-600 text-center px-3 pt-1.5">
-            {runningCount > 0 ? (
-              <><span className="text-green-500">{runningCount}</span> 件稼働中 / {sessions.length} 件</>
-            ) : (
-              `${sessions.length} 件`
-            )}
-          </p>
-        )}
-        {/* New session button */}
-        <div className="px-2 py-2">
+      {/* New session button — just above footer */}
+      {!loading && (
+        <div className="flex-shrink-0 px-2 py-1.5 border-t border-gray-200 dark:border-gray-800">
           <button
             onClick={() => router.push('/sessions/new')}
             className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md
-                       text-xs text-gray-500 dark:text-gray-400
+                       text-xs text-gray-400 dark:text-gray-600
                        border border-dashed border-gray-300 dark:border-gray-700
                        hover:text-blue-600 dark:hover:text-blue-400
                        hover:border-blue-400 dark:hover:border-blue-600
@@ -231,7 +222,20 @@ export default function SessionListSidebar({
             新規セッション
           </button>
         </div>
-      </div>
+      )}
+
+      {/* Footer */}
+      {!loading && sessions.length > 0 && (
+        <div className="flex-shrink-0 px-3 py-1.5 border-t border-gray-200 dark:border-gray-800">
+          <p className="text-[10px] text-gray-400 dark:text-gray-600 text-center">
+            {runningCount > 0 ? (
+              <><span className="text-green-500">{runningCount}</span> 件稼働中 / {sessions.length} 件</>
+            ) : (
+              `${sessions.length} 件`
+            )}
+          </p>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

PR #489 のマージ後に積み重ねた改善をまとめたPRです。

- **レイアウト統一**: サイドバー独自ヘッダーを廃止し、チャットのトップバーと一本化
  - 「全幅ヘッダー → 下段フレックス（サイドバー | チャット）」構造に変更
  - サイドバートグルボタンをヘッダー左端に控えめ配置
- **モバイル対応**: `md:` 未満ではサイドバー・トグルボタンを完全非表示
- **削除機能**: ホバーでゴミ箱ボタンを表示、確認ダイアログ付きで削除
  - 削除中はスピナー表示・行を半透明化
  - 現在表示中のセッション削除時は `/chats` へ自動遷移
- **新規セッションボタン**: リスト末尾・フッター直上の固定位置に破線ボーダーで配置
- **全体的なデザイン調整**: サイドバー幅・ドットサイズ・テキストサイズを抑えてすっきり

## Test plan

- [ ] デスクトップでサイドバーが表示され、ハンバーガーボタンで切り替えられる
- [ ] モバイル（768px未満）ではサイドバー・トグルボタンが非表示
- [ ] セッション行にホバーすると削除ボタンが表示される
- [ ] 削除ボタンで確認後にセッションが削除される
- [ ] 現在のセッションを削除すると /chats へ遷移する
- [ ] フッター直上の「新規セッション」ボタンで /sessions/new へ遷移する

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)