### PR TITLE
fix(acp): ACP ツール結果表示の修正（ContentBlock対応・runningステータス対応）

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -185,6 +185,20 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                           : m
                       ));
                     },
+                    onToolInputUpdate: (toolCallId, input, title, locations) => {
+                      setMessages(prev => prev.map(m => {
+                        if (m.toolUseId !== toolCallId) return m;
+                        try {
+                          const toolObj = JSON.parse(m.content || '{}');
+                          return { ...m, content: JSON.stringify({
+                            ...toolObj,
+                            input,
+                            ...(title != null ? { title } : {}),
+                            ...(locations != null ? { locations } : {}),
+                          })};
+                        } catch { return m; }
+                      }));
+                    },
                     onModeUpdate: (modeId) => {
                       console.log('[ACP] current_mode_update:', modeId);
                     },
@@ -792,6 +806,20 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }
                   : m
               ));
+            },
+            onToolInputUpdate: (toolCallId, input, title, locations) => {
+              setMessages(prev => prev.map(m => {
+                if (m.toolUseId !== toolCallId) return m;
+                try {
+                  const toolObj = JSON.parse(m.content || '{}');
+                  return { ...m, content: JSON.stringify({
+                    ...toolObj,
+                    input,
+                    ...(title != null ? { title } : {}),
+                    ...(locations != null ? { locations } : {}),
+                  })};
+                } catch { return m; }
+              }));
             },
             onModeUpdate: (modeId) => {
               console.log('[ACP] current_mode_update:', modeId);

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -146,6 +146,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 try {
                   const currentStatus = await agentAPIRef.current!.getSessionStatus(sessionId);
                   setAgentStatus(currentStatus);
+                  // Update agentType so markdown renders for Claude-based ACP sessions.
+                  // getACPSessionInfo hardcodes 'acp', but agent_type from status is authoritative.
+                  if (currentStatus.agent_type === 'claude' || currentStatus.agent_type === 'claude-acp') {
+                    setAgentType('claude-acp');
+                  } else if (currentStatus.agent_type) {
+                    setAgentType(currentStatus.agent_type);
+                  }
                 } catch {
                   // Non-fatal — status will be updated via SSE events.
                 }

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -146,11 +146,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 try {
                   const currentStatus = await agentAPIRef.current!.getSessionStatus(sessionId);
                   setAgentStatus(currentStatus);
-                  // Update agentType so markdown renders for Claude-based ACP sessions.
+                  // Update agentType so markdown renders for ACP sessions.
                   // getACPSessionInfo hardcodes 'acp', but agent_type from status is authoritative.
-                  if (currentStatus.agent_type === 'claude' || currentStatus.agent_type === 'claude-acp') {
-                    setAgentType('claude-acp');
-                  } else if (currentStatus.agent_type) {
+                  if (currentStatus.agent_type) {
                     setAgentType(currentStatus.agent_type);
                   }
                 } catch {
@@ -1367,7 +1365,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || agentType === 'claude-acp'}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || (!!agentType && agentType.includes('acp'))}
                   />
                 );
                 processedIds.add(message.id);
