### PR TITLE
fix: チャット画面をロングポーリング→1秒インターバルポーリングに戻す

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -598,117 +598,17 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     setShowQuestionModal(false);
   }, []);
 
-  // Ref to always call the latest version of pollMessages (avoids stale closure in long-poll loop)
-  const pollMessagesRef = useRef(pollMessages);
-  pollMessagesRef.current = pollMessages;
+  // 1秒インターバルポーリング（接続中のみ動作）
+  const pollingControl = useBackgroundAwareInterval(pollMessages, 1000, false);
 
-  // Fallback interval polling — used only when the server returns 501 (long-polling not supported).
-  const fallbackPollingControl = useBackgroundAwareInterval(pollMessages, 5000, true);
-  const fallbackPollingControlRef = useRef(fallbackPollingControl);
-  fallbackPollingControlRef.current = fallbackPollingControl;
-
-  // Long-poll refs
-  const longPollActiveRef = useRef(false);
-  const longPollAbortRef = useRef<AbortController | null>(null);
-  // Tracks the Unix-ms timestamp of the last known message_update.
-  // Passed as `since` to waitSessionMessages so the server can immediately
-  // return updated=true if messages arrived while the client was inactive.
-  const lastMessageTimestampRef = useRef<number | undefined>(undefined);
-
-  // Long-polling loop — replaces 1-second interval polling.
-  // Waits for message_update events from the server via GET /sessions/:sessionId/messages/wait,
-  // then calls pollMessages() to fetch the latest data.
-  // Falls back to 5-second interval polling when the server returns 501 (e.g. local mode).
   useEffect(() => {
-    if (!isConnected || !sessionId) {
-      fallbackPollingControlRef.current.stop();
-      return;
+    if (isConnected && sessionId) {
+      pollingControl.start();
+    } else {
+      pollingControl.stop();
     }
-
-    // Ensure fallback polling is stopped while long-polling is active
-    fallbackPollingControlRef.current.stop();
-
-    longPollActiveRef.current = true;
-    // Record the start time so the first waitSessionMessages call can detect
-    // any update that arrived after we began but before we subscribed.
-    lastMessageTimestampRef.current = Date.now();
-    let backoffMs = 1000;
-    const MAX_BACKOFF = 30_000;
-
-    const runLongPoll = async () => {
-      // Fetch initial state immediately
-      await pollMessagesRef.current();
-
-      while (longPollActiveRef.current) {
-        // Pause when page is hidden; resume and re-fetch when visible again
-        if (document.visibilityState === 'hidden') {
-          await new Promise<void>((resolve) => {
-            const handler = () => {
-              if (document.visibilityState === 'visible') {
-                document.removeEventListener('visibilitychange', handler);
-                resolve();
-              }
-            };
-            document.addEventListener('visibilitychange', handler);
-          });
-          if (!longPollActiveRef.current) break;
-          await pollMessagesRef.current();
-        }
-
-        if (!agentAPIRef.current) break;
-
-        const controller = new AbortController();
-        longPollAbortRef.current = controller;
-
-        try {
-          const result = await agentAPIRef.current.waitSessionMessages(sessionId, {
-            timeout: 30,
-            signal: controller.signal,
-            since: lastMessageTimestampRef.current,
-          });
-
-          if (!longPollActiveRef.current) break;
-
-          if (result.updated) {
-            // Update the cursor before fetching so the next call catches only newer events.
-            lastMessageTimestampRef.current = Date.parse(result.timestamp);
-            await pollMessagesRef.current();
-            backoffMs = 1000; // reset backoff on success
-          }
-          // result.updated === false means server-side timeout → immediately retry
-
-        } catch (err) {
-          if (!longPollActiveRef.current) break;
-          // AbortError means the request was intentionally cancelled
-          if (err instanceof Error && err.name === 'AbortError') break;
-
-          // 501: server does not support long-polling → fall back to interval
-          if (err instanceof AgentAPIProxyError && err.status === 501) {
-            console.info('[LongPoll] Server does not support long-polling, falling back to interval polling');
-            longPollActiveRef.current = false;
-            fallbackPollingControlRef.current.start();
-            return;
-          }
-
-          // 502/503: transient service issues — retry silently
-          if (!(err instanceof AgentAPIProxyError && (err.status === 502 || err.status === 503))) {
-            console.warn('[LongPoll] Error, retrying in', backoffMs, 'ms:', err);
-          }
-          await new Promise(r => setTimeout(r, backoffMs));
-          if (!longPollActiveRef.current) break;
-          backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF);
-        }
-      }
-    };
-
-    runLongPoll();
-
-    return () => {
-      longPollActiveRef.current = false;
-      longPollAbortRef.current?.abort();
-      fallbackPollingControlRef.current.stop();
-    };
-  }, [isConnected, sessionId]); // pollMessages はref経由で参照するため依存配列に不要
+    return () => pollingControl.stop();
+  }, [isConnected, sessionId, pollingControl]);
 
   // Get agent type from /status endpoint
   useEffect(() => {

--- a/src/app/components/SessionListSidebar.tsx
+++ b/src/app/components/SessionListSidebar.tsx
@@ -2,10 +2,9 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { createAgentAPIProxyClientFromStorage, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
+import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
 import { Session, SessionStatus } from '../../types/agentapi'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
-import { useSessionsStatusStream } from '../hooks/useSessionsStatusStream'
 
 interface SessionListSidebarProps {
   currentSessionId: string
@@ -74,31 +73,10 @@ export default function SessionListSidebar({
     }
   }, [client, selectedTeam])
 
-  // SSE でリアルタイム更新: ステータス変化をインプレース反映し、active になったらフルリフレッシュ
-  const handleProxyStatusEvent = useCallback((event: ProxySessionStatusEvent) => {
-    setSessions(prev => {
-      const idx = prev.findIndex(s => s.session_id === event.session_id)
-      if (idx === -1) return prev
-      const updated = [...prev]
-      updated[idx] = { ...updated[idx], status: event.status as SessionStatus }
-      return updated
-    })
-    if (event.status === 'active' || event.status === 'stopped') {
-      fetchSessions()
-    }
-  }, [fetchSessions])
-
-  useSessionsStatusStream({
-    client,
-    onStatusChange: handleProxyStatusEvent,
-    enabled: isVisible,
-  })
-
   useEffect(() => {
     if (!isVisible) return
     fetchSessions()
-    // SSE がリアルタイム更新を担うため、ポーリングは 30 秒に延長
-    const interval = setInterval(fetchSessions, 30000)
+    const interval = setInterval(fetchSessions, 5000)
     return () => clearInterval(interval)
   }, [fetchSessions, isVisible])
 

--- a/src/app/components/SessionListSidebar.tsx
+++ b/src/app/components/SessionListSidebar.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
+import { createAgentAPIProxyClientFromStorage, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
 import { Session, SessionStatus } from '../../types/agentapi'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
+import { useSessionsStatusStream } from '../hooks/useSessionsStatusStream'
 
 interface SessionListSidebarProps {
   currentSessionId: string
@@ -73,10 +74,31 @@ export default function SessionListSidebar({
     }
   }, [client, selectedTeam])
 
+  // SSE でリアルタイム更新: ステータス変化をインプレース反映し、active になったらフルリフレッシュ
+  const handleProxyStatusEvent = useCallback((event: ProxySessionStatusEvent) => {
+    setSessions(prev => {
+      const idx = prev.findIndex(s => s.session_id === event.session_id)
+      if (idx === -1) return prev
+      const updated = [...prev]
+      updated[idx] = { ...updated[idx], status: event.status as SessionStatus }
+      return updated
+    })
+    if (event.status === 'active' || event.status === 'stopped') {
+      fetchSessions()
+    }
+  }, [fetchSessions])
+
+  useSessionsStatusStream({
+    client,
+    onStatusChange: handleProxyStatusEvent,
+    enabled: isVisible,
+  })
+
   useEffect(() => {
     if (!isVisible) return
     fetchSessions()
-    const interval = setInterval(fetchSessions, 5000)
+    // SSE がリアルタイム更新を担うため、ポーリングは 30 秒に延長
+    const interval = setInterval(fetchSessions, 30000)
     return () => clearInterval(interval)
   }, [fetchSessions, isVisible])
 

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { Session, AgentStatus, SessionListParams } from '../../types/agentapi'
-import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
+import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
 import { useBackgroundAwareInterval } from '../hooks/usePageVisibility'
+import { useSessionsStatusStream } from '../hooks/useSessionsStatusStream'
 import { formatDate, formatRelativeTime } from '../../utils/timeUtils'
 import { truncateText } from '../../utils/textUtils'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
@@ -216,34 +217,51 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     return false
   }, [hasCreatingSessions, sessions, sessionAgentStatus])
 
-  // ポーリング間隔: 実行中セッションがある場合は5秒、ない場合は15秒
-  const pollingInterval = hasActiveSession ? 5000 : 15000
+  // SSE でセッションステータス変化を受信したときの処理
+  const handleProxyStatusEvent = useCallback((event: ProxySessionStatusEvent) => {
+    setSessions(prev => {
+      const idx = prev.findIndex(s => s.session_id === event.session_id)
+      if (idx === -1) return prev
+      const updated = [...prev]
+      updated[idx] = { ...updated[idx], status: event.status as Session['status'] }
+      return updated
+    })
 
-  // セッション一覧のサイレントポーリング（セッションの追加・削除・ライフサイクル変化を反映）
-  const sessionsPollingControl = useBackgroundAwareInterval(() => fetchSessions(true), pollingInterval, false)
+    // セッションが active になったタイミングでフルリフレッシュ（メタデータ取得のため）
+    if (event.status === 'active') {
+      fetchSessions()
+    }
+  }, [fetchSessions])
 
-  // エージェントレベルのステータス（running / stable / error）のポーリング
+  // プロキシ全体のセッションステータス SSE ストリーム
+  useSessionsStatusStream({
+    client: agentAPIProxy,
+    onStatusChange: handleProxyStatusEvent,
+  })
+
+  // エージェントステータスポーリング間隔: 実行中セッションがある場合は7秒、ない場合は30秒
+  // （SSE がセッション作成ライフサイクルをカバーするため、ポーリング頻度を下げる）
+  const pollingInterval = hasActiveSession ? 7000 : 30000
+
+  // エージェントレベルのステータス（running / stable / error）は引き続きポーリングで取得
   const statusPollingControl = useBackgroundAwareInterval(fetchSessionStatuses, pollingInterval, false)
 
   useEffect(() => {
     fetchSessions()
   }, [fetchSessions])
 
-  // セッション一覧・エージェントステータスを定期的に更新
+  // エージェントステータスを定期的に更新
   useEffect(() => {
     if (sessions.length > 0) {
-      sessionsPollingControl.start()
       statusPollingControl.start()
     } else {
-      sessionsPollingControl.stop()
       statusPollingControl.stop()
     }
 
     return () => {
-      sessionsPollingControl.stop()
       statusPollingControl.stop()
     }
-  }, [sessions.length, sessionsPollingControl, statusPollingControl])
+  }, [sessions.length, statusPollingControl])
 
 
   useEffect(() => {

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -3,9 +3,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { Session, AgentStatus, SessionListParams } from '../../types/agentapi'
-import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
+import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
 import { useBackgroundAwareInterval } from '../hooks/usePageVisibility'
-import { useSessionsStatusStream } from '../hooks/useSessionsStatusStream'
 import { formatDate, formatRelativeTime } from '../../utils/timeUtils'
 import { truncateText } from '../../utils/textUtils'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
@@ -110,9 +109,9 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     }
   }, [agentAPIProxy])
 
