### PR TITLE
feat: add GitHub Sync settings to team settings page

### DIFF
--- a/src/app/settings/team/page.tsx
+++ b/src/app/settings/team/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { SettingsData, BedrockConfig, APIMCPServerConfig, MarketplaceConfig, prepareSettingsForSave } from '@/types/settings'
-import { BedrockSettings, SettingsAccordion, MCPServerSettings, MarketplaceSettings, PluginSettings, EnvVarsSettings } from '@/components/settings'
+import { SettingsData, BedrockConfig, APIMCPServerConfig, MarketplaceConfig, GitSyncConfig, prepareSettingsForSave } from '@/types/settings'
+import { BedrockSettings, SettingsAccordion, MCPServerSettings, MarketplaceSettings, PluginSettings, EnvVarsSettings, GitHubSyncSettings } from '@/components/settings'
 import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
 import { useToast } from '@/contexts/ToastContext'
 
@@ -15,6 +15,7 @@ export default function TeamSettingsPage() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isTeamLoaded, setIsTeamLoaded] = useState(false)
+  const [gitSyncConfig, setGitSyncConfig] = useState<GitSyncConfig | undefined>(undefined)
   const { showToast } = useToast()
   const hasUnsavedChangesRef = useRef(false)
 
@@ -52,6 +53,14 @@ export default function TeamSettingsPage() {
       setOriginalSettings(data)
       setTeamName(name)
       setIsTeamLoaded(true)
+
+      // GitHub Sync 設定を読み込み
+      try {
+        const syncConfig = await client.getGitSyncConfig(name)
+        setGitSyncConfig(syncConfig ?? undefined)
+      } catch {
+        setGitSyncConfig(undefined)
+      }
     } catch (err) {
       console.error('Failed to load team settings:', err)
       setError('Failed to load team settings. The team may not exist or you may not have permission.')
@@ -113,6 +122,33 @@ export default function TeamSettingsPage() {
 
   const handleMCPServersChange = (servers: Record<string, APIMCPServerConfig>) => {
     setSettings((prev) => ({ ...prev, mcp_servers: servers }))
+  }
+
+  const handleGitSyncSave = async (config: GitSyncConfig) => {
+    const client = createAgentAPIProxyClientFromStorage()
+    const saved = await client.updateGitSyncConfig(teamName, config)
+    setGitSyncConfig(saved)
+    showToast('GitHub Sync 設定を保存しました', 'success')
+  }
+
+  const handleGitSyncDelete = async () => {
+    if (!confirm('GitHub Sync 設定を削除しますか？')) return
+    const client = createAgentAPIProxyClientFromStorage()
+    await client.deleteGitSyncConfig(teamName)
+    setGitSyncConfig(undefined)
+    showToast('GitHub Sync 設定を削除しました', 'success')
+  }
+
+  const handleGitSyncPush = async () => {
+    const client = createAgentAPIProxyClientFromStorage()
+    await client.gitSyncPush(teamName)
+    showToast('Push が完了しました', 'success')
+  }
+
+  const handleGitSyncPull = async () => {
+    const client = createAgentAPIProxyClientFromStorage()
+    await client.gitSyncPull(teamName)
+    showToast('Pull が完了しました', 'success')
   }
 
   const handleEnvVarsChange = (updates: Record<string, string>) => {
@@ -267,6 +303,20 @@ export default function TeamSettingsPage() {
             defaultOpen
           >
             <EnvVarsSettings envVarKeys={settings.env_var_keys} onChange={handleEnvVarsChange} />
+          </SettingsAccordion>
+
+          <SettingsAccordion
+            title="GitHub Sync"
+            description="設定・スケジュール・Webhook・Slackbot を GitHub リポジトリに双方向同期"
+            defaultOpen={false}
+          >
+            <GitHubSyncSettings
+              config={gitSyncConfig}
+              onSave={handleGitSyncSave}
+              onDelete={gitSyncConfig ? handleGitSyncDelete : undefined}
+              onPush={gitSyncConfig ? handleGitSyncPush : undefined}
+              onPull={gitSyncConfig ? handleGitSyncPull : undefined}
+            />
           </SettingsAccordion>
 
           <div className="flex items-center justify-between mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- チーム設定ページ (`/settings/team`) に GitHub Sync セクションを追加
- 個人設定ページと同様に、リポジトリ・ブランチ・PAT・自動プッシュなどを設定可能
- チームを選択した際に git sync 設定を読み込み、保存・削除・push・pull 操作が可能

## Test plan
- [ ] チーム設定ページを開き、GitHub Sync セクションが表示されることを確認
- [ ] リポジトリ名・ブランチ・PAT を入力して保存できることを確認
- [ ] 保存後に push/pull ボタンが有効になることを確認
- [ ] 削除ボタンで設定を削除できることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)