### PR TITLE
feat: agent type 未設定時の SSE 表示更新を1秒間隔にスロットル

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -268,6 +268,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const prevMessagesLengthRef = useRef(0);
   const prevAgentStatusRef = useRef<AgentStatus | null>(null);
   const lastLoadTimeRef = useRef<number>(0);
+  // Throttle refs for rendering when agentType is not set (null) — limit to 1-second intervals
+  const nullAgentRenderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingNullAgentMessagesRef = useRef<SessionMessage[] | null>(null);
+  const lastNullAgentRenderRef = useRef<number>(0);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -534,8 +538,24 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
 
             return [...prevMessages, ...trulyNewMessages];
           });
+        } else if (agentType === null) {
+          // For unknown agent type: throttle re-renders to at most once per second
+          // to prevent the display from updating too rapidly via SSE.
+          pendingNullAgentMessagesRef.current = newMessages;
+          if (!nullAgentRenderTimerRef.current) {
+            const elapsed = Date.now() - lastNullAgentRenderRef.current;
+            const delay = Math.max(0, 1000 - elapsed);
+            nullAgentRenderTimerRef.current = setTimeout(() => {
+              if (pendingNullAgentMessagesRef.current) {
+                setMessages(pendingNullAgentMessagesRef.current);
+                lastNullAgentRenderRef.current = Date.now();
+                pendingNullAgentMessagesRef.current = null;
+              }
+              nullAgentRenderTimerRef.current = null;
+            }, delay);
+          }
         } else {
-          // For other agents: always update with all messages to reflect timeline changes
+          // For other known agents: always update with all messages to reflect timeline changes
           setMessages(newMessages);
         }
       }
@@ -707,6 +727,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       longPollActiveRef.current = false;
       longPollAbortRef.current?.abort();
       fallbackPollingControlRef.current.stop();
+      // Clear any pending throttle timer for null-agent-type rendering
+      if (nullAgentRenderTimerRef.current) {
+        clearTimeout(nullAgentRenderTimerRef.current);
+        nullAgentRenderTimerRef.current = null;
+      }
     };
   }, [isConnected, sessionId]); // pollMessages はref経由で参照するため依存配列に不要
 


### PR DESCRIPTION
## Summary

- `agentType === null`（agent type 未設定）の場合、long-poll で `setMessages` が連続呼び出しされると表示更新が速すぎる問題を修正
- `agentType === null` のケースのみ、最後のレンダリングから1秒が経過するまで更新をバッファリングし、1秒ごとに最新メッセージを適用するよう変更
- `agentType === 'claude'` やその他の既知タイプには影響なし

## 変更内容

**`src/app/components/AgentAPIChat.tsx`**

1. スロットル用 ref を3つ追加:
   - `nullAgentRenderTimerRef` — pending setTimeout のハンドル
   - `pendingNullAgentMessagesRef` — バッファリング中の最新メッセージ
   - `lastNullAgentRenderRef` — 最後にレンダリングした時刻 (Unix ms)

2. `pollMessages` のメッセージ更新ブロックを修正:
   - `agentType === null` のとき `setTimeout` で1秒スロットルを適用
   - 複数の更新が来た場合は最後のものだけ反映（trailing throttle）

3. long-poll の cleanup 関数にタイマーのクリア処理を追加

## Test plan

- [ ] agent type が未設定のセッションでチャット画面を開き、更新が1秒ごとにまとまって反映されることを確認
- [ ] `claude` / `codex` agent type のセッションで従来通りリアルタイム更新されることを確認
- [ ] ページを離れた際にタイマーがクリアされること（メモリリークなし）を確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)