### PR TITLE
fix: show proper tool name in ACP tool use display

### DIFF
--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -10,6 +10,8 @@ interface ToolUseContent {
   name: string;
   id: string;
   input: Record<string, unknown>;
+  /** ACP tool title (e.g. full command text or file path summary). Shown in brief info area. */
+  title?: string;
 }
 
 interface ToolResultContent {
@@ -276,10 +278,17 @@ function MessageItem({
     const hasResult = !!toolResult;
 
     if (toolUse) {
-      // ツールの簡易情報を抽出（description, file_path, pattern など）
+      // ツールの簡易情報を抽出（ACP title > description, file_path, pattern など）
       const getBriefInfo = (): string | null => {
         const input = toolUse.input;
         const maxLength = 40;
+
+        // ACP title (コマンド全文やファイルパスのサマリーなど) を最優先で表示
+        if (toolUse.title && typeof toolUse.title === 'string') {
+          return toolUse.title.length > maxLength
+            ? toolUse.title.substring(0, maxLength) + '...'
+            : toolUse.title;
+        }
 
         // description があれば優先
         if (input.description && typeof input.description === 'string') {

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -1784,7 +1784,7 @@ export class AgentAPIProxyClient {
             }
             case 'tool_call': {
               streamingMsgId = null;
-              const toolObj = { type: 'tool_use', name: acpToolDisplayName(update.kind, update.title), id: update.toolCallId, input: update.rawInput ?? {} };
+              const toolObj = { type: 'tool_use', name: acpToolDisplayName(update.kind, update.title), id: update.toolCallId, input: update.rawInput ?? {}, title: update.title };
               result.push({ id: nextLocalId++, role: 'agent', content: JSON.stringify(toolObj), time: now, type: 'normal', toolUseId: update.toolCallId });
               break;
             }
@@ -1907,6 +1907,7 @@ export class AgentAPIProxyClient {
                 name: acpToolDisplayName(update.kind, update.title),
                 id: update.toolCallId,
                 input: update.rawInput ?? {},
+                title: update.title,
               };
               callbacks.onMessage({
                 id: nextLocalId++,

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -158,6 +158,30 @@ export interface ACPSessionUpdate {
   entries?: Array<{ content: string; status: string; priority: string }>;
 }
 
+/**
+ * Maps ACP tool `kind` values to human-readable tool names shown in the UI.
+ * `kind` carries the semantic tool type (e.g. "execute", "read"), while
+ * `title` often contains the full command/path text which is not suitable
+ * as a short display name.
+ */
+const ACP_KIND_TO_NAME: Record<string, string> = {
+  execute: 'Bash',
+  read: 'Read',
+  write: 'Write',
+  search: 'Search',
+  think: 'Think',
+  browse: 'Browser',
+};
+
+/**
+ * Returns a short human-readable tool name for display.
+ * Prefers the kind→name mapping; falls back to title, then kind, then 'tool'.
+ */
+function acpToolDisplayName(kind: string | undefined, title: string | undefined): string {
+  if (kind && ACP_KIND_TO_NAME[kind]) return ACP_KIND_TO_NAME[kind];
+  return title || kind || 'tool';
+}
+
 /** A permission option offered by the ACP agent. */
 export interface ACPPermissionOption {
   optionId: string;
@@ -1760,7 +1784,7 @@ export class AgentAPIProxyClient {
             }
             case 'tool_call': {
               streamingMsgId = null;
-              const toolObj = { type: 'tool_use', name: update.title || update.kind || 'tool', id: update.toolCallId, input: update.rawInput ?? {} };
+              const toolObj = { type: 'tool_use', name: acpToolDisplayName(update.kind, update.title), id: update.toolCallId, input: update.rawInput ?? {} };
               result.push({ id: nextLocalId++, role: 'agent', content: JSON.stringify(toolObj), time: now, type: 'normal', toolUseId: update.toolCallId });
               break;
             }
@@ -1878,9 +1902,9 @@ export class AgentAPIProxyClient {
               streamingMsgId = null;
               const toolObj = {
                 type: 'tool_use',
-                // Use title (human-readable, e.g. "Terminal", "Task") over
-                // kind (e.g. "execute", "think") for a better display name.
-                name: update.title || update.kind || 'tool',
+                // Use kind→name mapping for a proper tool name (e.g. "Bash" for "execute").
+                // title often contains the full command/path text, not a short name.
+                name: acpToolDisplayName(update.kind, update.title),
                 id: update.toolCallId,
                 input: update.rawInput ?? {},
               };


### PR DESCRIPTION
## Summary

- ACP の `tool_call` イベントの `kind` フィールド（`"execute"`, `"read"`, `"search"` など）を人間が読みやすいツール名にマッピングするように修正
- 従来は `title` フィールドを優先していたが、実際には `title` にコマンド全文（例: `"find /repo -name *.go | head -20"`）が入っており、緑色のツール名表示エリアに長い文字列が出ていた
- `kind` ベースのマッピング（`execute→Bash`, `read→Read`, `search→Search`, `think→Think`, `write→Write`, `browse→Browser`）で短くわかりやすいツール名を表示するよう変更

## 変更の詳細

**`src/lib/agentapi-proxy-client.ts`**:
- `ACP_KIND_TO_NAME` マッピングテーブルを追加
- `acpToolDisplayName(kind, title)` ヘルパー関数を追加  
  - `kind` が既知であればマップされた名前を返す
  - 未知の場合は `title → kind → 'tool'` の順でフォールバック
- `getACPMessageHistory` と `subscribeToACPSessionEvents` の2箇所で `name: update.title || update.kind || 'tool'` を `name: acpToolDisplayName(update.kind, update.title)` に変更

## Before / After

| kind | title (実際の値) | Before | After |
|------|-----------------|--------|-------|
| `execute` | `find /repo -name "*.go" \| head -20` | `find /repo -name "*.go" \| head -20` ❌ | `Bash` ✅ |
| `read` | `Read go.mod` | `Read go.mod` | `Read` ✅ |
| `search` | `grep --type=go "template" /repo` | `grep --type=go "template" /repo` ❌ | `Search` ✅ |
| `think` | `Task` | `Task` | `Think` ✅ |

## Test plan

- [ ] 開発環境の ACP セッションで tool use の緑表示に "Bash", "Read", "Search", "Think" などが表示されることを確認
- [ ] lint エラーなし (`npm run lint`)
- [ ] ビルド成功 (`npm run build`)

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)