@@ -1388,7 +1386,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || agentType === 'claude-acp'}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || (!!agentType && agentType.includes('acp'))}
                   />
                 );
                 processedIds.add(message.id);

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -143,8 +143,12 @@ export interface ACPSessionInfo {
 /** Discriminated union for ACP session/update payloads. */
 export interface ACPSessionUpdate {
   sessionUpdate: string;
-  // agent_message_chunk / user_message_chunk / agent_thought_chunk
-  content?: { type: string; text?: string } | null;
+  // agent_message_chunk / user_message_chunk / agent_thought_chunk:
+  //   content = { type: "text", text: "..." }
+  // tool_call / tool_call_update:
+  //   content = [{ type: "content"|"diff"|"terminal", content?: {type,text}, ... }]
+  //   (ACP ToolCallContent[] — use extractACPToolContent() to get text)
+  content?: unknown;
   messageId?: string;
   // tool_call / tool_call_update
   toolCallId?: string;
@@ -153,8 +157,10 @@ export interface ACPSessionUpdate {
   title?: string;
   status?: string;
   /** File/location hints emitted with tool_call (matches ACP ToolCallInfo.locations). */
-  locations?: Array<{ path: string }>;
+  locations?: Array<{ path: string; line?: number }>;
+  /** Raw tool input (Anthropic SDK format). May be empty {} on streaming start; full input arrives in subsequent tool_call_update. */
   rawInput?: unknown;
+  /** Raw tool output (Anthropic SDK format). Prefer content[] for display; rawOutput may contain non-text blocks. */
   rawOutput?: unknown;
   // plan
   entries?: Array<{ content: string; status: string; priority: string }>;
@@ -229,6 +235,16 @@ export interface ACPSessionCallbacks {
    */
   onToolUpdate?: (toolCallId: string, status: string) => void;
   /**
+   * Called when a tool call's input is updated (step 2 of the 3-step ACP sequence).
+   * The message with matching toolUseId should patch its input/title/locations.
+   */
+  onToolInputUpdate?: (
+    toolCallId: string,
+    input: unknown,
+    title?: string,
+    locations?: Array<{ path: string; line?: number }>
+  ) => void;
+  /**
    * Called when the agent switches to a different mode (current_mode_update).
    */
   onModeUpdate?: (modeId: string) => void;
@@ -246,11 +262,36 @@ export interface ACPSessionCallbacks {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Extract text from an ACP ContentBlock. */
-function acpExtractText(content: ACPSessionUpdate['content']): string {
-  if (!content) return '';
-  if (content.type === 'text' && typeof content.text === 'string') return content.text;
+/** Extract text from an ACP ContentBlock (used for agent/user message chunks). */
+function acpExtractText(content: unknown): string {
+  if (!content || typeof content !== 'object' || Array.isArray(content)) return '';
+  const obj = content as Record<string, unknown>;
+  if (obj.type === 'text' && typeof obj.text === 'string') return obj.text;
   return '';
+}
+
+/**
+ * Extract human-readable text from an ACP ToolCallContent array.
+ * claude-agent-acp sends tool results via this content array (not rawOutput)
+ * with each item having type "content" | "diff" | "terminal".
+ */
+function extractACPToolContent(content: unknown): string {
+  if (!content || !Array.isArray(content)) return '';
+  const texts: string[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== 'object') continue;
+    const obj = item as Record<string, unknown>;
+    if (obj.type === 'content') {
+      // { type: "content", content: { type: "text", text: "..." } }
+      const inner = obj.content as Record<string, unknown> | undefined;
+      if (inner && typeof inner.text === 'string') texts.push(inner.text);
+    } else if (obj.type === 'diff') {
+      // { type: "diff", path: "...", newText: "..." }
+      if (typeof obj.newText === 'string') texts.push(obj.newText);
+    }
+    // "terminal" type: skip (has no text)
+  }
+  return texts.join('\n');
 }
 
 /**
@@ -1870,12 +1911,37 @@ export class AgentAPIProxyClient {
               // Proxy sends "running"; ACP spec also defines "in_progress"
               const isRunning = update.status === 'running' || update.status === 'in_progress';
               if (isRunning) continue;
+
+              // Step 2: rawInput refinement update (no status, no output).
+              // claude-agent-acp sends this after streaming to patch the initial empty rawInput.
               if (!isSuccess && !isError) {
-                // Unknown status: if rawOutput is present, treat as success so the result is shown.
-                if (update.rawOutput == null) continue;
+                const hasOutput = update.rawOutput != null || extractACPToolContent(update.content) !== '';
+                if (!hasOutput) {
+                  // Patch the most recent tool_call message for this toolCallId.
+                  if (update.rawInput != null && update.toolCallId) {
+                    let idx = -1;
+                    for (let i = result.length - 1; i >= 0; i--) {
+                      if (result[i].toolUseId === update.toolCallId) { idx = i; break; }
+                    }
+                    if (idx >= 0) {
+                      try {
+                        const toolObj = JSON.parse(result[idx].content);
+                        toolObj.input = update.rawInput;
+                        if (update.title) toolObj.title = update.title;
+                        if (update.locations) toolObj.locations = update.locations;
+                        result[idx] = { ...result[idx], content: JSON.stringify(toolObj) };
+                      } catch { /* ignore parse errors */ }
+                    }
+                  }
+                  continue;
+                }
               }
