### PR TITLE
feat: replace session status polling with proxy-wide SSE stream

### DIFF
--- a/src/app/components/SessionListSidebar.tsx
+++ b/src/app/components/SessionListSidebar.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
+import { createAgentAPIProxyClientFromStorage, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
 import { Session, SessionStatus } from '../../types/agentapi'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
+import { useSessionsStatusStream } from '../hooks/useSessionsStatusStream'
 
 interface SessionListSidebarProps {
   currentSessionId: string
@@ -14,6 +15,7 @@ interface SessionListSidebarProps {
 function getStatusDotClass(status: SessionStatus): string {
   switch (status) {
     case 'active':   return 'bg-green-500'
+    case 'running':  return 'bg-yellow-400 animate-pulse'
     case 'starting': return 'bg-yellow-400 animate-pulse'
     case 'creating': return 'bg-blue-400 animate-pulse'
     case 'unhealthy':return 'bg-red-500'
@@ -22,7 +24,7 @@ function getStatusDotClass(status: SessionStatus): string {
 }
 
 function isRunningStatus(status: SessionStatus): boolean {
-  return status === 'active' || status === 'starting' || status === 'creating'
+  return status === 'active' || status === 'running' || status === 'starting' || status === 'creating'
 }
 
 function getSessionTitle(session: Session): string {
@@ -49,13 +51,13 @@ export default function SessionListSidebar({
 }: SessionListSidebarProps) {
   const router = useRouter()
   const { selectedTeam } = useTeamScope()
+  const [client] = useState(() => createAgentAPIProxyClientFromStorage())
   const [sessions, setSessions] = useState<Session[]>([])
   const [loading, setLoading] = useState(true)
   const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
 
   const fetchSessions = useCallback(async () => {
     try {
-      const client = createAgentAPIProxyClientFromStorage()
       const scopeParams: { scope: 'user' | 'team'; team_id?: string } = selectedTeam
         ? { scope: 'team', team_id: selectedTeam }
         : { scope: 'user' }
@@ -70,12 +72,33 @@ export default function SessionListSidebar({
     } finally {
       setLoading(false)
     }
-  }, [selectedTeam])
+  }, [client, selectedTeam])
+
+  // SSE でリアルタイム更新: ステータス変化をインプレース反映し、active になったらフルリフレッシュ
+  const handleProxyStatusEvent = useCallback((event: ProxySessionStatusEvent) => {
+    setSessions(prev => {
+      const idx = prev.findIndex(s => s.session_id === event.session_id)
+      if (idx === -1) return prev
+      const updated = [...prev]
+      updated[idx] = { ...updated[idx], status: event.status as SessionStatus }
+      return updated
+    })
+    if (event.status === 'active' || event.status === 'stopped') {
+      fetchSessions()
+    }
+  }, [fetchSessions])
+
+  useSessionsStatusStream({
+    client,
+    onStatusChange: handleProxyStatusEvent,
+    enabled: isVisible,
+  })
 
   useEffect(() => {
     if (!isVisible) return
     fetchSessions()
-    const interval = setInterval(fetchSessions, 5000)
+    // SSE がリアルタイム更新を担うため、ポーリングは 30 秒に延長
+    const interval = setInterval(fetchSessions, 30000)
     return () => clearInterval(interval)
   }, [fetchSessions, isVisible])
 
@@ -160,7 +183,9 @@ export default function SessionListSidebar({
                         {title}
                       </p>
                       <p className="text-[10px] text-gray-400 dark:text-gray-600 mt-0.5 leading-none">
-                        {running && session.status !== 'active' ? (
+                        {session.status === 'running' ? (
+                          <span className="text-yellow-500 dark:text-yellow-400">実行中</span>
+                        ) : running && session.status !== 'active' ? (
                           <span className="text-yellow-500 dark:text-yellow-400">
                             {session.status === 'starting' ? '起動中' : '作成中'}
                           </span>

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { Session, AgentStatus, SessionListParams } from '../../types/agentapi'
-import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
+import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
 import { useBackgroundAwareInterval } from '../hooks/usePageVisibility'
+import { useSessionsStatusStream } from '../hooks/useSessionsStatusStream'
 import { formatDate, formatRelativeTime } from '../../utils/timeUtils'
 import { truncateText } from '../../utils/textUtils'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
@@ -203,50 +204,47 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     }
   }, [sessions, agentAPIProxy])
 
-  // 作成中のセッション（propsから渡されたもの）があるかどうかを判定
+  // 作成中のセッションがある場合（propsから渡されたもの）があるかどうかを判定
   const hasCreatingSessions = useMemo(() => {
     return creatingSessions.some(s => s.status !== 'completed' && s.status !== 'failed')
   }, [creatingSessions])
 
-  // 起動中のセッションがあるかどうかを判定
+  // 起動中のセッションがあるかどうかを判定（エージェントステータスポーリング間隔の決定に使用）
   const hasActiveSession = useMemo(() => {
-    // 作成中のセッションがある場合
-    if (hasCreatingSessions) {
-      return true
-    }
-
-    // セッションが作成中または起動中の場合
-    if (sessions.some(s => s.status === 'creating' || s.status === 'starting')) {
-      return true
-    }
-
-    // エージェントが実行中のセッションがある場合
-    if (Object.values(sessionAgentStatus).some(status => status.status === 'running')) {
-      return true
-    }
-
+    if (hasCreatingSessions) return true
+    if (sessions.some(s => s.status === 'creating' || s.status === 'starting')) return true
+    if (Object.values(sessionAgentStatus).some(status => status.status === 'running')) return true
     return false
   }, [hasCreatingSessions, sessions, sessionAgentStatus])
 
-  // 作成中・起動中のセッションがある場合（エージェント running は除く）
-  const needsSessionRefresh = useMemo(() => {
-    if (hasCreatingSessions) {
-      return true
-    }
-    if (sessions.some(s => s.status === 'creating' || s.status === 'starting')) {
-      return true
-    }
-    return false
-  }, [hasCreatingSessions, sessions])
+  // SSE でセッションステータス変化を受信したときの処理
+  const handleProxyStatusEvent = useCallback((event: ProxySessionStatusEvent) => {
+    setSessions(prev => {
+      const idx = prev.findIndex(s => s.session_id === event.session_id)
+      if (idx === -1) return prev
+      const updated = [...prev]
+      updated[idx] = { ...updated[idx], status: event.status as Session['status'] }
+      return updated
+    })
 
-  // 起動中のセッションがある場合は7秒、ない場合は10秒
-  const pollingInterval = hasActiveSession ? 7000 : 10000
+    // セッションが active になったタイミングでフルリフレッシュ（メタデータ取得のため）
+    if (event.status === 'active') {
+      fetchSessions()
+    }
+  }, [fetchSessions])
 
-  // バックグラウンド対応の定期更新フック
+  // プロキシ全体のセッションステータス SSE ストリーム
+  useSessionsStatusStream({
+    client: agentAPIProxy,
+    onStatusChange: handleProxyStatusEvent,
+  })
+
+  // エージェントステータスポーリング間隔: 実行中セッションがある場合は7秒、ない場合は30秒
+  // （SSE がセッション作成ライフサイクルをカバーするため、ポーリング頻度を下げる）
+  const pollingInterval = hasActiveSession ? 7000 : 30000
+
+  // エージェントレベルのステータス（running / stable / error）は引き続きポーリングで取得
   const statusPollingControl = useBackgroundAwareInterval(fetchSessionStatuses, pollingInterval, false)
-
-  // 作成中のセッションがある場合はセッション一覧も定期的に更新
-  const sessionPollingControl = useBackgroundAwareInterval(fetchSessions, pollingInterval, false)
 
   useEffect(() => {
     fetchSessions()
@@ -264,19 +262,6 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
       statusPollingControl.stop()
     }
   }, [sessions.length, statusPollingControl])
-
-  // 作成中・起動中のセッションがある場合はセッション一覧を定期的に更新（エージェント running 時は除く）
-  useEffect(() => {
-    if (needsSessionRefresh) {
-      sessionPollingControl.start()
-    } else {
-      sessionPollingControl.stop()
-    }
-
-    return () => {
-      sessionPollingControl.stop()
-    }
-  }, [needsSessionRefresh, sessionPollingControl])
 
 
   useEffect(() => {

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -474,6 +474,9 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     if (session.status === 'starting') {
       return { status: 'starting' as const, colorClass: 'bg-indigo-500 animate-pulse', text: '起動中' }
     }
+    if (session.status === 'running') {
+      return { status: 'running' as const, colorClass: 'bg-yellow-500 animate-pulse', text: 'Running' }
+    }
 
     // ステータスが取得できていない場合
     if (!agentStatus) {

--- a/src/app/hooks/useSessionsStatusStream.ts
+++ b/src/app/hooks/useSessionsStatusStream.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { AgentAPIProxyClient, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client';
+import { usePageVisibility } from './usePageVisibility';
+
+interface UseSessionsStatusStreamOptions {
+  /** The AgentAPIProxyClient instance to use */
+  client: AgentAPIProxyClient;
+  /** Called whenever a session status change event arrives */
+  onStatusChange: (event: ProxySessionStatusEvent) => void;
+  /** Called when the SSE connection encounters an error */
+  onError?: (error: Error) => void;
+  /** Set to false to disable the stream entirely (default: true) */
+  enabled?: boolean;
+}
+
+/**
+ * Subscribes to the proxy-wide SSE endpoint GET /sessions/status/stream.
+ * Automatically pauses when the browser tab is hidden and reconnects on
+ * visibility restore or after an error.
+ */
+export function useSessionsStatusStream({
+  client,
+  onStatusChange,
+  onError,
+  enabled = true,
+}: UseSessionsStatusStreamOptions): void {
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep latest callbacks in refs so we never need to resubscribe just because
+  // the caller inline-created a new arrow function.
+  const onStatusChangeRef = useRef(onStatusChange);
+  onStatusChangeRef.current = onStatusChange;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const isVisible = usePageVisibility();
+
+  const disconnect = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (eventSourceRef.current) return; // already connected
+
+    const es = client.subscribeToSessionsStatusEvents(
+      (event) => onStatusChangeRef.current(event),
+      (error) => {
+        onErrorRef.current?.(error);
+        // Close the broken connection and schedule a reconnect
+        if (eventSourceRef.current) {
+          eventSourceRef.current.close();
+          eventSourceRef.current = null;
+        }
+        if (!reconnectTimerRef.current) {
+          reconnectTimerRef.current = setTimeout(() => {
+            reconnectTimerRef.current = null;
+            connect();
+          }, 5000);
+        }
+      }
+    );
+    eventSourceRef.current = es;
+  }, [client]);
+
+  useEffect(() => {
+    if (!enabled) {
+      disconnect();
+      return;
+    }
+
+    if (isVisible) {
+      connect();
+    } else {
+      // Pause when the tab is hidden to save resources; reconnect on restore.
+      disconnect();
+    }
+
+    return disconnect;
+  }, [enabled, isVisible, connect, disconnect]);
+}

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -91,6 +91,15 @@ interface AgentStatus {
   message?: string;
 }
 
+/**
+ * Proxy-wide session status change event emitted by GET /sessions/status/stream
+ */
+export interface ProxySessionStatusEvent {
+  session_id: string;
+  status: string;
+  timestamp: string;
+}
+
 export interface AgentAPIProxyClientConfig {
   baseURL: string;
   apiKey?: string;
@@ -636,6 +645,53 @@ export class AgentAPIProxyClient {
         if (this.debug) {
           console.log(`[AgentAPIProxy] Session EventSource will attempt to reconnect in ${reconnectInterval}ms`);
         }
+      }
+    };
+
+    return eventSource;
+  }
+
+  /**
+   * Subscribe to proxy-wide session status changes via SSE (GET /sessions/status/stream).
+   * Each event carries the session_id, new status, and timestamp for any session
+   * accessible by the current user.
+   *
+   * @returns The EventSource — call `.close()` to unsubscribe.
+   */
+  subscribeToSessionsStatusEvents(
+    onEvent: (event: ProxySessionStatusEvent) => void,
+    onError?: (error: Error) => void
+  ): EventSource {
+    const isUsingProxy = this.baseURL.includes('/api/proxy');
+    const eventSourceUrl = isUsingProxy
+      ? `/api/proxy/sessions/status/stream`
+      : `${this.baseURL}/sessions/status/stream`;
+
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Creating EventSource for proxy-wide session status:`, eventSourceUrl);
+    }
+
+    const eventSource = new EventSource(eventSourceUrl);
+
+    eventSource.onmessage = (event) => {
+      // Skip heartbeat comments (EventSource ignores comment lines automatically,
+      // but guard against empty data just in case)
+      if (!event.data) return;
+      try {
+        const data: ProxySessionStatusEvent = JSON.parse(event.data);
+        if (this.debug) {
+          console.log(`[AgentAPIProxy] Proxy session status event:`, data);
+        }
+        onEvent(data);
+      } catch (err) {
+        console.error('[AgentAPIProxy] Failed to parse proxy session status event:', err);
+      }
+    };
+
+    eventSource.onerror = () => {
+      console.error('[AgentAPIProxy] Proxy status EventSource error');
+      if (onError) {
+        onError(new Error('Proxy session status EventSource connection error'));
       }
     };
 

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -157,7 +157,7 @@ export interface RateLimitInfo {
 }
 
 // Session status types based on agentapi-proxy OpenAPI specification
-export type SessionStatus = 'creating' | 'starting' | 'active' | 'unhealthy' | 'stopped' | 'unknown';
+export type SessionStatus = 'creating' | 'starting' | 'running' | 'active' | 'unhealthy' | 'stopped' | 'unknown';
 
 // Resource scope types for team support
 export type ResourceScope = 'user' | 'team';


### PR DESCRIPTION
## Summary

- **`src/lib/agentapi-proxy-client.ts`**: Add `ProxySessionStatusEvent` interface and `subscribeToSessionsStatusEvents()` method that opens an `EventSource` to `GET /sessions/status/stream` (new endpoint added to agentapi-proxy in PR #726)
- **`src/app/hooks/useSessionsStatusStream.ts`** *(new)*: React hook wrapping the EventSource with auto-reconnect (5 s backoff) and auto-pause when the browser tab is hidden (via `usePageVisibility`)
- **`src/app/components/SessionListView.tsx`**: Replace `sessionPollingControl` (polling `fetchSessions` when sessions are `creating`/`starting`) with the new SSE hook; reduce `statusPollingControl` interval from 7-10 s → 7-30 s since SSE now covers session lifecycle changes

## Behaviour changes

| Before | After |
|--------|-------|
| Session list re-polled every 7-10 s when a session is creating/starting | SSE event triggers an immediate `setSessions` state update when status changes; `fetchSessions()` fires once on `active` to refresh metadata |
| Agent status (running/stable/error) polled every 7-10 s | Same polling, but interval falls back to 30 s when no active sessions (was 10 s) |

## Test plan

- [ ] Start a new session — observe the status badge update from "作成中" → "起動中" → "Available" without waiting for a poll cycle
- [ ] Confirm that switching browser tabs pauses and resumes the SSE connection
- [ ] Confirm that on SSE error the client reconnects after ~5 s
- [ ] Verify existing agent status polling (`running` / `stable` / `error` badges) still works

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)