### PR TITLE
feat(acp): agent_thought_chunk / in_progress tool updates / mode・コマンド更新に対応

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -168,6 +168,24 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                         m.id === msgId ? { ...m, content: m.content + text } : m
                       ));
                     },
+                    onThoughtChunk: (msgId, thought) => {
+                      setMessages(prev => prev.map(m =>
+                        m.id === msgId ? { ...m, thought: (m.thought ?? '') + thought } : m
+                      ));
+                    },
+                    onToolUpdate: (toolCallId, status) => {
+                      setMessages(prev => prev.map(m =>
+                        m.toolUseId === toolCallId
+                          ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }
+                          : m
+                      ));
+                    },
+                    onModeUpdate: (modeId) => {
+                      console.log('[ACP] current_mode_update:', modeId);
+                    },
+                    onCommandsUpdate: (commands) => {
+                      console.log('[ACP] available_commands_update:', commands);
+                    },
                     onStatus: (status) => {
                       setAgentStatus(status);
                     },
@@ -757,6 +775,24 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               setMessages(prev => prev.map(m =>
                 m.id === msgId ? { ...m, content: m.content + text } : m
               ));
+            },
+            onThoughtChunk: (msgId, thought) => {
+              setMessages(prev => prev.map(m =>
+                m.id === msgId ? { ...m, thought: (m.thought ?? '') + thought } : m
+              ));
+            },
+            onToolUpdate: (toolCallId, status) => {
+              setMessages(prev => prev.map(m =>
+                m.toolUseId === toolCallId
+                  ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }
+                  : m
+              ));
+            },
+            onModeUpdate: (modeId) => {
+              console.log('[ACP] current_mode_update:', modeId);
+            },
+            onCommandsUpdate: (commands) => {
+              console.log('[ACP] available_commands_update:', commands);
             },
             onStatus: (status) => {
               setAgentStatus(status);

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -269,6 +269,7 @@ function MessageItem({
   isClaudeAgent,
 }: MessageItemProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isThoughtExpanded, setIsThoughtExpanded] = useState(false);
 
   // ツール実行の場合（ツール結果も含めて表示）
   if (message.role === 'agent' && message.toolUseId) {
@@ -575,6 +576,30 @@ function MessageItem({
               {formatTimestamp(message.timestamp || message.time || '')}
             </span>
           </div>
+
+          {/* ACP agent thought — collapsible section shown before the main content */}
+          {message.thought && role !== 'user' && (
+            <div className="mb-2 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+              <button
+                onClick={() => setIsThoughtExpanded(!isThoughtExpanded)}
+                className="w-full flex items-center gap-2 px-3 py-1.5 bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors text-left"
+              >
+                <span className="text-sm">💭</span>
+                <span className="flex-1 text-xs font-medium text-gray-500 dark:text-gray-400">
+                  {isThoughtExpanded ? '思考を隠す' : '思考を表示'}
+                </span>
+                <span className="text-xs text-gray-400 dark:text-gray-600">
+                  {isThoughtExpanded ? '▲' : '▼'}
+                </span>
+              </button>
+              {isThoughtExpanded && (
+                <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 italic leading-relaxed border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/50">
+                  <div className="whitespace-pre-wrap break-words">{message.thought}</div>
+                </div>
+              )}
+            </div>
+          )}
+
           <div
             className={`text-gray-700 dark:text-gray-300 ${
               fontSettings.fontFamily === 'monospace' ? 'font-mono' : ''
@@ -596,6 +621,7 @@ function areEqual(prevProps: MessageItemProps, nextProps: MessageItemProps): boo
     prevProps.message.id === nextProps.message.id &&
     prevProps.message.role === nextProps.message.role &&
     prevProps.message.content === nextProps.message.content &&
+    prevProps.message.thought === nextProps.message.thought &&
     prevProps.message.type === nextProps.message.type &&
     prevProps.message.toolUseId === nextProps.message.toolUseId &&
     prevProps.message.parentToolUseId === nextProps.message.parentToolUseId &&

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -577,23 +577,17 @@ function MessageItem({
             </span>
           </div>
 
-          {/* ACP agent thought — collapsible section shown before the main content */}
+          {/* ACP agent thought — subtle collapsible link before the main content */}
           {message.thought && role !== 'user' && (
-            <div className="mb-2 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+            <div className="mb-1">
               <button
                 onClick={() => setIsThoughtExpanded(!isThoughtExpanded)}
-                className="w-full flex items-center gap-2 px-3 py-1.5 bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors text-left"
+                className="text-[11px] text-gray-400 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-500 transition-colors"
               >
-                <span className="text-sm">💭</span>
-                <span className="flex-1 text-xs font-medium text-gray-500 dark:text-gray-400">
-                  {isThoughtExpanded ? '思考を隠す' : '思考を表示'}
-                </span>
-                <span className="text-xs text-gray-400 dark:text-gray-600">
-                  {isThoughtExpanded ? '▲' : '▼'}
-                </span>
+                💭 {isThoughtExpanded ? '思考を隠す' : '思考を表示'}
               </button>
               {isThoughtExpanded && (
-                <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 italic leading-relaxed border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/50">
+                <div className="mt-1 pl-2 border-l border-gray-200 dark:border-gray-700 text-xs text-gray-400 dark:text-gray-500 italic leading-relaxed">
                   <div className="whitespace-pre-wrap break-words">{message.thought}</div>
                 </div>
               )}

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -143,7 +143,7 @@ export interface ACPSessionInfo {
 /** Discriminated union for ACP session/update payloads. */
 export interface ACPSessionUpdate {
   sessionUpdate: string;
-  // agent_message_chunk / user_message_chunk
+  // agent_message_chunk / user_message_chunk / agent_thought_chunk
   content?: { type: string; text?: string } | null;
   messageId?: string;
   // tool_call / tool_call_update
@@ -152,10 +152,16 @@ export interface ACPSessionUpdate {
   /** Human-readable tool title (e.g. "Terminal", "Task", "Find …"). Takes precedence over kind. */
   title?: string;
   status?: string;
+  /** File/location hints emitted with tool_call (matches ACP ToolCallInfo.locations). */
+  locations?: Array<{ path: string }>;
   rawInput?: unknown;
   rawOutput?: unknown;
   // plan
   entries?: Array<{ content: string; status: string; priority: string }>;
+  // current_mode_update
+  modeId?: string;
+  // available_commands_update
+  availableCommands?: Array<{ name: string; description: string; input?: { hint?: string } }>;
 }
 
 /**
@@ -212,6 +218,24 @@ export interface ACPSessionCallbacks {
   onMessage: (message: SessionMessage) => void;
   /** Called with additional text to append to an existing streaming message. */
   onChunk: (messageId: number, text: string) => void;
+  /**
+   * Called with additional thought text to append to an existing streaming message.
+   * The thought is displayed in a collapsible "Thinking…" section.
+   */
+  onThoughtChunk: (messageId: number, thought: string) => void;
+  /**
+   * Called when a tool call's status changes to in_progress.
+   * The message with matching toolUseId should update its visual state.
+   */
+  onToolUpdate?: (toolCallId: string, status: string) => void;
+  /**
+   * Called when the agent switches to a different mode (current_mode_update).
+   */
+  onModeUpdate?: (modeId: string) => void;
+  /**
+   * Called when the agent advertises its slash-command list (available_commands_update).
+   */
+  onCommandsUpdate?: (commands: Array<{ name: string; description: string; hint?: string }>) => void;
   /** Called when agent status changes (e.g. prompt turn finished). */
   onStatus: (status: AgentStatus) => void;
   /** Called when a permission request arrives from the agent. */
@@ -1782,15 +1806,39 @@ export class AgentAPIProxyClient {
               }
               break;
             }
+            case 'agent_thought_chunk': {
+              const thought = acpExtractText(update.content);
+              if (!thought) continue;
+              if (streamingMsgId !== null) {
+                // Append thought to existing streaming message.
+                const idx = result.findIndex(m => m.id === streamingMsgId);
+                if (idx >= 0) result[idx] = { ...result[idx], thought: (result[idx].thought ?? '') + thought };
+              } else {
+                // Start a new message that begins with thought (content filled later).
+                const id = nextLocalId++;
+                streamingMsgId = id;
+                result.push({ id, role: 'agent', content: '', thought, time: now, type: 'normal' });
+              }
+              break;
+            }
             case 'tool_call': {
               streamingMsgId = null;
-              const toolObj = { type: 'tool_use', name: acpToolDisplayName(update.kind, update.title), id: update.toolCallId, input: update.rawInput ?? {}, title: update.title };
+              const toolObj = {
+                type: 'tool_use',
+                name: acpToolDisplayName(update.kind, update.title),
+                id: update.toolCallId,
+                input: update.rawInput ?? {},
+                title: update.title,
+                locations: update.locations,
+              };
               result.push({ id: nextLocalId++, role: 'agent', content: JSON.stringify(toolObj), time: now, type: 'normal', toolUseId: update.toolCallId });
               break;
             }
             case 'tool_call_update': {
               const isSuccess = update.status === 'completed' || update.status === 'success';
               const isError = update.status === 'failed' || update.status === 'error';
+              // in_progress: update the existing tool call message in-place (no new message needed for history replay)
+              if (update.status === 'in_progress') continue;
               if (!isSuccess && !isError) continue;
               const content = update.rawOutput != null ? (typeof update.rawOutput === 'string' ? update.rawOutput : JSON.stringify(update.rawOutput)) : '';
               result.push({ id: nextLocalId++, role: 'tool_result', content, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isSuccess ? 'success' : 'error' });
@@ -1903,6 +1951,29 @@ export class AgentAPIProxyClient {
               break;
             }
 
+            case 'agent_thought_chunk': {
+              const thought = acpExtractText(update.content);
+              if (!thought) return;
+
+              // Thought chunks always belong to the current streaming message.
+              // If there is none yet, start one (content can be filled later).
+              if (streamingMsgId === null) {
+                const id = nextLocalId++;
+                streamingMsgId = id;
+                callbacks.onMessage({
+                  id,
+                  role: 'agent',
+                  content: '',
+                  thought,
+                  time: now,
+                  type: 'normal',
+                });
+              } else {
+                callbacks.onThoughtChunk(streamingMsgId, thought);
+              }
+              break;
+            }
+
             case 'tool_call': {
               // Finalize any streaming text before the tool call.
               streamingMsgId = null;
@@ -1916,6 +1987,7 @@ export class AgentAPIProxyClient {
                 id: update.toolCallId,
                 input: update.rawInput ?? {},
                 title: update.title,
+                locations: update.locations,
               };
               callbacks.onMessage({
                 id: nextLocalId++,
@@ -1931,6 +2003,14 @@ export class AgentAPIProxyClient {
             case 'tool_call_update': {
               const isSuccess = update.status === 'completed' || update.status === 'success';
               const isError = update.status === 'failed' || update.status === 'error';
+              const isInProgress = update.status === 'in_progress';
+
+              if (isInProgress) {
+                // Notify the UI so it can update the tool card's visual state.
+                callbacks.onToolUpdate?.(update.toolCallId ?? '', 'in_progress');
+                return;
+              }
+
               if (!isSuccess && !isError) return;
 
               const content = update.rawOutput != null
@@ -1972,6 +2052,25 @@ export class AgentAPIProxyClient {
                 time: now,
                 type: 'normal',
               });
+              break;
+            }
+
+            case 'current_mode_update': {
+              if (update.modeId) {
+                callbacks.onModeUpdate?.(update.modeId);
+              }
+              break;
+            }
+
+            case 'available_commands_update': {
+              if (update.availableCommands && Array.isArray(update.availableCommands)) {
+                const commands = update.availableCommands.map(cmd => ({
+                  name: cmd.name,
+                  description: cmd.description,
+                  hint: cmd.input?.hint,
+                }));
+                callbacks.onCommandsUpdate?.(commands);
+              }
               break;
             }
           }

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -216,6 +216,8 @@ export interface SessionMessage {
   id: number; // Changed from string to number (matches API spec)
   role: 'user' | 'assistant' | 'system' | 'tool_result' | 'agent';
   content: string;
+  /** Agent thinking / reasoning text (ACP agent_thought_chunk). Shown in a collapsible section. */
+  thought?: string;
   timestamp?: string; // Made optional (for backwards compatibility)
   time: string; // ISO 8601 timestamp from API
   session_id?: string; // Made optional (not in API spec)


### PR DESCRIPTION
## Summary

formulahendry/acp-ui の実装を参考に、ACP セッションのメッセージ処理に不足していた機能を追加します。

- **`agent_thought_chunk` 対応** (`SessionMessage.thought` フィールドを追加)
  - エージェントの思考テキストをメッセージに蓄積し、UI では 💭 折りたたみセクションとして表示
  - `subscribeToACPSessionEvents` / `getACPMessageHistory` の両方で処理
- **`tool_call_update` の `in_progress` ステータス対応**
  - `in_progress` 状態を無視していたのを `onToolUpdate` コールバックで通知するよう修正
- **`current_mode_update` 対応**
  - エージェント側からのモード切替通知を `onModeUpdate` コールバックで受信
- **`available_commands_update` 対応**
  - スラッシュコマンド一覧の更新通知を `onCommandsUpdate` コールバックで受信
- **`ACPSessionUpdate` 型に `locations` / `modeId` / `availableCommands` を追加**
- **`tool_call` に `locations` フィールドを伝播**

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/types/agentapi.ts` | `SessionMessage.thought?: string` を追加 |
| `src/lib/agentapi-proxy-client.ts` | 型拡張 + SSE ハンドラ / 履歴復元ロジックを更新 |
| `src/app/components/AgentAPIChat.tsx` | 初回・visibility 再接続の SSE 購読に新コールバックを配線 |
| `src/app/components/MessageItem.tsx` | 💭 思考折りたたみ UI を追加、`areEqual` に `thought` を追加 |

## Test plan

- [ ] ACP セッションで思考チャンク (`agent_thought_chunk`) が届いたとき、メッセージに「思考を表示」ボタンが表示されることを確認
- [ ] ツール実行中 (`tool_call_update` `in_progress`) に UI が更新されることを確認
- [ ] 非 ACP セッションの動作が従来どおりであることを確認
- [ ] ページを閉じて再表示したとき、思考テキストが復元されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)