### PR TITLE
fix(acp): set status running when agent_message_chunk or tool_call arrives

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -140,6 +140,16 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 setIsInitialLoadComplete(true);
                 setIsStarting(false);
 
+                // Fetch current status immediately so the UI reflects running/stable
+                // on reconnect (e.g. user navigated away then came back while the
+                // agent was still processing the provisioner's initial prompt).
+                try {
+                  const currentStatus = await agentAPIRef.current!.getSessionStatus(sessionId);
+                  setAgentStatus(currentStatus);
+                } catch {
+                  // Non-fatal — status will be updated via SSE events.
+                }
+
                 // Subscribe to ACP SSE stream.
                 if (acpEventSourceRef.current) {
                   console.log(`[ACP] initializeChat: closing existing EventSource (readyState=${acpEventSourceRef.current.readyState})`);

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -1879,6 +1879,11 @@ export class AgentAPIProxyClient {
               const text = acpExtractText(update.content);
               if (!text) return;
 
+              // Agent is actively streaming — mark as running so the UI
+              // suppresses input and shows the stop button even when the
+              // prompt was sent by the provisioner (stock session pickup).
+              callbacks.onStatus({ status: 'running' });
+
               if (streamingMsgId !== null) {
                 // Append to existing streaming message.
                 callbacks.onChunk(streamingMsgId, text);
@@ -1900,6 +1905,8 @@ export class AgentAPIProxyClient {
             case 'tool_call': {
               // Finalize any streaming text before the tool call.
               streamingMsgId = null;
+              // Tool is executing — keep the running state.
+              callbacks.onStatus({ status: 'running' });
               const toolObj = {
                 type: 'tool_use',
                 // Use kind→name mapping for a proper tool name (e.g. "Bash" for "execute").


### PR DESCRIPTION
## Summary

- `subscribeToACPSessionEvents` の `agent_message_chunk` と `tool_call` ハンドラに `callbacks.onStatus({ status: 'running' })` を追加
- これにより、stock session pickup 時にプロビジョナーが初回プロンプトを送信した場合でも UI が "running" 状態を検知できるようになる

## Problem

UI は `sendACPPrompt()` を自分で呼んだ時のみ `setAgentStatus({ status: 'running' })` を呼んでいた。stock session では provisioner が初回プロンプトを送信するため、UI はそれを検知できず、stop ボタンの表示と入力フィールドの抑制が機能しなかった。

## Test plan

- [ ] ACP セッションを新規作成し、エージェントが応答中にチャット入力が無効になることを確認
- [ ] stop ボタンが表示されることを確認
- [ ] エージェントの応答が完了したら入力が再び有効になることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)