### PR TITLE
feat(acp): ACP ネイティブ HTTP トランスポート対応

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -130,7 +130,12 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 console.log(`[ACP] initializeChat: ACP session detected (acpSessionId=${info.sessionId}), previous acpInfo=${JSON.stringify(acpInfo)}`);
                 setACPInfo(info);
                 setAgentType('acp');
-                setMessages([]);
+
+                // Restore message history from bridge's in-memory store.
+                const history = await agentAPIRef.current!.getACPMessageHistory(sessionId, info.sessionId);
+                setMessages(history);
+                console.log(`[ACP] initializeChat: restored ${history.length} messages from bridge history`);
+
                 setHasMoreMessages(false);
                 setIsInitialLoadComplete(true);
                 setIsStarting(false);

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -115,6 +115,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       }
 
       const initializeChat = async () => {
+        console.log(`[ACP] initializeChat called (sessionId=${sessionId}, existingACPInfo=${JSON.stringify(acpInfo)}, existingEventSource=${acpEventSourceRef.current?.readyState ?? 'none'})`);
         try {
           setError(null);
           setIsConnected(true); // Set connected immediately for better UX
@@ -126,6 +127,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             if (agentAPIRef.current) {
               const info = await agentAPIRef.current.getACPSessionInfo(sessionId);
               if (info) {
+                console.log(`[ACP] initializeChat: ACP session detected (acpSessionId=${info.sessionId}), previous acpInfo=${JSON.stringify(acpInfo)}`);
                 setACPInfo(info);
                 setAgentType('acp');
                 setMessages([]);
@@ -135,8 +137,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
 
                 // Subscribe to ACP SSE stream.
                 if (acpEventSourceRef.current) {
+                  console.log(`[ACP] initializeChat: closing existing EventSource (readyState=${acpEventSourceRef.current.readyState})`);
                   acpEventSourceRef.current.close();
                 }
+                console.log(`[ACP] initializeChat: creating new EventSource for acpSessionId=${info.sessionId}`);
                 acpEventSourceRef.current = agentAPIRef.current.subscribeToACPSessionEvents(
                   sessionId,
                   info.sessionId,
@@ -158,7 +162,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                       setShowQuestionModal(true);
                     },
                     onError: (err) => {
-                      console.error('[ACP] SSE error:', err);
+                      console.error('[ACP] SSE error callback (from AgentAPIChat):', err);
                     },
                   }
                 );

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client';
+import { createAgentAPIProxyClientFromStorage, ACPSessionInfo } from '../../lib/agentapi-proxy-client';
 import { AgentAPIProxyError } from '../../lib/agentapi-proxy-client';
 import { SessionMessage, SessionMessageListResponse, PendingAction } from '../../types/agentapi';
 import { useBackgroundAwareInterval } from '../hooks/usePageVisibility';
@@ -120,6 +120,52 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           setIsConnected(true); // Set connected immediately for better UX
 
           if (sessionId) {
+            // ── ACP session detection ───────────────────────────────────────
+            // Try GET /{sessionId}/session first. If it succeeds, this is an
+            // ACP-transport session – use SSE + JSON-RPC instead of polling.
+            if (agentAPIRef.current) {
+              const info = await agentAPIRef.current.getACPSessionInfo(sessionId);
+              if (info) {
+                setACPInfo(info);
+                setAgentType('acp');
+                setMessages([]);
+                setHasMoreMessages(false);
+                setIsInitialLoadComplete(true);
+                setIsStarting(false);
+
+                // Subscribe to ACP SSE stream.
+                if (acpEventSourceRef.current) {
+                  acpEventSourceRef.current.close();
+                }
+                acpEventSourceRef.current = agentAPIRef.current.subscribeToACPSessionEvents(
+                  sessionId,
+                  info.sessionId,
+                  {
+                    onMessage: (msg) => {
+                      setMessages(prev => [...prev, msg]);
+                    },
+                    onChunk: (msgId, text) => {
+                      setMessages(prev => prev.map(m =>
+                        m.id === msgId ? { ...m, content: m.content + text } : m
+                      ));
+                    },
+                    onStatus: (status) => {
+                      setAgentStatus(status);
+                    },
+                    onPermission: (action, rpcId) => {
+                      setACPPendingPermission({ action, rpcId });
+                      setPendingAction(action);
+                      setShowQuestionModal(true);
+                    },
+                    onError: (err) => {
+                      console.error('[ACP] SSE error:', err);
+                    },
+                  }
+                );
+                return;
+              }
+            }
+
             // Session-based connection: load latest messages
             try {
               if (!agentAPIRef.current) return;
@@ -262,6 +308,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [agentType, setAgentType] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [showQuestionModal, setShowQuestionModal] = useState(false);
+
+  // ACP session state
+  const [acpInfo, setACPInfo] = useState<ACPSessionInfo | null>(null);
+  const [acpPendingPermission, setACPPendingPermission] = useState<{ action: PendingAction; rpcId: number } | null>(null);
+  const acpNextPromptId = useRef(1);
+  const acpEventSourceRef = useRef<EventSource | null>(null);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesTopRef = useRef<HTMLDivElement>(null);
@@ -578,10 +631,23 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     if (!sessionId || !agentAPIRef.current || !pendingAction) return;
 
     try {
-      await agentAPIRef.current.sendAction(sessionId, {
-        type: 'answer_question',
-        answers
-      });
+      if (acpInfo && acpPendingPermission) {
+        // ── ACP: reply to session/request_permission via POST /rpc ───────
+        // answers format: { "0": "selectedOptionLabel" }
+        const selectedLabel = Object.values(answers)[0] as string | undefined;
+        // Find optionId from the pending permission's options.
+        const options = acpPendingPermission.action.content?.questions?.[0]?.options ?? [];
+        const matched = options.find(o => o.label === selectedLabel);
+        const optionId = matched ? matched.label : (selectedLabel ?? '');
+        await agentAPIRef.current.replyToACPPermission(sessionId, acpPendingPermission.rpcId, optionId);
+        setACPPendingPermission(null);
+      } else {
+        // ── Regular session ───────────────────────────────────────────────
+        await agentAPIRef.current.sendAction(sessionId, {
+          type: 'answer_question',
+          answers
+        });
+      }
 
       // Clear pending action and close modal
       setPendingAction(null);
@@ -592,23 +658,33 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         setError(`Failed to submit answers: ${err.message}`);
       }
     }
-  }, [sessionId, pendingAction]);
+  }, [sessionId, pendingAction, acpInfo, acpPendingPermission]);
 
   const handleQuestionModalClose = useCallback(() => {
     setShowQuestionModal(false);
   }, []);
 
