### PR TITLE
fix: ACP セッションで tool 名が "other"/"execute" と表示される問題を修正

### DIFF
--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -4,6 +4,7 @@ import { SessionMessage } from '../../types/agentapi';
 import React, { useState, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { getToolDisplayName, getToolBriefInfo } from '../../utils/toolUtils';
 
 interface ToolUseContent {
   type: 'tool_use';
@@ -276,44 +277,7 @@ function MessageItem({
     const hasResult = !!toolResult;
 
     if (toolUse) {
-      // ツールの簡易情報を抽出（description, file_path, pattern など）
-      const getBriefInfo = (): string | null => {
-        const input = toolUse.input;
-        const maxLength = 40;
-
-        // description があれば優先
-        if (input.description && typeof input.description === 'string') {
-          return input.description.length > maxLength
-            ? input.description.substring(0, maxLength) + '...'
-            : input.description;
-        }
-
-        // ファイル系のツール
-        if (input.file_path && typeof input.file_path === 'string') {
-          const path = input.file_path;
-          return path.length > maxLength
-            ? '...' + path.substring(path.length - maxLength)
-            : path;
-        }
-
-        // パターン検索系
-        if (input.pattern && typeof input.pattern === 'string') {
-          return input.pattern.length > maxLength
-            ? input.pattern.substring(0, maxLength) + '...'
-            : input.pattern;
-        }
-
-        // コマンド系
-        if (input.command && typeof input.command === 'string') {
-          return input.command.length > maxLength
-            ? input.command.substring(0, maxLength) + '...'
-            : input.command;
-        }
-
-        return null;
-      };
-
-      const briefInfo = getBriefInfo();
+      const briefInfo = getToolBriefInfo(toolUse.name, toolUse.input);
 
       return (
         <div className="px-4 sm:px-6 py-0.5">
@@ -338,7 +302,7 @@ function MessageItem({
                   : 'text-red-600 dark:text-red-400'
                 : 'text-gray-500 dark:text-gray-400'
             }`}>
-              {toolUse.name}
+              {getToolDisplayName(toolUse.name, toolUse.input)}
             </span>
 
             {/* 結果インジケーター */}

--- a/src/app/components/RunningTools.tsx
+++ b/src/app/components/RunningTools.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SessionMessage } from '../../types/agentapi';
+import { getToolDisplayName } from '../../utils/toolUtils';
 
 interface ToolUseContent {
   type: 'tool_use';
@@ -74,7 +75,7 @@ export default function RunningTools({ messages }: RunningToolsProps) {
                     <div className="w-2 h-2 bg-yellow-500 rounded-full animate-pulse"></div>
                   </div>
                   <div className="text-xs font-medium text-gray-900 dark:text-white">
-                    {toolUse.name}
+                    {getToolDisplayName(toolUse.name, toolUse.input)}
                   </div>
                 </div>
               </div>

--- a/src/app/components/ToolExecutionPane.tsx
+++ b/src/app/components/ToolExecutionPane.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { SessionMessage } from '../../types/agentapi';
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client';
+import { getToolDescription } from '../../utils/toolUtils';
 
 interface ToolUseContent {
   type: 'tool_use';
@@ -21,44 +22,6 @@ function parseToolUseContent(content: string): ToolUseContent | null {
     // Not a valid tool_use JSON
   }
   return null;
-}
-
-// ツール名から概要を生成
-function getToolDescription(toolName: string, input: Record<string, unknown>): string {
-  // descriptionがあれば優先的に使用
-  const description = input.description as string | undefined;
-
-  switch (toolName) {
-    case 'Task':
-      // サブエージェント名を取得
-      const subagentType = input.subagent_type as string | undefined;
-      if (subagentType && description) {
-        return `${subagentType}: ${description}`;
-      } else if (subagentType) {
-        return `${subagentType}を実行中`;
-      } else if (description) {
-        return description;
-      }
-      return 'サブエージェントを実行中';
-    case 'Read':
-      return description || `ファイル "${input.file_path}" を読み込み中`;
-    case 'Write':
-      return description || `ファイル "${input.file_path}" を作成中`;
-    case 'Edit':
-      return description || `ファイル "${input.file_path}" を編集中`;
-    case 'Bash':
-      return description || 'コマンドを実行中';
-    case 'Glob':
-      return description || `パターン "${input.pattern}" でファイルを検索中`;
-    case 'Grep':
-      return description || `"${input.pattern}" を検索中`;
-    case 'WebFetch':
-      return description || 'Webページを取得中';
-    case 'WebSearch':
-      return description || `"${input.query}" を検索中`;
-    default:
-      return description || `${toolName}を実行中`;
-  }
 }
 
 interface ToolExecutionPaneProps {

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -1,0 +1,190 @@
+/**
+ * Utility functions for tool name display
+ *
+ * Handles both Claude Code tool names (Bash, Read, Write, etc.) and
+ * ACP (Agent Communication Protocol) ToolKind values
+ * (execute, other, read, edit, bash, search, fetch, think, etc.)
+ */
+
+/**
+ * Maps a tool name (which may be an ACP ToolKind) to a user-friendly display name.
+ * ACP ToolKinds are lowercase category labels; this function normalizes them into
+ * readable names and tries to extract more specific info from input fields when
+ * the kind is generic ("execute" or "other").
+ */
+export function getToolDisplayName(
+  name: string,
+  input: Record<string, unknown> | null | undefined
+): string {
+  const inp = input ?? {};
+
+  // Handle generic ACP "other" kind: try to find a meaningful name in input fields
+  if (name === 'other') {
+    if (inp.tool_name && typeof inp.tool_name === 'string') return inp.tool_name;
+    if (inp.name && typeof inp.name === 'string') return inp.name;
+    if (inp.title && typeof inp.title === 'string') return inp.title;
+    return 'Other';
+  }
+
+  // Handle ACP "execute" kind: try to be more specific from command
+  if (name === 'execute') {
+    if (inp.command && typeof inp.command === 'string') {
+      const firstWord = inp.command.trim().split(/\s+/)[0];
+      if (firstWord) {
+        // Capitalize first letter of the command for display
+        return firstWord.charAt(0).toUpperCase() + firstWord.slice(1);
+      }
+    }
+    return 'Execute';
+  }
+
+  // Known ACP ToolKind → display name mappings
+  const acpKindMap: Record<string, string> = {
+    'read': 'Read',
+    'edit': 'Edit',
+    'write': 'Write',
+    'delete': 'Delete',
+    'move': 'Move',
+    'search': 'Search',
+    'think': 'Think',
+    'fetch': 'Fetch',
+    'switch_mode': 'SwitchMode',
+    'bash': 'Bash',
+    'str_replace': 'Edit',
+    'create': 'Write',
+    'list': 'List',
+    'run': 'Execute',
+  };
+
+  if (name in acpKindMap) {
+    return acpKindMap[name];
+  }
+
+  // Default: capitalize the first letter (handles unknown names gracefully)
+  if (name.length === 0) return '(tool)';
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * Returns a brief info string for a tool call based on the tool name and input.
+ * This is displayed as secondary text next to the tool name.
+ */
+export function getToolBriefInfo(
+  name: string,
+  input: Record<string, unknown> | null | undefined
+): string | null {
+  if (!input) return null;
+  const maxLength = 40;
+
+  const truncate = (s: string, max: number = maxLength) =>
+    s.length > max ? s.substring(0, max) + '...' : s;
+
+  // description があれば優先
+  if (input.description && typeof input.description === 'string') {
+    return truncate(input.description);
+  }
+
+  // title (ACP specific)
+  if (input.title && typeof input.title === 'string') {
+    return truncate(input.title);
+  }
+
+  // ファイル系のツール
+  if (input.file_path && typeof input.file_path === 'string') {
+    const path = input.file_path;
+    return path.length > maxLength ? '...' + path.substring(path.length - maxLength) : path;
+  }
+
+  // ACP edit/str_replace tools use "path" instead of "file_path"
+  if (input.path && typeof input.path === 'string') {
+    const path = input.path;
+    return path.length > maxLength ? '...' + path.substring(path.length - maxLength) : path;
+  }
+
+  // パターン検索系
+  if (input.pattern && typeof input.pattern === 'string') {
+    return truncate(input.pattern);
+  }
+
+  // 検索クエリ
+  if (input.query && typeof input.query === 'string') {
+    return truncate(input.query);
+  }
+
+  // コマンド系
+  if (input.command && typeof input.command === 'string') {
+    return truncate(input.command);
+  }
+
+  // URL
+  if (input.url && typeof input.url === 'string') {
+    return truncate(input.url);
+  }
+
+  return null;
+}
+
+/**
+ * Returns a longer description of a tool call for display in the ToolExecutionPane.
+ */
+export function getToolDescription(
+  name: string,
+  input: Record<string, unknown> | null | undefined
+): string {
+  const inp = input ?? {};
+  const displayName = getToolDisplayName(name, inp);
+  const description = inp.description as string | undefined;
+  const title = inp.title as string | undefined;
+
+  // Prefer description or title if available
+  if (description) return description;
+  if (title) return title;
+
+  // Tool-specific descriptions
+  const lowerName = name.toLowerCase();
+  switch (lowerName) {
+    case 'task':
+    case 'agent': {
+      const subagentType = inp.subagent_type as string | undefined;
+      if (subagentType) return `${subagentType}を実行中`;
+      return 'サブエージェントを実行中';
+    }
+    case 'read':
+      return `ファイル "${inp.file_path ?? inp.path ?? ''}" を読み込み中`;
+    case 'write':
+    case 'create':
+      return `ファイル "${inp.file_path ?? inp.path ?? ''}" を作成中`;
+    case 'edit':
+    case 'str_replace':
+      return `ファイル "${inp.file_path ?? inp.path ?? ''}" を編集中`;
+    case 'bash':
+    case 'execute':
+    case 'run': {
+      const cmd = inp.command as string | undefined;
+      if (cmd) return truncateStr(cmd, 60);
+      return 'コマンドを実行中';
+    }
+    case 'glob':
+    case 'search':
+    case 'list':
+      return `"${inp.pattern ?? inp.query ?? ''}" を検索中`;
+    case 'grep':
+      return `"${inp.pattern ?? ''}" を検索中`;
+    case 'webfetch':
+    case 'fetch':
+      return `"${inp.url ?? ''}" を取得中`;
+    case 'websearch':
+      return `"${inp.query ?? ''}" を検索中`;
+    case 'think':
+      return '思考中...';
+    case 'other':
+      if (inp.tool_name) return `${inp.tool_name} を実行中`;
+      return 'ツールを実行中';
+    default:
+      return `${displayName}を実行中`;
+  }
+}
+
+function truncateStr(s: string, max: number): string {
+  return s.length > max ? s.substring(0, max) + '...' : s;
+}


### PR DESCRIPTION
## Summary

- ACP (Agent Communication Protocol) セッションで tool 名が `other` や `execute` としか表示されない問題を修正
- `src/utils/toolUtils.ts` を新規作成して tool 名変換ロジックを共有ユーティリティとして切り出し
- `MessageItem.tsx`、`RunningTools.tsx`、`ToolExecutionPane.tsx` がこのユーティリティを利用するよう更新

## 背景

agentapi-proxy の ACP bridge は tool_use メッセージの `name` フィールドに ACP の `ToolKind` を設定する：

| ACP ToolKind | UI の旧表示 | UI の新表示 |
|---|---|---|
| `execute` (Bash コマンド等) | `execute` | コマンド名 (例: `Bash`, `Python`) |
| `other` | `other` | `input.tool_name`/`input.name`/`input.title` を優先使用、なければ `Other` |
| `bash` | `bash` | `Bash` |
| `read` | `read` | `Read` |
| `edit`, `str_replace` | `edit` / `str_replace` | `Edit` |
| `search` | `search` | `Search` |
| `fetch` | `fetch` | `Fetch` |

## 変更内容

### 新規: `src/utils/toolUtils.ts`

- `getToolDisplayName(name, input)` — ACP ToolKind を人間が読めるツール名にマッピング
- `getToolBriefInfo(name, input)` — ACP の `path` フィールドや `title` にも対応
- `getToolDescription(name, input)` — ToolExecutionPane 向けの説明文

### 変更: `MessageItem.tsx` / `RunningTools.tsx` / `ToolExecutionPane.tsx`
- 共有ユーティリティを利用するよう変更（重複コードを削除）

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)