### PR TITLE
feat: スケジュールフォームに環境変数入力を追加

### DIFF
--- a/src/app/components/ScheduleFormModal.tsx
+++ b/src/app/components/ScheduleFormModal.tsx
@@ -39,6 +39,7 @@ export default function ScheduleFormModal({
   const [reuseMessage, setReuseMessage] = useState('')
   const [memoryKeyPairs, setMemoryKeyPairs] = useState<MemoryKeyPair[]>([{ key: '', value: '' }])
   const [showCustomMemory, setShowCustomMemory] = useState(false)
+  const [envVarPairs, setEnvVarPairs] = useState<MemoryKeyPair[]>([{ key: '', value: '' }])
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -61,6 +62,7 @@ export default function ScheduleFormModal({
       const isKnownPreset = !mk || Object.keys(mk).length === 0
         || (Object.keys(mk).length === 1 && mk['schedule_id'] === '{{ .schedule_id }}')
       setShowCustomMemory(!isKnownPreset)
+      setEnvVarPairs(recordToMemoryKeyPairs(editingSchedule.session_config?.environment))
 
       if (editingSchedule.cron_expr) {
         setExecutionType('recurring')
@@ -106,6 +108,7 @@ export default function ScheduleFormModal({
     setReuseMessage('')
     setMemoryKeyPairs([{ key: '', value: '' }])
     setShowCustomMemory(false)
+    setEnvVarPairs([{ key: '', value: '' }])
     setError(null)
   }
 
@@ -188,6 +191,8 @@ export default function ScheduleFormModal({
       if (oneshot) sessionParams.oneshot = true
       const hasParams = Object.keys(sessionParams).length > 0
 
+      const environment = memoryKeyPairsToRecord(envVarPairs)
+
       const scheduleData: CreateScheduleRequest = {
         name: name.trim(),
         timezone,
@@ -196,6 +201,7 @@ export default function ScheduleFormModal({
           tags: repository.trim() ? { repository: repository.trim() } : undefined,
           reuse_session: reuseSession || undefined,
           reuse_message: (reuseSession && reuseMessage.trim()) ? reuseMessage.trim() : undefined,
+          environment: environment || undefined,
         },
         ...scopeParams,
       }
@@ -555,6 +561,22 @@ export default function ScheduleFormModal({
                 />
               </div>
             )}
+          </div>
+
+          {/* Environment Variables */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              環境変数
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+              セッション実行時に渡す環境変数を設定します。
+            </p>
+            <MemoryKeyInput
+              pairs={envVarPairs}
+              onChange={setEnvVarPairs}
+              disabled={isSubmitting}
+              helpText="KEY=VALUE 形式で環境変数を入力してください"
+            />
           </div>
 
           {/* Error */}


### PR DESCRIPTION
## 概要

スケジュール作成・編集フォームに環境変数の入力 UI を追加します。

## 背景

agentapi-proxy 側の `SessionConfig.Environment` は既に実装済みで、スケジュール実行時に環境変数をセッションに渡す機能が完全に動作しています。しかし UI 側でこのフィールドを入力する手段がなかったため、今回追加します。

## 変更内容

- `ScheduleFormModal.tsx`: 環境変数セクションを追加
  - 既存の `MemoryKeyInput` コンポーネントを再利用した KEY=VALUE 形式の入力欄
  - 編集時は既存スケジュールの `session_config.environment` から復元
  - フォームリセット時に環境変数もクリア
  - submit 時に `session_config.environment` に含めて送信

## スクリーンショット

フォームの「セッション間の記憶を有効化する」セクションの下に「環境変数」セクションが追加されます。

## テスト

- [ ] スケジュール新規作成時に環境変数を設定してセッションに渡されることを確認
- [ ] スケジュール編集時に既存の環境変数が正しく表示・編集できることを確認
- [ ] 環境変数が空の場合は `session_config.environment` に含まれないことを確認