-  // 1秒インターバルポーリング（接続中のみ動作）
+  // 1秒インターバルポーリング（接続中かつ非ACPセッションのみ動作）
   const pollingControl = useBackgroundAwareInterval(pollMessages, 1000, false);
 
   useEffect(() => {
-    if (isConnected && sessionId) {
+    if (isConnected && sessionId && !acpInfo) {
       pollingControl.start();
     } else {
       pollingControl.stop();
     }
     return () => pollingControl.stop();
-  }, [isConnected, sessionId, pollingControl]);
+  }, [isConnected, sessionId, acpInfo, pollingControl]);
+
+  // ACP EventSource cleanup on unmount / session change.
+  useEffect(() => {
+    return () => {
+      if (acpEventSourceRef.current) {
+        acpEventSourceRef.current.close();
+        acpEventSourceRef.current = null;
+      }
+    };
+  }, [sessionId]);
 
   // Get agent type from /status endpoint
   useEffect(() => {
@@ -680,14 +756,32 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           setError('AgentAPI client not available');
           return;
         }
-        const sessionMessage = await agentAPIRef.current.sendSessionMessage(sessionId, {
-          content: messageContent,
-          type: messageType
-        });
 
-        // For user messages, add to messages
-        if (messageType === 'user') {
-          setMessages(prev => [...prev, sessionMessage]);
+        if (acpInfo) {
+          // ── ACP session: send via JSON-RPC POST /rpc ──────────────────
+          const promptId = acpNextPromptId.current++;
+          // Add user message locally (ACP echo may arrive via SSE too).
+          const now = new Date().toISOString();
+          setMessages(prev => [...prev, {
+            id: Date.now(),
+            role: 'user',
+            content: messageContent,
+            time: now,
+            type: 'normal',
+          }]);
+          setAgentStatus({ status: 'running' });
+          await agentAPIRef.current.sendACPPrompt(sessionId, acpInfo.sessionId, messageContent, promptId);
+        } else {
+          // ── Regular session ───────────────────────────────────────────
+          const sessionMessage = await agentAPIRef.current.sendSessionMessage(sessionId, {
+            content: messageContent,
+            type: messageType
+          });
+
+          // For user messages, add to messages
+          if (messageType === 'user') {
+            setMessages(prev => [...prev, sessionMessage]);
+          }
         }
       } else {
         setError('No session ID available. Cannot send message.');
@@ -719,7 +813,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     } finally {
       setIsLoading(false);
     }
-  }, [inputValue, isLoading, isConnected, sessionId, agentStatus, loadRecentMessages]);
+  }, [inputValue, isLoading, isConnected, sessionId, agentStatus, loadRecentMessages, acpInfo]);
 
   const handleShowPlanModal = useCallback((content: string) => {
     setPlanContent(content);
@@ -747,10 +841,22 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     setError(null);
 
     try {
-      await agentAPIRef.current.sendAction(sessionId, {
-        type: 'approve_plan',
-        approved
-      });
+      if (acpInfo && acpPendingPermission) {
+        // ACP: approve/reject the pending switch_mode permission request.
+        // "allow-once" (or first allow option) for approve, "plan" for reject.
+        const options = acpPendingPermission.action.content?.questions?.[0]?.options ?? [];
+        const allowOpt = options.find(o => o.description?.includes('allow'));
+        const optionId = approved
+          ? (allowOpt?.label ?? options[0]?.label ?? 'allow-once')
+          : 'plan';
+        await agentAPIRef.current.replyToACPPermission(sessionId, acpPendingPermission.rpcId, optionId);
+        setACPPendingPermission(null);
+      } else {
+        await agentAPIRef.current.sendAction(sessionId, {
+          type: 'approve_plan',
+          approved
+        });
+      }
 
       // モーダルを閉じる
       setShowPlanModal(false);
@@ -768,7 +874,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     } finally {
       setIsLoading(false);
     }
-  }, [sessionId]);
+  }, [sessionId, acpInfo, acpPendingPermission]);
 
   const sendStopSignal = async () => {
     if (!sessionId || !agentAPIRef.current) {
@@ -777,7 +883,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     }
 
     try {
-      if (agentType === 'claude' || agentType === 'codex') {
+      if (acpInfo) {
+        // ACP セッション: session/cancel を JSON-RPC で送信
+        await agentAPIRef.current.cancelACPSession(sessionId, acpInfo.sessionId);
+        console.log('Stop signal sent via ACP session/cancel');
+      } else if (agentType === 'claude' || agentType === 'codex') {
         // agentapi ベースのエージェント（claude, codex）: /action エンドポイントを使用
         await agentAPIRef.current.sendAction(sessionId, { type: 'stop_agent' });
         console.log('Stop signal sent via /action endpoint (agent type:', agentType, ')');

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -1239,7 +1239,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex'}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || agentType === 'claude-acp'}
                   />
                 );
                 processedIds.add(message.id);
@@ -1260,7 +1260,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex'}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || agentType === 'claude-acp'}
                   />
                 );
                 processedIds.add(message.id);

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -769,15 +769,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         if (acpInfo) {
           // ── ACP session: send via JSON-RPC POST /rpc ──────────────────
           const promptId = acpNextPromptId.current++;
-          // Add user message locally (ACP echo may arrive via SSE too).
-          const now = new Date().toISOString();
-          setMessages(prev => [...prev, {
-            id: Date.now(),
-            role: 'user',
-            content: messageContent,
-            time: now,
-            type: 'normal',
-          }]);
+          // Do NOT add the user message locally here.
+          // The bridge broadcasts a synthetic user_message_chunk via SSE,
+          // which will arrive via onMessage and be added to the message list.
           setAgentStatus({ status: 'running' });
           await agentAPIRef.current.sendACPPrompt(sessionId, acpInfo.sessionId, messageContent, promptId);
         } else {

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -331,13 +331,16 @@ function MessageItem({
             }`}></div>
 
             {/* ツール名 */}
-            <span className={`text-xs flex-shrink-0 ${
-              hasResult
-                ? isSuccess
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
-                : 'text-gray-500 dark:text-gray-400'
-            }`}>
+            <span
+              className={`text-xs flex-shrink-0 max-w-[160px] truncate ${
+                hasResult
+                  ? isSuccess
+                    ? 'text-green-600 dark:text-green-400'
+                    : 'text-red-600 dark:text-red-400'
+                  : 'text-gray-500 dark:text-gray-400'
+              }`}
+              title={toolUse.name}
+            >
               {toolUse.name}
             </span>
 

--- a/src/app/components/ToolExecutionPane.tsx
+++ b/src/app/components/ToolExecutionPane.tsx
@@ -141,7 +141,7 @@ export default function ToolExecutionPane({ sessionId, agentStatus }: ToolExecut
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
-                <span className="text-gray-600 dark:text-gray-400">
+                <span className="text-gray-600 dark:text-gray-400 max-w-[300px] truncate" title={getToolDescription(toolUse.name, toolUse.input)}>
                   {getToolDescription(toolUse.name, toolUse.input)}
                 </span>
               </div>

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -149,6 +149,8 @@ export interface ACPSessionUpdate {
   // tool_call / tool_call_update
   toolCallId?: string;
   kind?: string;
+  /** Human-readable tool title (e.g. "Terminal", "Task", "Find …"). Takes precedence over kind. */
+  title?: string;
   status?: string;
   rawInput?: unknown;
   rawOutput?: unknown;
@@ -1758,7 +1760,7 @@ export class AgentAPIProxyClient {
             }
             case 'tool_call': {
               streamingMsgId = null;
-              const toolObj = { type: 'tool_use', name: update.kind || 'tool', id: update.toolCallId, input: update.rawInput ?? {} };
+              const toolObj = { type: 'tool_use', name: update.title || update.kind || 'tool', id: update.toolCallId, input: update.rawInput ?? {} };
               result.push({ id: nextLocalId++, role: 'agent', content: JSON.stringify(toolObj), time: now, type: 'normal', toolUseId: update.toolCallId });
               break;
             }
@@ -1876,7 +1878,9 @@ export class AgentAPIProxyClient {
               streamingMsgId = null;
               const toolObj = {
                 type: 'tool_use',
-                name: update.kind || 'tool',
+                // Use title (human-readable, e.g. "Terminal", "Task") over
+                // kind (e.g. "execute", "think") for a better display name.
+                name: update.title || update.kind || 'tool',
                 id: update.toolCallId,
                 input: update.rawInput ?? {},
               };

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -1707,10 +1707,13 @@ export class AgentAPIProxyClient {
    */
   async getACPSessionInfo(sessionId: string): Promise<ACPSessionInfo | null> {
     try {
+      console.log(`[ACP] getACPSessionInfo called (proxySessionId=${sessionId})`);
       const info = await this.makeRequest<ACPSessionInfo>(`/${sessionId}/session`);
+      console.log(`[ACP] getACPSessionInfo result:`, info);
       if (info?.sessionId) return info;
       return null;
-    } catch {
+    } catch (err) {
+      console.warn(`[ACP] getACPSessionInfo failed (proxySessionId=${sessionId}):`, err);
       return null;
     }
   }
@@ -1743,6 +1746,12 @@ export class AgentAPIProxyClient {
     let nextLocalId = 1;
     // Track the current streaming agent message id (for chunk accumulation).
     let streamingMsgId: number | null = null;
+
+    console.log(`[ACP] EventSource created (url=${sseUrl}, acpSessionId=${acpSessionId})`);
+
+    eventSource.addEventListener('open', () => {
+      console.log(`[ACP] SSE connection opened (url=${sseUrl}, acpSessionId=${acpSessionId})`);
+    });
 
     eventSource.addEventListener('message', (event: MessageEvent) => {
       try {
@@ -1898,11 +1907,17 @@ export class AgentAPIProxyClient {
       }
     });
 
-    eventSource.onerror = () => {
-      if (this.debug) {
-        console.error('[AgentAPIProxy] ACP SSE connection error');
+    eventSource.onerror = (event) => {
+      // EventSource.readyState: 0=CONNECTING, 1=OPEN, 2=CLOSED
+      const state = eventSource.readyState;
+      console.error(`[ACP] SSE onerror (url=${sseUrl}, acpSessionId=${acpSessionId}, readyState=${state})`, event);
+      if (state === EventSource.CLOSED) {
+        console.error(`[ACP] SSE connection permanently closed`);
+      } else {
+        // readyState=CONNECTING means the browser is auto-reconnecting.
+        console.warn(`[ACP] SSE error – browser will auto-reconnect (readyState=${state})`);
       }
-      callbacks.onError(new Error('ACP SSE connection error'));
+      callbacks.onError(new Error(`ACP SSE connection error (readyState=${state})`));
     };
 
     return eventSource;

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -1719,6 +1719,86 @@ export class AgentAPIProxyClient {
   }
 
   /**
+   * Fetch the full message history from the ACP bridge's in-memory store.
+   * Returns parsed SessionMessage array reconstructed from the stored JSON-RPC messages.
+   * Used on reconnect to replay events that arrived before the SSE connection was established.
+   */
+  async getACPMessageHistory(
+    sessionId: string,
+    acpSessionId: string
+  ): Promise<SessionMessage[]> {
+    try {
+      const resp = await this.makeRequest<{ messages: ACPJSONRPCMessage[] }>(`/${sessionId}/messages`);
+      const rawMsgs = resp?.messages ?? [];
+      const result: SessionMessage[] = [];
+      let nextLocalId = Date.now(); // use timestamp-based IDs to avoid collision with SSE ids
+      let streamingMsgId: number | null = null;
+
+      for (const msg of rawMsgs) {
+        const now = new Date().toISOString();
+
+        if (msg.method === 'session/update') {
+          const update = (msg.params as { sessionId: string; update: ACPSessionUpdate })?.update;
+          if (!update) continue;
+
+          switch (update.sessionUpdate) {
+            case 'agent_message_chunk': {
+              const text = acpExtractText(update.content);
+              if (!text) continue;
+              if (streamingMsgId !== null) {
+                // Append to existing streaming message.
+                const idx = result.findIndex(m => m.id === streamingMsgId);
+                if (idx >= 0) result[idx] = { ...result[idx], content: result[idx].content + text };
+              } else {
+                const id = nextLocalId++;
+                streamingMsgId = id;
+                result.push({ id, role: 'agent', content: text, time: now, type: 'normal' });
+              }
+              break;
+            }
+            case 'tool_call': {
+              streamingMsgId = null;
+              const toolObj = { type: 'tool_use', name: update.kind || 'tool', id: update.toolCallId, input: update.rawInput ?? {} };
+              result.push({ id: nextLocalId++, role: 'agent', content: JSON.stringify(toolObj), time: now, type: 'normal', toolUseId: update.toolCallId });
+              break;
+            }
+            case 'tool_call_update': {
+              const isSuccess = update.status === 'completed' || update.status === 'success';
+              const isError = update.status === 'failed' || update.status === 'error';
+              if (!isSuccess && !isError) continue;
+              const content = update.rawOutput != null ? (typeof update.rawOutput === 'string' ? update.rawOutput : JSON.stringify(update.rawOutput)) : '';
+              result.push({ id: nextLocalId++, role: 'tool_result', content, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isSuccess ? 'success' : 'error' });
+              break;
+            }
+            case 'plan': {
+              streamingMsgId = null;
+              if (!update.entries || update.entries.length === 0) continue;
+              result.push({ id: nextLocalId++, role: 'agent', content: acpPlanToMarkdown(update.entries), time: now, type: 'plan' });
+              break;
+            }
+            case 'user_message_chunk': {
+              const text = acpExtractText(update.content);
+              if (!text) continue;
+              result.push({ id: nextLocalId++, role: 'user', content: text, time: now, type: 'normal' });
+              break;
+            }
+            default:
+              streamingMsgId = null;
+          }
+        } else if (msg.result != null || msg.error) {
+          // prompt result/error: reset streaming state
+          streamingMsgId = null;
+        }
+      }
+      console.log(`[ACP] getACPMessageHistory: ${result.length} messages restored`);
+      return result;
+    } catch (err) {
+      console.warn(`[ACP] getACPMessageHistory failed:`, err);
+      return [];
+    }
+  }
+
+  /**
    * Subscribe to ACP session events via SSE at /{sessionId}/sse.
    *
    * The SSE stream emits raw JSON-RPC 2.0 messages from the ACP agent:

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -130,6 +130,95 @@ export class AgentAPIProxyError extends Error {
   }
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// ACP (Agent Client Protocol) types
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Response from GET /{sessionId}/session for ACP sessions. */
+export interface ACPSessionInfo {
+  sessionId: string;
+  status: string;
+}
+
+/** Discriminated union for ACP session/update payloads. */
+export interface ACPSessionUpdate {
+  sessionUpdate: string;
+  // agent_message_chunk / user_message_chunk
+  content?: { type: string; text?: string } | null;
+  messageId?: string;
+  // tool_call / tool_call_update
+  toolCallId?: string;
+  kind?: string;
+  status?: string;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  // plan
+  entries?: Array<{ content: string; status: string; priority: string }>;
+}
+
+/** A permission option offered by the ACP agent. */
+export interface ACPPermissionOption {
+  optionId: string;
+  name: string;
+  kind?: string;
+}
+
+/** Params for session/request_permission (agent → client). */
+export interface ACPPermissionParams {
+  sessionId: string;
+  toolCall: { toolCallId: string; kind?: string };
+  options: ACPPermissionOption[];
+}
+
+/** Raw JSON-RPC 2.0 message envelope received from the SSE stream. */
+export interface ACPJSONRPCMessage {
+  jsonrpc: '2.0';
+  id?: number | string | null;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+/** Callbacks for subscribeToACPSessionEvents. */
+export interface ACPSessionCallbacks {
+  /** Called for each complete or streaming agent message. */
+  onMessage: (message: SessionMessage) => void;
+  /** Called with additional text to append to an existing streaming message. */
+  onChunk: (messageId: number, text: string) => void;
+  /** Called when agent status changes (e.g. prompt turn finished). */
+  onStatus: (status: AgentStatus) => void;
+  /** Called when a permission request arrives from the agent. */
+  onPermission: (action: PendingAction, rpcId: number) => void;
+  /** Called on transport errors. */
+  onError: (error: Error) => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Extract text from an ACP ContentBlock. */
+function acpExtractText(content: ACPSessionUpdate['content']): string {
+  if (!content) return '';
+  if (content.type === 'text' && typeof content.text === 'string') return content.text;
+  return '';
+}
+
+/** Convert ACP plan entries to a Markdown task list. */
+function acpPlanToMarkdown(entries: NonNullable<ACPSessionUpdate['entries']>): string {
+  let md = '## Plan\n\n';
+  for (const e of entries) {
+    const marker =
+      e.status === 'completed' ? '- [x]' :
+      e.status === 'in_progress' ? '- [~]' :
+      e.status === 'cancelled' ? '- [!]' : '- [ ]';
+    const priority =
+      e.priority === 'high' ? ' 🔴' :
+      e.priority === 'low' ? ' 🔵' : '';
+    md += `${marker} ${e.content}${priority}\n`;
+  }
+  return md;
+}
+
 /**
  * AgentAPIProxyClient handles session management and communicates directly with agentapi-proxy.
  */
@@ -1598,6 +1687,285 @@ export class AgentAPIProxyClient {
     }
     return this.makeRequest<{ success: boolean }>(`/files/${encodeURIComponent(fileId)}`, {
       method: 'DELETE',
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // ACP (Agent Client Protocol) HTTP transport
+  //
+  // ACP sessions expose a minimal 2-endpoint HTTP transport instead of the
+  // agentapi-compatible REST API:
+  //
+  //   GET  /{sessionId}/session  – session info (acpSessionId, status)
+  //   POST /{sessionId}/rpc      – JSON-RPC 2.0 messages (client → agent)
+  //   GET  /{sessionId}/sse      – SSE stream of JSON-RPC 2.0 messages (agent → client)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns ACP session info if the session uses ACP transport, null otherwise.
+   * Use this to detect whether a session is ACP-based.
+   */
+  async getACPSessionInfo(sessionId: string): Promise<ACPSessionInfo | null> {
+    try {
+      const info = await this.makeRequest<ACPSessionInfo>(`/${sessionId}/session`);
+      if (info?.sessionId) return info;
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Subscribe to ACP session events via SSE at /{sessionId}/sse.
+   *
+   * The SSE stream emits raw JSON-RPC 2.0 messages from the ACP agent:
+   *   - session/update notifications  → converted to SessionMessage via callbacks.onMessage
+   *   - session/request_permission    → converted to PendingAction via callbacks.onPermission
+   *   - session/prompt result         → signals turn end via callbacks.onStatus({status:'stable'})
+   *
+   * Returns the EventSource; call .close() to unsubscribe.
+   */
+  subscribeToACPSessionEvents(
+    sessionId: string,
+    acpSessionId: string,
+    callbacks: ACPSessionCallbacks
+  ): EventSource {
+    const isUsingProxy = this.baseURL.includes('/api/proxy');
+    const sseUrl = isUsingProxy
+      ? `/api/proxy/${sessionId}/sse`
+      : `${this.baseURL}/${sessionId}/sse`;
+
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] ACP SSE subscribe: ${sseUrl}`);
+    }
+
+    const eventSource = new EventSource(sseUrl);
+    let nextLocalId = 1;
+    // Track the current streaming agent message id (for chunk accumulation).
+    let streamingMsgId: number | null = null;
+
+    eventSource.addEventListener('message', (event: MessageEvent) => {
+      try {
+        const msg: ACPJSONRPCMessage = JSON.parse(event.data);
+
+        if (this.debug) {
+          console.log('[AgentAPIProxy] ACP SSE message:', msg);
+        }
+
+        // ── session/update notification ──────────────────────────────────
+        if (msg.method === 'session/update') {
+          const update = (msg.params as { sessionId: string; update: ACPSessionUpdate })?.update;
+          if (!update) return;
+
+          const now = new Date().toISOString();
+
+          switch (update.sessionUpdate) {
+            case 'agent_message_chunk': {
+              const text = acpExtractText(update.content);
+              if (!text) return;
+
+              if (streamingMsgId !== null) {
+                // Append to existing streaming message.
+                callbacks.onChunk(streamingMsgId, text);
+              } else {
+                // Start a new streaming message.
+                const id = nextLocalId++;
+                streamingMsgId = id;
+                callbacks.onMessage({
+                  id,
+                  role: 'agent',
+                  content: text,
+                  time: now,
+                  type: 'normal',
+                });
+              }
+              break;
+            }
+
+            case 'tool_call': {
+              // Finalize any streaming text before the tool call.
+              streamingMsgId = null;
+              const toolObj = {
+                type: 'tool_use',
+                name: update.kind || 'tool',
+                id: update.toolCallId,
+                input: update.rawInput ?? {},
+              };
+              callbacks.onMessage({
+                id: nextLocalId++,
+                role: 'agent',
+                content: JSON.stringify(toolObj),
+                time: now,
+                type: 'normal',
+                toolUseId: update.toolCallId,
+              });
+              break;
+            }
+
+            case 'tool_call_update': {
+              const isSuccess = update.status === 'completed' || update.status === 'success';
+              const isError = update.status === 'failed' || update.status === 'error';
+              if (!isSuccess && !isError) return;
+
+              const content = update.rawOutput != null
+                ? (typeof update.rawOutput === 'string' ? update.rawOutput : JSON.stringify(update.rawOutput))
+                : '';
+              callbacks.onMessage({
+                id: nextLocalId++,
+                role: 'tool_result',
+                content,
+                time: now,
+                type: 'normal',
+                parentToolUseId: update.toolCallId,
+                status: isSuccess ? 'success' : 'error',
+              });
+              break;
+            }
+
+            case 'plan': {
+              streamingMsgId = null;
+              if (!update.entries || update.entries.length === 0) return;
+              const planMD = acpPlanToMarkdown(update.entries);
+              callbacks.onMessage({
+                id: nextLocalId++,
+                role: 'agent',
+                content: planMD,
+                time: now,
+                type: 'plan',
+              });
+              break;
+            }
+
+            case 'user_message_chunk': {
+              const text = acpExtractText(update.content);
+              if (!text) return;
+              callbacks.onMessage({
+                id: nextLocalId++,
+                role: 'user',
+                content: text,
+                time: now,
+                type: 'normal',
+              });
+              break;
+            }
+          }
+          return;
+        }
+
+        // ── session/request_permission (agent → client RPC) ──────────────
+        if (msg.method === 'session/request_permission' && msg.id != null) {
+          streamingMsgId = null;
+          const params = msg.params as ACPPermissionParams;
+          const action: PendingAction = {
+            type: 'answer_question',
+            tool_use_id: params.toolCall?.toolCallId ?? '',
+            content: {
+              questions: [{
+                question: 'Permission required',
+                header: 'Permission Required',
+                options: (params.options ?? []).map(o => ({
+                  label: o.name || o.optionId,
+                  description: o.kind ?? '',
+                })),
+                multiSelect: false,
+              }],
+            },
+          };
+          callbacks.onPermission(action, msg.id as number);
+          return;
+        }
+
+        // ── Result of session/prompt (turn finished) ──────────────────────
+        if (msg.result != null && msg.id != null) {
+          streamingMsgId = null;
+          callbacks.onStatus({ status: 'stable' });
+          return;
+        }
+
+        // ── Error on session/prompt ───────────────────────────────────────
+        if (msg.error && msg.id != null) {
+          streamingMsgId = null;
+          callbacks.onStatus({ status: 'stable' });
+          callbacks.onError(new Error(msg.error.message));
+          return;
+        }
+
+      } catch (err) {
+        if (this.debug) {
+          console.error('[AgentAPIProxy] ACP SSE parse error:', err);
+        }
+        callbacks.onError(err instanceof Error ? err : new Error('Failed to parse ACP SSE message'));
+      }
+    });
+
+    eventSource.onerror = () => {
+      if (this.debug) {
+        console.error('[AgentAPIProxy] ACP SSE connection error');
+      }
+      callbacks.onError(new Error('ACP SSE connection error'));
+    };
+
+    return eventSource;
+  }
+
+  /**
+   * Send a session/prompt request to the ACP agent.
+   * The result (stopReason) arrives asynchronously via the SSE stream.
+   * @param promptId - JSON-RPC id; correlates the SSE result message.
+   */
+  async sendACPPrompt(
+    sessionId: string,
+    acpSessionId: string,
+    text: string,
+    promptId: number
+  ): Promise<void> {
+    await this.makeRequest<unknown>(`/${sessionId}/rpc`, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: promptId,
+        method: 'session/prompt',
+        params: {
+          sessionId: acpSessionId,
+          prompt: [{ type: 'text', text }],
+        },
+      }),
+    });
+  }
+
+  /**
+   * Reply to a session/request_permission RPC that arrived via SSE.
+   * @param rpcId  - The JSON-RPC id from the SSE message.
+   * @param optionId - The selected option id to send back.
+   */
+  async replyToACPPermission(
+    sessionId: string,
+    rpcId: number,
+    optionId: string
+  ): Promise<void> {
+    await this.makeRequest<unknown>(`/${sessionId}/rpc`, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: rpcId,
+        result: {
+          outcome: { outcome: 'selected', optionId },
+        },
+      }),
+    });
+  }
+
+  /**
+   * Cancel the current ACP session turn.
+   */
+  async cancelACPSession(sessionId: string, acpSessionId: string): Promise<void> {
+    await this.makeRequest<unknown>(`/${sessionId}/rpc`, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/cancel',
+        params: { sessionId: acpSessionId },
+      }),
     });
   }
 }