-  const fetchSessions = useCallback(async () => {
+  const fetchSessions = useCallback(async (silent = false) => {
     try {
-      setLoading(true)
+      if (!silent) setLoading(true)
       setError(null)
 
       // Compute scope parameters directly from selectedTeam
@@ -217,51 +216,34 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     return false
   }, [hasCreatingSessions, sessions, sessionAgentStatus])
 
-  // SSE でセッションステータス変化を受信したときの処理
-  const handleProxyStatusEvent = useCallback((event: ProxySessionStatusEvent) => {
-    setSessions(prev => {
-      const idx = prev.findIndex(s => s.session_id === event.session_id)
-      if (idx === -1) return prev
-      const updated = [...prev]
-      updated[idx] = { ...updated[idx], status: event.status as Session['status'] }
-      return updated
-    })
+  // ポーリング間隔: 実行中セッションがある場合は5秒、ない場合は15秒
+  const pollingInterval = hasActiveSession ? 5000 : 15000
 
-    // セッションが active になったタイミングでフルリフレッシュ（メタデータ取得のため）
-    if (event.status === 'active') {
-      fetchSessions()
-    }
-  }, [fetchSessions])
+  // セッション一覧のサイレントポーリング（セッションの追加・削除・ライフサイクル変化を反映）
+  const sessionsPollingControl = useBackgroundAwareInterval(() => fetchSessions(true), pollingInterval, false)
 
-  // プロキシ全体のセッションステータス SSE ストリーム
-  useSessionsStatusStream({
-    client: agentAPIProxy,
-    onStatusChange: handleProxyStatusEvent,
-  })
-
-  // エージェントステータスポーリング間隔: 実行中セッションがある場合は7秒、ない場合は30秒
-  // （SSE がセッション作成ライフサイクルをカバーするため、ポーリング頻度を下げる）
-  const pollingInterval = hasActiveSession ? 7000 : 30000
-
-  // エージェントレベルのステータス（running / stable / error）は引き続きポーリングで取得
+  // エージェントレベルのステータス（running / stable / error）のポーリング
   const statusPollingControl = useBackgroundAwareInterval(fetchSessionStatuses, pollingInterval, false)
 
   useEffect(() => {
     fetchSessions()
   }, [fetchSessions])
 
-  // エージェントステータスを定期的に更新
+  // セッション一覧・エージェントステータスを定期的に更新
   useEffect(() => {
     if (sessions.length > 0) {
+      sessionsPollingControl.start()
       statusPollingControl.start()
     } else {
+      sessionsPollingControl.stop()
       statusPollingControl.stop()
     }
 
     return () => {
+      sessionsPollingControl.stop()
       statusPollingControl.stop()
     }
-  }, [sessions.length, statusPollingControl])
+  }, [sessions.length, sessionsPollingControl, statusPollingControl])
 
 
   useEffect(() => {
@@ -647,7 +629,7 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
           </button>
           <div className="w-px h-6 bg-gray-300 dark:bg-gray-600"></div>
           <button
-            onClick={fetchSessions}
+            onClick={() => fetchSessions()}
             disabled={loading}
             className="inline-flex items-center px-3 py-1.5 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 disabled:opacity-50 font-medium"
           >


### PR DESCRIPTION
## Summary

- **AgentAPIChat**: ロングポーリング (`waitSessionMessages`) を削除し、1秒インターバルポーリングに戻す
- **SessionListSidebar / SessionListView**: SSE (`useSessionsStatusStream`) は変更なし（SSE のまま維持）

## 変更内容

### AgentAPIChat.tsx
- ロングポーリングループ (`runLongPoll`) を削除
- `pollMessagesRef`, `fallbackPollingControlRef`, `longPollActiveRef`, `longPollAbortRef`, `lastMessageTimestampRef` を削除
- `useBackgroundAwareInterval(pollMessages, 1000, false)` で 1秒インターバルポーリングに変更
- 接続中 (`isConnected && sessionId`) のみポーリングを実行

## Test plan

- [ ] チャット画面でメッセージが1秒ごとに更新されることを確認
- [ ] エージェントのステータス変化がリアルタイムに反映されることを確認
- [ ] セッション一覧の SSE は引き続き正常動作することを確認
- [ ] ページが非表示の時はポーリングが停止することを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)