### PR TITLE
feat: ACP モードでもツール実行中のスピナーを表示

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -161,6 +161,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                         }
                       } catch { /* not a tool message */ }
                     }
+                    // per-session bridge signals completion via tool_result message (not onToolUpdate)
+                    if (msg.role === 'tool_result' && msg.parentToolUseId) {
+                      setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== msg.parentToolUseId));
+                    }
                     setMessages(prev => [...prev, msg]);
                   },
                   onChunk: (msgId: number, text: string) => {
@@ -174,7 +178,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     ));
                   },
                   onToolUpdate: (toolCallId: string, status: string) => {
-                    setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== toolCallId));
+                    // Only remove from running tools on actual completion (not in_progress)
+                    if (status === 'success' || status === 'error') {
+                      setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== toolCallId));
+                    }
                     setMessages(prev => prev.map(m =>
                       m.toolUseId === toolCallId
                         ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }
@@ -871,6 +878,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 }
               } catch { /* not a tool message */ }
             }
+            // per-session bridge signals completion via tool_result message (not onToolUpdate)
+            if (msg.role === 'tool_result' && msg.parentToolUseId) {
+              setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== msg.parentToolUseId));
+            }
             setMessages(prev => [...prev, msg]);
           },
           onChunk: (msgId: number, text: string) => {
@@ -884,7 +895,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             ));
           },
           onToolUpdate: (toolCallId: string, status: string) => {
-            setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== toolCallId));
+            // Only remove from running tools on actual completion (not in_progress)
+            if (status === 'success' || status === 'error') {
+              setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== toolCallId));
+            }
             setMessages(prev => prev.map(m =>
               m.toolUseId === toolCallId
                 ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -16,7 +16,7 @@ import { pushNotificationManager } from '../../utils/pushNotification';
 import { getEnterKeyBehavior, getFontSettings, FontSettings, setFontSettings as saveFontSettings, FontFamily } from '../../types/settings';
 import ShareSessionButton from './ShareSessionButton';
 import MessageItem from './MessageItem';
-import ToolExecutionPane from './ToolExecutionPane';
+import ToolExecutionPane, { ACPRunningTool } from './ToolExecutionPane';
 import PlanApprovalModal from './PlanApprovalModal';
 import AskUserQuestionModal from './AskUserQuestionModal';
 import SessionListSidebar from './SessionListSidebar';
@@ -149,6 +149,18 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               // Shared callback object used for both normal ACP and early-ACP-fallback paths.
               const acpCallbacks = {
                   onMessage: (msg: SessionMessage) => {
+                    if (msg.toolUseId && msg.role === 'agent') {
+                      try {
+                        const toolObj = JSON.parse(msg.content || '{}');
+                        if (toolObj.type === 'tool_use' && toolObj.name) {
+                          setAcpRunningTools(prev =>
+                            prev.some(t => t.toolCallId === msg.toolUseId)
+                              ? prev
+                              : [...prev, { toolCallId: msg.toolUseId!, name: toolObj.name, input: toolObj.input ?? {} }]
+                          );
+                        }
+                      } catch { /* not a tool message */ }
+                    }
                     setMessages(prev => [...prev, msg]);
                   },
                   onChunk: (msgId: number, text: string) => {
@@ -162,6 +174,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     ));
                   },
                   onToolUpdate: (toolCallId: string, status: string) => {
+                    setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== toolCallId));
                     setMessages(prev => prev.map(m =>
                       m.toolUseId === toolCallId
                         ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }
@@ -186,6 +199,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     console.log('[ACP] current_mode_update:', modeId);
                   },
                   onStatus: (status: { status: 'stable' | 'running' | 'error'; agent_type?: string }) => {
+                    if (status.status === 'stable') setAcpRunningTools([]);
                     setAgentStatus(status);
                   },
                   onPermission: (action: PendingAction, rpcId: number) => {
@@ -384,6 +398,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [isLoading, setIsLoading] = useState(false);
   const [fontSettings, setFontSettings] = useState<FontSettings>(() => getFontSettings());
   const [agentStatus, setAgentStatus] = useState<AgentStatus | null>(null);
+  const [acpRunningTools, setAcpRunningTools] = useState<ACPRunningTool[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
@@ -844,6 +859,18 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
 
       const reconnectCallbacks = {
           onMessage: (msg: SessionMessage) => {
+            if (msg.toolUseId && msg.role === 'agent') {
+              try {
+                const toolObj = JSON.parse(msg.content || '{}');
+                if (toolObj.type === 'tool_use' && toolObj.name) {
+                  setAcpRunningTools(prev =>
+                    prev.some(t => t.toolCallId === msg.toolUseId)
+                      ? prev
+                      : [...prev, { toolCallId: msg.toolUseId!, name: toolObj.name, input: toolObj.input ?? {} }]
+                  );
+                }
+              } catch { /* not a tool message */ }
+            }
             setMessages(prev => [...prev, msg]);
           },
           onChunk: (msgId: number, text: string) => {
@@ -857,6 +884,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             ));
           },
           onToolUpdate: (toolCallId: string, status: string) => {
+            setAcpRunningTools(prev => prev.filter(t => t.toolCallId !== toolCallId));
             setMessages(prev => prev.map(m =>
               m.toolUseId === toolCallId
                 ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }
@@ -881,6 +909,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             console.log('[ACP] current_mode_update:', modeId);
           },
           onStatus: (status: { status: 'stable' | 'running' | 'error'; agent_type?: string }) => {
+            if (status.status === 'stable') setAcpRunningTools([]);
             setAgentStatus(status);
           },
           onPermission: (action: PendingAction, rpcId: number) => {
@@ -1552,7 +1581,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       </div>
 
       {/* ツール実行確認ペーン */}
-      {sessionId && <ToolExecutionPane sessionId={sessionId} agentStatus={agentStatus?.status} />}
+      {sessionId && <ToolExecutionPane sessionId={sessionId} agentStatus={agentStatus?.status} acpRunningTools={acpRunningTools} />}
 
       {/* Input */}
       <div className="bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-4 sm:px-6 py-3 flex-shrink-0">

--- a/src/app/components/ToolExecutionPane.tsx
+++ b/src/app/components/ToolExecutionPane.tsx
@@ -61,12 +61,19 @@ function getToolDescription(toolName: string, input: Record<string, unknown>): s
   }
 }
 
+export interface ACPRunningTool {
+  toolCallId: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
 interface ToolExecutionPaneProps {
   sessionId: string;
   agentStatus?: 'stable' | 'running' | 'error';
+  acpRunningTools?: ACPRunningTool[];
 }
 
-export default function ToolExecutionPane({ sessionId, agentStatus }: ToolExecutionPaneProps) {
+export default function ToolExecutionPane({ sessionId, agentStatus, acpRunningTools }: ToolExecutionPaneProps) {
   const [runningTools, setRunningTools] = useState<Array<{ toolUse: ToolUseContent; message: SessionMessage }>>([]);
   const [isEndpointAvailable, setIsEndpointAvailable] = useState<boolean>(true);
 
@@ -121,9 +128,49 @@ export default function ToolExecutionPane({ sessionId, agentStatus }: ToolExecut
     };
   }, [sessionId, isEndpointAvailable]);
 
-  // エンドポイントが利用できない場合は何も表示しない
+  const spinnerYellow = (
+    <svg className="w-3 h-3 text-yellow-600 dark:text-yellow-400 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+  );
+
+  const spinnerGray = (
+    <svg className="animate-spin w-3 h-3 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+  );
+
+  // エンドポイントが利用できない場合 (ACP モード等): ACP ツール情報またはエージェント実行中のときのみ表示
   if (!isEndpointAvailable) {
-    return null;
+    const hasAcpTools = acpRunningTools && acpRunningTools.length > 0;
+    if (!hasAcpTools && agentStatus !== 'running') return null;
+    return (
+      <div className="bg-gray-50 dark:bg-gray-800 border-t border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+        <div className="px-4 sm:px-6 py-2">
+          <div className="flex items-center space-x-3 min-h-[20px]">
+            {hasAcpTools ? (
+              acpRunningTools!.map(tool => (
+                <div key={tool.toolCallId} className="flex items-center space-x-2 text-xs">
+                  {spinnerYellow}
+                  <span className="text-gray-600 dark:text-gray-400 max-w-[300px] truncate" title={getToolDescription(tool.name, tool.input)}>
+                    {getToolDescription(tool.name, tool.input)}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <div className="flex items-center space-x-2 text-xs">
+                {spinnerGray}
+                <span className="text-gray-400 dark:text-gray-500">
+                  エージェント実行中
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -137,10 +184,7 @@ export default function ToolExecutionPane({ sessionId, agentStatus }: ToolExecut
                 key={message.toolUseId}
                 className="flex items-center space-x-2 text-xs"
               >
-                <svg className="w-3 h-3 text-yellow-600 dark:text-yellow-400 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
+                {spinnerYellow}
                 <span className="text-gray-600 dark:text-gray-400 max-w-[300px] truncate" title={getToolDescription(toolUse.name, toolUse.input)}>
                   {getToolDescription(toolUse.name, toolUse.input)}
                 </span>
@@ -149,10 +193,7 @@ export default function ToolExecutionPane({ sessionId, agentStatus }: ToolExecut
           ) : agentStatus === 'running' ? (
             // エージェントが running 状態でツールがない場合
             <div className="flex items-center space-x-2 text-xs">
-              <svg className="animate-spin w-3 h-3 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
+              {spinnerGray}
               <span className="text-gray-400 dark:text-gray-500">
                 エージェント実行中
               </span>


### PR DESCRIPTION
## Summary

- `ToolExecutionPane` は `/{sessionId}/tool_status` エンドポイントが 404 を返すとコンポーネント全体を非表示にしていたため、ACP モードではエージェント実行中・ツール実行中のスピナーが表示されていなかった
- ACP モードでも `claude-agentapi` エージェントと同様に、チャット入力欄上部にスピナーを表示するよう修正

## Changes

**`ToolExecutionPane.tsx`**
- `ACPRunningTool` 型を定義・export
- `acpRunningTools` prop を追加
- エンドポイント不可時でも `agentStatus === 'running'` または `acpRunningTools` がある場合はスピナーを表示

**`AgentAPIChat.tsx`**
- `acpRunningTools` state を追加し、ACP SSE イベントに連動して追跡
- `ToolExecutionPane` に `acpRunningTools` を prop として渡す

## Test plan

- [ ] ACP モードのセッションでエージェントにメッセージを送り、実行中にスピナーが表示されることを確認
- [ ] ツール実行中は黄色スピナー＋ツール名が表示されることを確認
- [ ] ツール未実行・エージェント応答中はグレースピナー＋「エージェント実行中」が表示されることを確認
- [ ] エージェント応答完了後にスピナーが消えることを確認
- [ ] 既存の `claude-agentapi` モードの動作に影響がないことを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)