### PR DESCRIPTION
## Summary

agentapi-proxy の ACP HTTP トランスポート（PR #731）に対応するフロントエンドの変更。

ACP セッション（`POST /rpc` + `GET /sse`）を自動検出し、既存の agentapi-compat API（ポーリング）の代わりに JSON-RPC 2.0 SSE ストリームで通信する。

## 変更内容

### `src/lib/agentapi-proxy-client.ts`

新規型定義：
- `ACPSessionInfo`, `ACPSessionUpdate`, `ACPJSONRPCMessage`, `ACPPermissionParams`, `ACPSessionCallbacks`

新規メソッド（`AgentAPIProxyClient`）：
| メソッド | 説明 |
|---|---|
| `getACPSessionInfo(sessionId)` | `GET /{sessionId}/session` で ACP セッション判定 |
| `subscribeToACPSessionEvents(...)` | SSE 購読 + ACP → SessionMessage 変換 |
| `sendACPPrompt(...)` | `POST /rpc` で `session/prompt` 送信 |
| `replyToACPPermission(...)` | `POST /rpc` でパーミッション応答 |
| `cancelACPSession(...)` | `POST /rpc` で `session/cancel` 送信 |

SSE 変換ロジック：
- `agent_message_chunk` → テキストを既存メッセージに append（ストリーミング表示）
- `tool_call` → `{ type:"tool_use", ... }` JSON を content に持つ SessionMessage
- `tool_call_update` → `role: "tool_result"` SessionMessage
- `plan` → Markdown タスクリスト、`type: "plan"` SessionMessage
- `session/request_permission` → `PendingAction` として `onPermission` に通知

### `src/app/components/AgentAPIChat.tsx`

- 初期化時に `getACPSessionInfo()` で ACP 判定 → ACP なら SSE 購読、ポーリング無効
- `sendMessage` → ACP セッション時は `sendACPPrompt()`
- `handleAnswerSubmit` → ACP パーミッション時は `replyToACPPermission()`
- `handleApprovePlan` → ACP セッション時は `replyToACPPermission()`
- `sendStopSignal` → ACP セッション時は `cancelACPSession()`
- セッション切替・アンマウント時に EventSource をクリーンアップ

## Test plan

- [ ] ACP セッション（`claude-acp` タイプ）で `GET /session` が返ることを確認
- [ ] SSE で `agent_message_chunk` が届き、リアルタイムにテキストが表示されること
- [ ] `session/request_permission` でパーミッションダイアログが表示され、応答できること
- [ ] 停止ボタンで `session/cancel` が送信されること
- [ ] 非 ACP セッション（claude, codex 等）は従来通りポーリングで動作すること

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)