-              const content = extractRawOutputText(update.rawOutput);
-              result.push({ id: nextLocalId++, role: 'tool_result', content, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isError ? 'error' : 'success' });
+
+              // Step 3: result update (status = completed/failed, or content/rawOutput present).
+              // Prefer ACP content[] over rawOutput (rawOutput may contain non-text Anthropic blocks).
+              const acpText = extractACPToolContent(update.content);
+              const resultContent = acpText || extractRawOutputText(update.rawOutput);
+              result.push({ id: nextLocalId++, role: 'tool_result', content: resultContent, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isError ? 'error' : 'success' });
               break;
             }
             case 'plan': {
@@ -2046,16 +2112,29 @@ export class AgentAPIProxyClient {
                 return;
               }
 
+              // Step 2: rawInput patch (no status, no output yet)
               if (!isSuccess && !isError) {
-                // Unknown status: if rawOutput is present, treat as success so the result is shown.
-                if (update.rawOutput == null) return;
+                const hasOutput = update.rawOutput != null || extractACPToolContent(update.content) !== '';
+                if (!hasOutput) {
+                  if (update.rawInput != null && update.toolCallId) {
+                    callbacks.onToolInputUpdate?.(
+                      update.toolCallId,
+                      update.rawInput,
+                      update.title,
+                      update.locations,
+                    );
+                  }
+                  return;
+                }
               }
 
-              const content = extractRawOutputText(update.rawOutput);
+              // Step 3: result — prefer ACP content[] over rawOutput
+              const acpText = extractACPToolContent(update.content);
+              const resultContent = acpText || extractRawOutputText(update.rawOutput);
               callbacks.onMessage({
                 id: nextLocalId++,
                 role: 'tool_result',
-                content,
+                content: resultContent,
                 time: now,
                 type: 'normal',
                 parentToolUseId: update.toolCallId,

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -253,6 +253,26 @@ function acpExtractText(content: ACPSessionUpdate['content']): string {
   return '';
 }
 
+/**
+ * Extract human-readable text from rawOutput.
+ * rawOutput can be a string, an array of {text} objects (ACP think/explore tools),
+ * or an arbitrary object. Falls back to JSON.stringify for unknown shapes.
+ */
+function extractRawOutputText(rawOutput: unknown): string {
+  if (rawOutput == null) return '';
+  if (typeof rawOutput === 'string') return rawOutput;
+  if (Array.isArray(rawOutput)) {
+    return rawOutput
+      .map(item => {
+        if (typeof item === 'string') return item;
+        if (item && typeof item.text === 'string') return item.text;
+        return JSON.stringify(item);
+      })
+      .join('\n');
+  }
+  return JSON.stringify(rawOutput);
+}
+
 /** Convert ACP plan entries to a Markdown task list. */
 function acpPlanToMarkdown(entries: NonNullable<ACPSessionUpdate['entries']>): string {
   let md = '## Plan\n\n';
@@ -1840,7 +1860,7 @@ export class AgentAPIProxyClient {
               // in_progress: update the existing tool call message in-place (no new message needed for history replay)
               if (update.status === 'in_progress') continue;
               if (!isSuccess && !isError) continue;
-              const content = update.rawOutput != null ? (typeof update.rawOutput === 'string' ? update.rawOutput : JSON.stringify(update.rawOutput)) : '';
+              const content = extractRawOutputText(update.rawOutput);
               result.push({ id: nextLocalId++, role: 'tool_result', content, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isSuccess ? 'success' : 'error' });
               break;
             }
@@ -2013,9 +2033,7 @@ export class AgentAPIProxyClient {
 
               if (!isSuccess && !isError) return;
 
-              const content = update.rawOutput != null
-                ? (typeof update.rawOutput === 'string' ? update.rawOutput : JSON.stringify(update.rawOutput))
-                : '';
+              const content = extractRawOutputText(update.rawOutput);
               callbacks.onMessage({
                 id: nextLocalId++,
                 role: 'tool_result',

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -255,8 +255,11 @@ function acpExtractText(content: ACPSessionUpdate['content']): string {
 
 /**
  * Extract human-readable text from rawOutput.
- * rawOutput can be a string, an array of {text} objects (ACP think/explore tools),
- * or an arbitrary object. Falls back to JSON.stringify for unknown shapes.
+ * rawOutput can be:
+ *   - string: returned as-is
+ *   - Array of {text} or {type, text} ContentBlock objects (ACP think/explore tools)
+ *   - Single {text} or {type, text} ContentBlock object
+ *   - Arbitrary object: falls back to JSON.stringify
  */
 function extractRawOutputText(rawOutput: unknown): string {
   if (rawOutput == null) return '';
@@ -265,10 +268,17 @@ function extractRawOutputText(rawOutput: unknown): string {
     return rawOutput
       .map(item => {
         if (typeof item === 'string') return item;
-        if (item && typeof item.text === 'string') return item.text;
+        if (item && typeof (item as Record<string, unknown>).text === 'string') {
+          return (item as Record<string, unknown>).text as string;
+        }
         return JSON.stringify(item);
       })
       .join('\n');
+  }
+  // Handle single ContentBlock object {type: "text", text: "..."} or {text: "..."}
+  const obj = rawOutput as Record<string, unknown>;
+  if (typeof obj.text === 'string') {
+    return obj.text;
   }
   return JSON.stringify(rawOutput);
 }
@@ -1857,11 +1867,15 @@ export class AgentAPIProxyClient {
             case 'tool_call_update': {
               const isSuccess = update.status === 'completed' || update.status === 'success';
               const isError = update.status === 'failed' || update.status === 'error';
-              // in_progress: update the existing tool call message in-place (no new message needed for history replay)
-              if (update.status === 'in_progress') continue;
-              if (!isSuccess && !isError) continue;
+              // Proxy sends "running"; ACP spec also defines "in_progress"
+              const isRunning = update.status === 'running' || update.status === 'in_progress';
+              if (isRunning) continue;
+              if (!isSuccess && !isError) {
+                // Unknown status: if rawOutput is present, treat as success so the result is shown.
+                if (update.rawOutput == null) continue;
+              }
               const content = extractRawOutputText(update.rawOutput);
-              result.push({ id: nextLocalId++, role: 'tool_result', content, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isSuccess ? 'success' : 'error' });
+              result.push({ id: nextLocalId++, role: 'tool_result', content, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isError ? 'error' : 'success' });
               break;
             }
             case 'plan': {
@@ -2023,15 +2037,19 @@ export class AgentAPIProxyClient {
             case 'tool_call_update': {
               const isSuccess = update.status === 'completed' || update.status === 'success';
               const isError = update.status === 'failed' || update.status === 'error';
-              const isInProgress = update.status === 'in_progress';
+              // Proxy sends "running"; ACP spec also defines "in_progress"
+              const isRunning = update.status === 'running' || update.status === 'in_progress';
 
-              if (isInProgress) {
+              if (isRunning) {
                 // Notify the UI so it can update the tool card's visual state.
                 callbacks.onToolUpdate?.(update.toolCallId ?? '', 'in_progress');
                 return;
               }
 
-              if (!isSuccess && !isError) return;
+              if (!isSuccess && !isError) {
+                // Unknown status: if rawOutput is present, treat as success so the result is shown.
+                if (update.rawOutput == null) return;
+              }
 
               const content = extractRawOutputText(update.rawOutput);
               callbacks.onMessage({


### PR DESCRIPTION
## Summary

- `extractRawOutputText`: 単一の ContentBlock オブジェクト `{type: "text", text: "..."}` を正しく処理できるよう修正（配列はすでに対応済みだったが、オブジェクト単体のケースが未対応だった）
- `tool_call_update`: プロキシが送る `running` ステータスを `in_progress` と同等に処理するよう修正（以前は `in_progress` のみチェックしていたため running が `onToolUpdate` に通知されなかった）
- `tool_call_update`: ステータスなしでも rawOutput があれば success として表示するよう修正（Explore サブエージェントのツール結果が消えていた問題に対応）

## 変更点

`src/lib/agentapi-proxy-client.ts`:

1. **`extractRawOutputText` 関数の改善**: rawOutput が `{text: "..."}` や `{type: "text", text: "..."}` のような単一 ContentBlock オブジェクトの場合、`.text` フィールドを抽出するよう修正。
2. **`running` ステータスの処理**: プロキシの実際のステータス値は `running` だが、コードは `in_progress` のみチェックしていた。両方に対応。
3. **不明ステータスでも rawOutput があれば表示**: Explore サブエージェントがステータスなしで tool_call_update を送る場合も rawOutput があれば結果として表示。

## Test plan

- [ ] ACP セッションで Read/Search/Execute ツールの緑のエリアに正しいコンテンツが表示されること
- [ ] Think/Explore ツールの結果も正しく表示されること
- [ ] ツール実行中（running状態）に UI が適切に反応すること

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)