### PR TITLE
feat(acp): ACP-compliant SSE history and visible connection status

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -140,6 +140,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         try {
           setError(null);
           setIsConnected(true); // Set connected immediately for better UX
+          setACPConnectionStatus('idle');
 
           if (sessionId) {
             // ── ACP session detection ───────────────────────────────────────
@@ -196,6 +197,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   onError: (err: Event | Error) => {
                     console.error('[ACP] SSE error callback (from AgentAPIChat):', err);
                   },
+                  onConnectionStatus: (status: 'connecting' | 'connected' | 'reconnecting' | 'disconnected') => {
+                    setACPConnectionStatus(status);
+                  },
               };
 
               const info = await agentAPIRef.current.getACPSessionInfo(sessionId);
@@ -204,13 +208,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 setACPInfo(info);
                 setAgentType('acp');
 
-                // Always fetch history from the per-session bridge.
-                // We always use the per-session SSE (which does NOT replay history),
-                // so there is no risk of duplicates from SSE replay.
-                const history = await agentAPIRef.current!.getACPMessageHistory(sessionId, info.sessionId);
-                setMessages(history);
-                console.log(`[ACP] initializeChat: restored ${history.length} messages from bridge history`);
-
+                // Per the ACP spec, message history is delivered via SSE replay when the
+                // client connects (with optional Last-Event-ID for efficient resumption).
+                // We do NOT call a separate /messages REST endpoint — that is non-ACP.
+                setMessages([]);
                 setHasMoreMessages(false);
                 setIsInitialLoadComplete(true);
                 setIsStarting(false);
@@ -425,6 +426,8 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [acpPendingPermission, setACPPendingPermission] = useState<{ action: PendingAction; rpcId: number } | null>(null);
   const acpNextPromptId = useRef(1);
   const acpEventSourceRef = useRef<{ close: () => void } | null>(null);
+  /** Tracks the ACP SSE stream connection state for display in the header. */
+  const [acpConnectionStatus, setACPConnectionStatus] = useState<'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected'>('idle');
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -1298,10 +1301,36 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             
             {/* Connection Status */}
             <div className="flex items-center space-x-1 sm:space-x-2">
-              <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`}></div>
-              <span className={`text-xs sm:text-sm ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'} hidden sm:inline`}>
-                {isConnected ? 'Connected' : 'Disconnected'}
-              </span>
+              {acpInfo ? (
+                // ACP mode: reflect the SSE stream state rather than generic HTTP connectivity.
+                <>
+                  <div className={`w-2 h-2 rounded-full ${
+                    acpConnectionStatus === 'connected' ? 'bg-green-500' :
+                    acpConnectionStatus === 'connecting' || acpConnectionStatus === 'reconnecting' ? 'bg-yellow-500 animate-pulse' :
+                    acpConnectionStatus === 'disconnected' ? 'bg-red-500' :
+                    'bg-gray-400'
+                  }`}></div>
+                  <span className={`text-xs sm:text-sm hidden sm:inline ${
+                    acpConnectionStatus === 'connected' ? 'text-green-600 dark:text-green-400' :
+                    acpConnectionStatus === 'connecting' || acpConnectionStatus === 'reconnecting' ? 'text-yellow-600 dark:text-yellow-400' :
+                    acpConnectionStatus === 'disconnected' ? 'text-red-600 dark:text-red-400' :
+                    'text-gray-500 dark:text-gray-400'
+                  }`}>
+                    {acpConnectionStatus === 'connected' ? 'ACP Connected' :
+                     acpConnectionStatus === 'connecting' ? 'ACP Connecting...' :
+                     acpConnectionStatus === 'reconnecting' ? 'ACP Reconnecting...' :
+                     acpConnectionStatus === 'disconnected' ? 'ACP Disconnected' :
+                     'ACP'}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`}></div>
+                  <span className={`text-xs sm:text-sm ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'} hidden sm:inline`}>
+                    {isConnected ? 'Connected' : 'Disconnected'}
+                  </span>
+                </>
+              )}
             </div>
 
             {/* Delete Session Button */}

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -208,10 +208,19 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 setACPInfo(info);
                 setAgentType('acp');
 
-                // Per the ACP spec, message history is delivered via SSE replay when the
-                // client connects (with optional Last-Event-ID for efficient resumption).
-                // We do NOT call a separate /messages REST endpoint — that is non-ACP.
-                setMessages([]);
+                // The bridge's SSE only delivers NEW events on fresh connect (history replay
+                // on fresh connect was disabled in bridge PR #739 to prevent duplicates
+                // when clients fetch history via REST and also receive SSE replay).
+                // Fetch the full message history via REST, then subscribe to SSE for
+                // new events going forward.
+                try {
+                  const history = await agentAPIRef.current!.getACPMessageHistory(sessionId, info.sessionId);
+                  setMessages(history);
+                  console.log(`[ACP] initializeChat: loaded ${history.length} messages from history`);
+                } catch (err) {
+                  console.warn('[ACP] initializeChat: failed to load message history:', err);
+                  setMessages([]);
+                }
                 setHasMoreMessages(false);
                 setIsInitialLoadComplete(true);
                 setIsStarting(false);
@@ -820,9 +829,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     if (!acpInfo || !sessionId || !agentAPIRef.current) return;
 
     const reconnectACP = async () => {
-      console.log('[ACP] Page became visible, refreshing messages and checking SSE connection...');
+      console.log('[ACP] Page became visible, refreshing messages...');
 
-      // 1. Fetch fresh message history from the bridge
+      // Refresh message history from the bridge to catch up on anything missed.
       try {
         const history = await agentAPIRef.current!.getACPMessageHistory(sessionId, acpInfo.sessionId);
         setMessages(history);
@@ -831,7 +840,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         console.warn('[ACP] Failed to refresh message history on visibility change:', err);
       }
 
-      // 2. Fetch current agent status
+      // Refresh agent status.
       try {
         const currentStatus = await agentAPIRef.current!.getSessionStatus(sessionId);
         setAgentStatus(currentStatus);
@@ -839,81 +848,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         // Non-fatal — status will be updated via SSE events
       }
 
-      // 3. Reconnect SSE
-      console.log('[ACP] Reconnecting SSE after visibility change...');
-      if (acpEventSourceRef.current) {
-        acpEventSourceRef.current.close();
-      }
-
-      const reconnectCallbacks = {
-          onMessage: (msg: SessionMessage) => {
-            setMessages(prev => [...prev, msg]);
-          },
-          onChunk: (msgId: number, text: string) => {
-            setMessages(prev => prev.map(m =>
-              m.id === msgId ? { ...m, content: m.content + text } : m
-            ));
-          },
-          onThoughtChunk: (msgId: number, thought: string) => {
-            setMessages(prev => prev.map(m =>
-              m.id === msgId ? { ...m, thought: (m.thought ?? '') + thought } : m
-            ));
-          },
-          onToolUpdate: (toolCallId: string, status: string) => {
-            setMessages(prev => prev.map(m =>
-              m.toolUseId === toolCallId
-                ? { ...m, content: JSON.stringify({ ...JSON.parse(m.content || '{}'), _status: status }) }
-                : m
-            ));
-          },
-          onToolInputUpdate: (toolCallId: string, input: unknown, title?: string, locations?: Array<{ path: string; line?: number }>) => {
-            setMessages(prev => prev.map(m => {
-              if (m.toolUseId !== toolCallId) return m;
-              try {
-                const toolObj = JSON.parse(m.content || '{}');
-                return { ...m, content: JSON.stringify({
-                  ...toolObj,
-                  input,
-                  ...(title != null ? { title } : {}),
-                  ...(locations != null ? { locations } : {}),
-                })};
-              } catch { return m; }
-            }));
-          },
-          onModeUpdate: (modeId: string) => {
-            console.log('[ACP] current_mode_update:', modeId);
-          },
-          onStatus: (status: { status: 'stable' | 'running' | 'error'; agent_type?: string }) => {
-            setAgentStatus(status);
-          },
-          onPermission: (action: PendingAction, rpcId: number) => {
-            setACPPendingPermission({ action, rpcId });
-            setPendingAction(action);
-            setShowQuestionModal(true);
-          },
-          onError: (err: Event | Error) => {
-            console.error('[ACP] SSE error callback (from visibility reconnect):', err);
-          },
-      };
-
-      if (acpServerEnabled && acpServerClientRef.current) {
-        acpEventSourceRef.current = acpServerClientRef.current.subscribeToEvents(
-          sessionId,
-          reconnectCallbacks
-        );
-      } else {
-        acpEventSourceRef.current = agentAPIRef.current!.subscribeToACPSessionEvents(
-          sessionId,
-          acpInfo.sessionId,
-          {
-            ...reconnectCallbacks,
-            onCommandsUpdate: (commands) => {
-              console.log('[ACP] available_commands_update:', commands);
-            },
-          }
-        );
-      }
-      console.log('[ACP] SSE reconnected after visibility change');
+      // The existing SSE subscription auto-reconnects internally with Last-Event-ID,
+      // so any events missed while the page was hidden will arrive via the reconnect.
+      // No need to close/reopen the subscription here.
     };
 
     reconnectACP();

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -113,6 +113,8 @@ export interface ACPServerEventCallbacks {
   onTitleUpdate?: (title: string) => void;
   onModeUpdate?: (mode: string) => void;
   onError?: (err: Event | Error) => void;
+  /** Called when the SSE connection state changes. */
+  onConnectionStatus?: (status: 'connecting' | 'connected' | 'reconnecting' | 'disconnected') => void;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -520,26 +522,43 @@ export class ACPServerClient {
       }
     };
 
+    // Track the last received SSE event id for ACP-compliant Last-Event-ID resumption.
+    let lastEventId: string | null = null;
+    let isFirstConnect = true;
+
     const connect = async (retryDelay = 1000) => {
       if (abortController.signal.aborted) return;
+
+      callbacks.onConnectionStatus?.(isFirstConnect ? 'connecting' : 'reconnecting');
+      isFirstConnect = false;
+
       try {
+        const headers: Record<string, string> = {
+          ...this.getHeaders(),
+          'Accept': 'text/event-stream',
+          'Acp-Session-Id': sessionId,
+        };
+        // On reconnect, send Last-Event-ID so the server can resume from the last seen event.
+        if (lastEventId !== null) {
+          headers['Last-Event-ID'] = lastEventId;
+        }
+
         const response = await fetch(this.acpUrl, {
           method: 'GET',
-          headers: {
-            ...this.getHeaders(),
-            'Accept': 'text/event-stream',
-            'Acp-Session-Id': sessionId,
-          },
+          headers,
           signal: abortController.signal,
         });
 
         if (!response.ok || !response.body) {
+          callbacks.onConnectionStatus?.('disconnected');
           callbacks.onError?.(new Error(`[ACPServerClient] SSE connection failed: ${response.status}`));
           if (!abortController.signal.aborted) {
             setTimeout(() => connect(Math.min(retryDelay * 2, 30000)), retryDelay);
           }
           return;
         }
+
+        callbacks.onConnectionStatus?.('connected');
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
@@ -554,27 +573,37 @@ export class ACPServerClient {
           buffer = lines.pop() ?? '';
 
           for (const line of lines) {
-            if (line.startsWith('data: ')) {
+            if (line.startsWith('id: ')) {
+              // Track the last event id for Last-Event-ID on reconnect.
+              lastEventId = line.slice(4).trim();
+            } else if (line.startsWith('data: ')) {
               const data = line.slice(6).trim();
               if (data) dispatchEvent(data);
             }
           }
         }
 
-        // Stream closed normally — reconnect after a short delay
+        // Stream closed normally — reconnect after a short delay.
+        callbacks.onConnectionStatus?.('disconnected');
         if (!abortController.signal.aborted) {
           setTimeout(() => connect(1000), 1000);
         }
       } catch (err) {
         if (abortController.signal.aborted) return;
         console.error('[ACPServerClient] SSE fetch error:', err);
+        callbacks.onConnectionStatus?.('disconnected');
         setTimeout(() => connect(Math.min(retryDelay * 2, 30000)), retryDelay);
       }
     };
 
     connect();
 
-    return { close: () => abortController.abort() };
+    return {
+      close: () => {
+        abortController.abort();
+        callbacks.onConnectionStatus?.('disconnected');
+      },
+    };
   }
 }
 

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -258,6 +258,8 @@ export interface ACPSessionCallbacks {
   onPermission: (action: PendingAction, rpcId: number) => void;
   /** Called on transport errors. */
   onError: (error: Error) => void;
+  /** Called when the SSE connection state changes. */
+  onConnectionStatus?: (status: 'connecting' | 'connected' | 'reconnecting' | 'disconnected') => void;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -1999,9 +2001,11 @@ export class AgentAPIProxyClient {
     let streamingMsgId: number | null = null;
 
     console.log(`[ACP] EventSource created (url=${sseUrl}, acpSessionId=${acpSessionId})`);
+    callbacks.onConnectionStatus?.('connecting');
 
     eventSource.addEventListener('open', () => {
       console.log(`[ACP] SSE connection opened (url=${sseUrl}, acpSessionId=${acpSessionId})`);
+      callbacks.onConnectionStatus?.('connected');
     });
 
     eventSource.addEventListener('message', (event: MessageEvent) => {
@@ -2240,9 +2244,11 @@ export class AgentAPIProxyClient {
       console.error(`[ACP] SSE onerror (url=${sseUrl}, acpSessionId=${acpSessionId}, readyState=${state})`, event);
       if (state === EventSource.CLOSED) {
         console.error(`[ACP] SSE connection permanently closed`);
+        callbacks.onConnectionStatus?.('disconnected');
       } else {
         // readyState=CONNECTING means the browser is auto-reconnecting.
         console.warn(`[ACP] SSE error – browser will auto-reconnect (readyState=${state})`);
+        callbacks.onConnectionStatus?.('reconnecting');
       }
       callbacks.onError(new Error(`ACP SSE connection error (readyState=${state})`));
     };


### PR DESCRIPTION
## Summary

- **ACP connection status visible in UI**: In ACP mode the header now shows the SSE stream state (Connecting… / ACP Connected / ACP Reconnecting… / ACP Disconnected) with an animated yellow dot during reconnection, instead of the generic green/red "Connected" dot
- **`Last-Event-ID` tracking in `ACPServerClient`**: Parses `id:` lines from the SSE stream and includes `Last-Event-ID` on reconnect so the server can resume from the last seen event for efficient resumption
- **`onConnectionStatus` callback**: Added to both `ACPServerEventCallbacks` and `ACPSessionCallbacks`; called at every SSE state transition
- **Fix: restore initial message history fetch**: Reverted the removal of `getACPMessageHistory()` — the bridge deliberately does NOT replay history on fresh SSE connect (per bridge PR #739, to avoid duplicates when clients already have history). The correct flow is: fetch full history via REST on initial connect, then subscribe to SSE for new events going forward
- **Fix: simplify `reconnectACP`**: Removed the SSE close/reopen on page visibility change; `subscribeToEvents()` auto-reconnects internally with `Last-Event-ID`, so missed events are replayed without a full teardown. The visibility handler now only refreshes message history and agent status

## Test plan

- [ ] Open an ACP session — header shows "ACP Connecting…" (yellow pulse) then "ACP Connected" (green)
- [ ] Previously-sent messages appear immediately (loaded from bridge history via REST on connect)
- [ ] Kill network briefly — header shows "ACP Reconnecting…" (yellow pulse), then returns to "ACP Connected"; no messages lost
- [ ] Non-ACP session — header still shows original "Connected / Disconnected" indicator
- [ ] Build: `bun run build` ✓  |  Type check: `npx tsc --noEmit` ✓  |  Lint: `bun run lint` ✓

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)