### PR TITLE
feat: waitSessionMessages に since パラメータを追加してキャッチアップを実現

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -610,6 +610,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   // Long-poll refs
   const longPollActiveRef = useRef(false);
   const longPollAbortRef = useRef<AbortController | null>(null);
+  // Tracks the Unix-ms timestamp of the last known message_update.
+  // Passed as `since` to waitSessionMessages so the server can immediately
+  // return updated=true if messages arrived while the client was inactive.
+  const lastMessageTimestampRef = useRef<number | undefined>(undefined);
 
   // Long-polling loop — replaces 1-second interval polling.
   // Waits for message_update events from the server via GET /sessions/:sessionId/messages/wait,
@@ -625,6 +629,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     fallbackPollingControlRef.current.stop();
 
     longPollActiveRef.current = true;
+    // Record the start time so the first waitSessionMessages call can detect
+    // any update that arrived after we began but before we subscribed.
+    lastMessageTimestampRef.current = Date.now();
     let backoffMs = 1000;
     const MAX_BACKOFF = 30_000;
 
@@ -657,11 +664,14 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           const result = await agentAPIRef.current.waitSessionMessages(sessionId, {
             timeout: 30,
             signal: controller.signal,
+            since: lastMessageTimestampRef.current,
           });
 
           if (!longPollActiveRef.current) break;
 
           if (result.updated) {
+            // Update the cursor before fetching so the next call catches only newer events.
+            lastMessageTimestampRef.current = Date.parse(result.timestamp);
             await pollMessagesRef.current();
             backoffMs = 1000; // reset backoff on success
           }

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -672,16 +672,22 @@ export class AgentAPIProxyClient {
    * @param sessionId - The session to watch for message updates.
    * @param options.timeout - Max wait seconds (default: 30, max: 60).
    * @param options.signal - AbortSignal to cancel the request (e.g. on component unmount).
+   * @param options.since - Unix timestamp in milliseconds of the last known message update.
+   *   If the session received a message_update after this time the server returns immediately
+   *   with updated=true, allowing the client to catch up after a period of inactivity.
    */
   async waitSessionMessages(
     sessionId: string,
-    options: { timeout?: number; signal?: AbortSignal } = {}
+    options: { timeout?: number; signal?: AbortSignal; since?: number } = {}
   ): Promise<WaitSessionMessagesResponse> {
-    const { timeout = 30, signal } = options;
-    const endpoint = `/sessions/${sessionId}/messages/wait?timeout=${timeout}`;
+    const { timeout = 30, signal, since } = options;
+    let endpoint = `/sessions/${sessionId}/messages/wait?timeout=${timeout}`;
+    if (since !== undefined) {
+      endpoint += `&since=${since}`;
+    }
 
     if (this.debug) {
-      console.log(`[AgentAPIProxy] Long-polling for message updates in session ${sessionId} (timeout=${timeout}s)`);
+      console.log(`[AgentAPIProxy] Long-polling for message updates in session ${sessionId} (timeout=${timeout}s, since=${since})`);
     }
 
     return this.makeRequest<WaitSessionMessagesResponse>(endpoint, { signal });


### PR DESCRIPTION
## Summary

- `agentapi-proxy-client.ts`: `waitSessionMessages` に `since?: number` オプションを追加し、`?since=<Unix ms>` クエリパラメータとして渡す
- `AgentAPIChat.tsx`: `lastMessageTimestampRef` で最後の `updated: true` 時のタイムスタンプを追跡し、次回の `waitSessionMessages` に `since` として渡す

## 背景

[agentapi-proxy PR #729](https://github.com/takutakahashi/agentapi-proxy/pull/729) でサーバー側に `since` パラメータを追加。
クライアント（このリポジトリ）側も `since` を渡さないと効果がなかったため、対応する変更を行う。

## キャッチアップの仕組み

1. ループ開始時に `lastMessageTimestampRef.current = Date.now()` で基準時刻を設定
2. `waitSessionMessages?since=<last_ts>` を呼び出す
3. サーバーは `lastMessageAt > since` なら即座に `updated: true` を返す
4. クライアントは `lastMessageTimestampRef.current = Date.parse(result.timestamp)` でカーソルを更新
5. 非アクティブ中に更新があった場合、次のポーリングで即座に検知できる

## Test plan

- [ ] 通常の動作（メッセージ受信で即時更新）が壊れていないことを確認
- [ ] タブを非表示にして Claude がメッセージを追加し、タブを再表示したときに即座に最新まで追従されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)