### PR TITLE
fix(acp): enable markdown rendering for Claude-based ACP sessions

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -146,6 +146,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 try {
                   const currentStatus = await agentAPIRef.current!.getSessionStatus(sessionId);
                   setAgentStatus(currentStatus);
+                  // Update agentType so markdown renders for Claude-based ACP sessions.
+                  // getACPSessionInfo hardcodes 'acp', but agent_type from status is authoritative.
+                  if (currentStatus.agent_type === 'claude' || currentStatus.agent_type === 'claude-acp') {
+                    setAgentType('claude-acp');
+                  } else if (currentStatus.agent_type) {
+                    setAgentType(currentStatus.agent_type);
+                  }
                 } catch {
                   // Non-fatal — status will be updated via SSE events.
                 }

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -146,11 +146,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 try {
                   const currentStatus = await agentAPIRef.current!.getSessionStatus(sessionId);
                   setAgentStatus(currentStatus);
-                  // Update agentType so markdown renders for Claude-based ACP sessions.
+                  // Update agentType so markdown renders for ACP sessions.
                   // getACPSessionInfo hardcodes 'acp', but agent_type from status is authoritative.
-                  if (currentStatus.agent_type === 'claude' || currentStatus.agent_type === 'claude-acp') {
-                    setAgentType('claude-acp');
-                  } else if (currentStatus.agent_type) {
+                  if (currentStatus.agent_type) {
                     setAgentType(currentStatus.agent_type);
                   }
                 } catch {
@@ -1367,7 +1365,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || agentType === 'claude-acp'}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || (!!agentType && agentType.includes('acp'))}
                   />
                 );
                 processedIds.add(message.id);
@@ -1388,7 +1386,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || agentType === 'claude-acp'}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || (!!agentType && agentType.includes('acp'))}
                   />
                 );
                 processedIds.add(message.id);


### PR DESCRIPTION
## Summary

- ACP セッション検出時、`getACPSessionInfo` が `agentType` を常に `'acp'` にハードコードしていた
- `isClaudeAgent` 条件が `'claude' | 'codex' | 'claude-acp'` をチェックするため、`'acp'` はマッチせず markdown が一切レンダリングされなかった
- `getSessionStatus` で既に `agent_type` を取得しているのに ACP ブランチでは利用していなかった

## Fix

`getSessionStatus` の結果から `agent_type` を読み取り、Claude ベースの ACP セッションには `claude-acp` をセットするよう修正。

## Test plan

- [ ] ACP セッションを開き、Claude が markdown を含むレスポンスを返したとき正しくレンダリングされることを確認
- [ ] `agent_type` が `claude` / `claude-acp` 以外の ACP セッションでは従来通り plain text 表示になることを確認
- [ ] 通常の非 ACP セッション（claude / codex）の markdown レンダリングに影響がないことを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)