### PR TITLE
feat(acp): use server-provided timestamp for ACP session/update messages

### DIFF
--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -1761,11 +1761,11 @@ export class AgentAPIProxyClient {
       let streamingMsgId: number | null = null;
 
       for (const msg of rawMsgs) {
-        const now = new Date().toISOString();
-
         if (msg.method === 'session/update') {
-          const update = (msg.params as { sessionId: string; update: ACPSessionUpdate })?.update;
+          const acpParams = msg.params as { sessionId: string; update: ACPSessionUpdate; time?: string };
+          const update = acpParams?.update;
           if (!update) continue;
+          const now = acpParams?.time || new Date().toISOString();
 
           switch (update.sessionUpdate) {
             case 'agent_message_chunk': {
@@ -1869,10 +1869,11 @@ export class AgentAPIProxyClient {
 
         // ── session/update notification ──────────────────────────────────
         if (msg.method === 'session/update') {
-          const update = (msg.params as { sessionId: string; update: ACPSessionUpdate })?.update;
+          const acpParams = msg.params as { sessionId: string; update: ACPSessionUpdate; time?: string };
+          const update = acpParams?.update;
           if (!update) return;
 
-          const now = new Date().toISOString();
+          const now = acpParams?.time || new Date().toISOString();
 
           switch (update.sessionUpdate) {
             case 'agent_message_chunk': {


### PR DESCRIPTION
## Summary

This PR updates `src/lib/agentapi-proxy-client.ts` to read the server-provided `time` field from ACP `session/update` notification params instead of always generating a client-side timestamp.

### Changes

- **`getACPMessageHistory`**: The params cast is updated to include `time?: string`. The `now` variable is now set from `acpParams?.time` with a fallback to `new Date().toISOString()` for backward compatibility.
- **`subscribeToACPSessionEvents`**: Same treatment — the SSE message handler reads `acpParams?.time` first, falling back to `new Date().toISOString()`.

### Motivation

The agentapi-proxy bridge (see takutakahashi/agentapi-proxy#735) now injects a `time` field into `session/update` params:

```json
{ "sessionId": "...", "update": {...}, "time": "2026-05-09T12:34:56Z" }
```

Using the server-provided timestamp ensures that messages replayed from history (`getACPMessageHistory`) and messages received live via SSE (`subscribeToACPSessionEvents`) share consistent, server-authoritative timestamps — which matters for correct ordering and display in the UI.

The fallback to `new Date().toISOString()` ensures backward compatibility with older proxy versions that do not yet emit the `time` field.