### PR TITLE
feat: add Claude sandbox config UI to session/schedule/webhook forms

### DIFF
--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -7,6 +7,7 @@ import { SessionFilter, getFilterValuesForSessionCreation } from '../../lib/filt
 import { OrganizationHistory } from '../../utils/organizationHistory'
 import { addRepositoryToHistory } from '../../types/settings'
 import MemoryKeyInput, { MemoryKeyPair, memoryKeyPairsToRecord } from './MemoryKeyInput'
+import SandboxConfigInput, { SandboxConfigState, defaultSandboxConfigState, sandboxConfigStateToConfig } from './SandboxConfigInput'
 
 interface NewConversationModalProps {
   isOpen: boolean
@@ -36,6 +37,7 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [oneshot, setOneshot] = useState(false)
   const [memoryKeyPairs, setMemoryKeyPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
+  const [sandboxState, setSandboxState] = useState<SandboxConfigState>(defaultSandboxConfigState())
   
   // Initialize with current filter values
   const initializeFromFilters = useCallback(() => {
@@ -235,13 +237,15 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
 
       const agentAPI = createAgentAPIProxyClientFromStorage()
       const memoryKey = memoryKeyPairsToRecord(memoryKeyPairs)
+      const sandbox = sandboxConfigStateToConfig(sandboxState)
       await agentAPI.start({
         environment: sessionData.environment,
         metadata: sessionData.metadata,
         tags: sessionData.tags,
         params: {
           message: description.trim(),
-          ...(oneshot ? { oneshot: true } : {})
+          ...(oneshot ? { oneshot: true } : {}),
+          ...(sandbox ? { sandbox } : {}),
         },
         ...(memoryKey ? { memory_key: memoryKey } : {}),
         ...scopeParams
@@ -512,6 +516,15 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
               onChange={setMemoryKeyPairs}
               disabled={isCreating}
               helpText="メモリを識別するタグマップ。未指定の場合はセッションのタグが使われます。"
+            />
+          </div>
+
+          {/* Sandbox Config */}
+          <div>
+            <SandboxConfigInput
+              state={sandboxState}
+              onChange={setSandboxState}
+              disabled={isCreating}
             />
           </div>
 

--- a/src/app/components/SandboxConfigInput.tsx
+++ b/src/app/components/SandboxConfigInput.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import { useState } from 'react'
+
+export interface ClaudeSandboxFilesystemConfig {
+  allowWrite?: string[]
+  denyWrite?: string[]
+  denyRead?: string[]
+  allowRead?: string[]
+}
+
+export interface ClaudeSandboxNetworkConfig {
+  allowedDomains?: string[]
+  deniedDomains?: string[]
+  allowLocalBinding?: boolean
+  allowAllUnixSockets?: boolean
+}
+
+export interface ClaudeSandboxConfig {
+  enabled?: boolean
+  failIfUnavailable?: boolean
+  autoAllowBashIfSandboxed?: boolean
+  excludedCommands?: string[]
+  allowUnsandboxedCommands?: boolean
+  filesystem?: ClaudeSandboxFilesystemConfig
+  network?: ClaudeSandboxNetworkConfig
+}
+
+export interface SandboxConfigState {
+  enabled: boolean
+  autoAllowBashIfSandboxed: boolean
+  allowUnsandboxedCommands: boolean
+  excludedCommands: string
+  fsAllowWrite: string
+  fsDenyRead: string
+  networkAllowedDomains: string
+  networkDeniedDomains: string
+}
+
+export function defaultSandboxConfigState(): SandboxConfigState {
+  return {
+    enabled: false,
+    autoAllowBashIfSandboxed: true,
+    allowUnsandboxedCommands: true,
+    excludedCommands: '',
+    fsAllowWrite: '',
+    fsDenyRead: '',
+    networkAllowedDomains: '',
+    networkDeniedDomains: '',
+  }
+}
+
+export function sandboxConfigStateToConfig(state: SandboxConfigState): ClaudeSandboxConfig | undefined {
+  if (!state.enabled) return undefined
+
+  const parseLines = (s: string): string[] =>
+    s.split('\n').map(l => l.trim()).filter(Boolean)
+
+  const excludedCommands = parseLines(state.excludedCommands)
+  const fsAllowWrite = parseLines(state.fsAllowWrite)
+  const fsDenyRead = parseLines(state.fsDenyRead)
+  const allowedDomains = parseLines(state.networkAllowedDomains)
+  const deniedDomains = parseLines(state.networkDeniedDomains)
+
+  const config: ClaudeSandboxConfig = {
+    enabled: true,
+    autoAllowBashIfSandboxed: state.autoAllowBashIfSandboxed,
+    allowUnsandboxedCommands: state.allowUnsandboxedCommands,
+  }
+
+  if (excludedCommands.length > 0) config.excludedCommands = excludedCommands
+
+  if (fsAllowWrite.length > 0 || fsDenyRead.length > 0) {
+    config.filesystem = {}
+    if (fsAllowWrite.length > 0) config.filesystem.allowWrite = fsAllowWrite
+    if (fsDenyRead.length > 0) config.filesystem.denyRead = fsDenyRead
+  }
+
+  if (allowedDomains.length > 0 || deniedDomains.length > 0) {
+    config.network = {}
+    if (allowedDomains.length > 0) config.network.allowedDomains = allowedDomains
+    if (deniedDomains.length > 0) config.network.deniedDomains = deniedDomains
+  }
+
+  return config
+}
+
+interface SandboxConfigInputProps {
+  state: SandboxConfigState
+  onChange: (state: SandboxConfigState) => void
+  disabled?: boolean
+}
+
+export default function SandboxConfigInput({ state, onChange, disabled }: SandboxConfigInputProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const update = (patch: Partial<SandboxConfigState>) => onChange({ ...state, ...patch })
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-600 rounded-md overflow-hidden">
+      {/* Header toggle */}
+      <button
+        type="button"
+        onClick={() => setExpanded(v => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600"
+        disabled={disabled}
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+          </svg>
+          <span>Claude Sandbox 設定</span>
+          {state.enabled && (
+            <span className="text-xs bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-full">
+              有効
+            </span>
+          )}
+        </div>
+        <svg
+          className={`w-4 h-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {expanded && (
+        <div className="px-4 py-4 space-y-5">
+          {/* Enable sandbox */}
+          <div className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              id="sandbox-enabled"
+              checked={state.enabled}
+              onChange={e => update({ enabled: e.target.checked })}
+              className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              disabled={disabled}
+            />
+            <div>
+              <label htmlFor="sandbox-enabled" className="block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
+                サンドボックスを有効にする
+              </label>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                bash コマンドをファイルシステム・ネットワーク分離環境内で実行します（macOS / Linux / WSL2）
+              </p>
+            </div>
+          </div>
+
+          {state.enabled && (
+            <>
+              {/* Auto allow bash */}
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  id="sandbox-auto-allow"
+                  checked={state.autoAllowBashIfSandboxed}
+                  onChange={e => update({ autoAllowBashIfSandboxed: e.target.checked })}
+                  className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  disabled={disabled}
+                />
+                <div>
+                  <label htmlFor="sandbox-auto-allow" className="block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
+                    サンドボックス内の bash を自動承認する
+                  </label>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    サンドボックス内で実行されるコマンドの承認プロンプトをスキップします（デフォルト: ON）
+                  </p>
+                </div>
+              </div>
+
+              {/* Allow unsandboxed commands */}
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  id="sandbox-allow-escape"
+                  checked={state.allowUnsandboxedCommands}
+                  onChange={e => update({ allowUnsandboxedCommands: e.target.checked })}
+                  className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  disabled={disabled}
+                />
+                <div>
+                  <label htmlFor="sandbox-allow-escape" className="block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
+                    サンドボックス外実行（エスケープハッチ）を許可する
+                  </label>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    <code className="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">dangerouslyDisableSandbox</code> パラメータを許可します（デフォルト: ON）
+                  </p>
+                </div>
+              </div>
+
+              {/* Excluded commands */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  サンドボックス除外コマンド
+                </label>
+                <textarea
+                  value={state.excludedCommands}
+                  onChange={e => update({ excludedCommands: e.target.value })}
+                  rows={2}
+                  className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white font-mono"
+                  placeholder={'docker *\nnpm *'}
+                  disabled={disabled}
+                />
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  1行1パターン。例: <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded">docker *</code>
+                </p>
+              </div>
+
+              {/* Filesystem */}
+              <div className="border border-gray-200 dark:border-gray-600 rounded-md p-3 space-y-3">
+                <p className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+                  ファイルシステム制限
+                </p>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    書き込み許可パス（allowWrite）
+                  </label>
+                  <textarea
+                    value={state.fsAllowWrite}
+                    onChange={e => update({ fsAllowWrite: e.target.value })}
+                    rows={2}
+                    className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white font-mono"
+                    placeholder={'/tmp/build\n~/.kube'}
+                    disabled={disabled}
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    作業ディレクトリ外で書き込みを許可するパス（1行1パス）
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    読み取り禁止パス（denyRead）
+                  </label>
+                  <textarea
+                    value={state.fsDenyRead}
+                    onChange={e => update({ fsDenyRead: e.target.value })}
+                    rows={2}
+                    className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white font-mono"
+                    placeholder={'~/.aws\n~/.ssh'}
+                    disabled={disabled}
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    読み取りをブロックするパス（1行1パス）
+                  </p>
+                </div>
+              </div>
+
+              {/* Network */}
+              <div className="border border-gray-200 dark:border-gray-600 rounded-md p-3 space-y-3">
+                <p className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+                  ネットワーク制限
+                </p>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    許可ドメイン（allowedDomains）
+                  </label>
+                  <textarea
+                    value={state.networkAllowedDomains}
+                    onChange={e => update({ networkAllowedDomains: e.target.value })}
+                    rows={2}
+                    className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white font-mono"
+                    placeholder={'github.com\n*.npmjs.org'}
+                    disabled={disabled}
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    アウトバウンドトラフィックを許可するドメイン（1行1ドメイン、ワイルドカード対応）
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    拒否ドメイン（deniedDomains）
+                  </label>
+                  <textarea
+                    value={state.networkDeniedDomains}
+                    onChange={e => update({ networkDeniedDomains: e.target.value })}
+                    rows={2}
+                    className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white font-mono"
+                    placeholder={'internal.corp.example.com'}
+                    disabled={disabled}
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    ブロックするドメイン（allowedDomains より優先）
+                  </p>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/components/ScheduleFormModal.tsx
+++ b/src/app/components/ScheduleFormModal.tsx
@@ -7,6 +7,7 @@ import CronExpressionInput from './CronExpressionInput'
 import { OrganizationHistory } from '../../utils/organizationHistory'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 import MemoryKeyInput, { MemoryKeyPair, memoryKeyPairsToRecord, recordToMemoryKeyPairs } from './MemoryKeyInput'
+import SandboxConfigInput, { SandboxConfigState, defaultSandboxConfigState, sandboxConfigStateToConfig } from './SandboxConfigInput'
 
 interface ScheduleFormModalProps {
   isOpen: boolean
@@ -40,6 +41,7 @@ export default function ScheduleFormModal({
   const [memoryKeyPairs, setMemoryKeyPairs] = useState<MemoryKeyPair[]>([{ key: '', value: '' }])
   const [showCustomMemory, setShowCustomMemory] = useState(false)
   const [envVarPairs, setEnvVarPairs] = useState<MemoryKeyPair[]>([{ key: '', value: '' }])
+  const [sandboxState, setSandboxState] = useState<SandboxConfigState>(defaultSandboxConfigState())
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -189,6 +191,8 @@ export default function ScheduleFormModal({
       const sessionParams: ScheduleSessionConfig['params'] = {}
       if (message.trim()) sessionParams.message = message.trim()
       if (oneshot) sessionParams.oneshot = true
+      const sandbox = sandboxConfigStateToConfig(sandboxState)
+      if (sandbox) sessionParams.sandbox = sandbox
       const hasParams = Object.keys(sessionParams).length > 0
 
       const environment = memoryKeyPairsToRecord(envVarPairs)
@@ -576,6 +580,15 @@ export default function ScheduleFormModal({
               onChange={setEnvVarPairs}
               disabled={isSubmitting}
               helpText="KEY=VALUE 形式で環境変数を入力してください"
+            />
+          </div>
+
+          {/* Sandbox Config */}
+          <div>
+            <SandboxConfigInput
+              state={sandboxState}
+              onChange={setSandboxState}
+              disabled={isSubmitting}
             />
           </div>
 

--- a/src/app/components/WebhookFormModal.tsx
+++ b/src/app/components/WebhookFormModal.tsx
@@ -15,6 +15,7 @@ import {
 import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
 import { OrganizationHistory } from '../../utils/organizationHistory'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
+import SandboxConfigInput, { SandboxConfigState, defaultSandboxConfigState, sandboxConfigStateToConfig } from './SandboxConfigInput'
 
 interface WebhookFormModalProps {
   isOpen: boolean
@@ -35,6 +36,7 @@ interface TriggerFormData {
   reuseSession: boolean
   mountPayload: boolean
   oneshot: boolean
+  sandboxState: SandboxConfigState
   goTemplate?: string
   environment: Record<string, string>
   tags: Record<string, string>
@@ -52,6 +54,7 @@ const emptyTrigger: TriggerFormData = {
   reuseSession: false,
   mountPayload: false,
   oneshot: false,
+  sandboxState: defaultSandboxConfigState(),
   goTemplate: '',
   environment: {},
   tags: {},
@@ -109,6 +112,7 @@ export default function WebhookFormModal({
             reuseSession: t.session_config?.reuse_session ?? false,
             mountPayload: t.session_config?.mount_payload ?? false,
             oneshot: t.session_config?.params?.oneshot ?? false,
+            sandboxState: defaultSandboxConfigState(),
             goTemplate: t.conditions.go_template || '',
             environment: t.session_config?.environment || {},
             tags: t.session_config?.tags || {},
@@ -380,6 +384,11 @@ export default function WebhookFormModal({
         }
         // Always set oneshot explicitly (true or false)
         session_config.params.oneshot = t.oneshot
+        // Apply sandbox config if enabled
+        const triggerSandbox = sandboxConfigStateToConfig(t.sandboxState)
+        if (triggerSandbox) {
+          session_config.params.sandbox = triggerSandbox
+        }
 
         return {
           id: t.id,
@@ -1091,6 +1100,12 @@ export default function WebhookFormModal({
                       <p className="text-xs text-gray-500 dark:text-gray-400 -mt-3 ml-6">
                         有効にすると、セッション終了後に自動的に削除されます
                       </p>
+
+                      {/* Sandbox Config */}
+                      <SandboxConfigInput
+                        state={trigger.sandboxState}
+                        onChange={(s) => updateTrigger(index, 'sandboxState', s)}
+                      />
 
                       {/* Reuse Message Template */}
                       {trigger.reuseSession && (

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -17,6 +17,7 @@ import TopBar from '../../components/TopBar'
 import SessionCreationProgressModal from '../../components/SessionCreationProgressModal'
 import { SessionCreationProgress, SessionCreationStatus } from '../../../types/sessionProgress'
 import { useTeamScope } from '../../../contexts/TeamScopeContext'
+import SandboxConfigInput, { SandboxConfigState, defaultSandboxConfigState, sandboxConfigStateToConfig } from '../../components/SandboxConfigInput'
 
 export default function NewSessionPage() {
   const { selectedTeam } = useTeamScope()
@@ -41,6 +42,7 @@ export default function NewSessionPage() {
   const [cycleEnabled, setCycleEnabled] = useState(false)
   const [cycleMessage, setCycleMessage] = useState('')
   const [cycleMaxCount, setCycleMaxCount] = useState(10)
+  const [sandboxState, setSandboxState] = useState<SandboxConfigState>(defaultSandboxConfigState())
 
   useEffect(() => {
     loadTemplates()
@@ -122,7 +124,8 @@ export default function NewSessionPage() {
     message: string,
     repo: string,
     agentType: AgentApiType,
-    managerId: string
+    managerId: string,
+    sandbox?: ReturnType<typeof sandboxConfigStateToConfig>
   ): Promise<{ success: boolean; error?: string }> => {
     try {
       console.log('Starting session creation with initial message...')
@@ -166,6 +169,11 @@ export default function NewSessionPage() {
         if (cycleMaxCount > 0) {
           params.cycle_max_count = cycleMaxCount
         }
+      }
+
+      // サンドボックス設定が有効な場合は送信
+      if (sandbox) {
+        params.sandbox = sandbox
       }
 
       console.log('[NewSessionPage] Final params:', params)
@@ -270,7 +278,8 @@ export default function NewSessionPage() {
         currentMessage,
         currentRepository,
         selectedAgentType,
-        selectedManagerId
+        selectedManagerId,
+        sandboxConfigStateToConfig(sandboxState)
       )
     }
 
@@ -503,6 +512,11 @@ export default function NewSessionPage() {
                     サイクル{cycleMaxCount > 0 ? ` (${cycleMaxCount}回)` : ''}
                   </span>
                 )}
+                {sandboxState.enabled && (
+                  <span className="px-1.5 py-0.5 bg-green-100 dark:bg-green-900/40 text-green-600 dark:text-green-400 text-xs rounded-full">
+                    Sandbox
+                  </span>
+                )}
               </button>
 
               {showAdvancedSettings && (
@@ -636,6 +650,13 @@ export default function NewSessionPage() {
                       </div>
                     )}
                   </div>
+
+                  {/* サンドボックス設定 */}
+                  <SandboxConfigInput
+                    state={sandboxState}
+                    onChange={setSandboxState}
+                    disabled={isCreating}
+                  />
 
                   {/* エージェントタイプ */}
                   <div>

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,4 +1,5 @@
 import { ResourceScope } from './agentapi';
+import { ClaudeSandboxConfig } from '../app/components/SandboxConfigInput';
 
 // Schedule status types
 export type ScheduleStatus = 'active' | 'paused' | 'completed';
@@ -11,6 +12,7 @@ export interface ScheduleSessionConfig {
     message?: string;
     github_token?: string;
     oneshot?: boolean;
+    sandbox?: ClaudeSandboxConfig;
     [key: string]: unknown;
   };
   memory_key?: Record<string, string>;

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -1,4 +1,5 @@
 import { ResourceScope } from './agentapi';
+import { ClaudeSandboxConfig } from '../app/components/SandboxConfigInput';
 
 // Webhook types
 export type WebhookType = 'github' | 'custom';
@@ -37,6 +38,7 @@ export interface SessionParams {
   github_token?: string;
   agent_type?: string;
   oneshot?: boolean;
+  sandbox?: ClaudeSandboxConfig;
 }
 
 // Session configuration for webhook triggers


### PR DESCRIPTION
## Summary

- `SandboxConfigInput.tsx` 共有コンポーネントを新規作成
  - Claude Code の sandbox 設定（有効化、bash自動承認、除外コマンド、filesystem/network制限）を折りたたみ式UIで入力可能
- `NewConversationModal.tsx`、`ScheduleFormModal.tsx`、`WebhookFormModal.tsx` の各フォームに sandbox 設定セクションを追加
- `src/types/schedule.ts`、`src/types/webhook.ts` の params 型に `sandbox?: ClaudeSandboxConfig` を追加

## 設定項目

| 項目 | 説明 |
|---|---|
| enabled | サンドボックスの有効化 |
| autoAllowBashIfSandboxed | サンドボックス内 bash の自動承認 |
| allowUnsandboxedCommands | エスケープハッチの許可 |
| excludedCommands | サンドボックス除外コマンド（1行1パターン） |
| filesystem.allowWrite | 書き込み許可パス |
| filesystem.denyRead | 読み取り禁止パス |
| network.allowedDomains | 許可ドメイン |
| network.deniedDomains | 拒否ドメイン |

## Test plan

- [ ] セッション作成フォームで sandbox を有効化 → API リクエストに params.sandbox が含まれることを確認
- [ ] スケジュール作成フォームで sandbox を有効化 → session_config.params.sandbox に反映されることを確認
- [ ] webhook トリガーで sandbox を有効化 → trigger の session_config.params.sandbox に反映されることを確認
- [ ] sandbox 無効（デフォルト）のまま送信 → params.sandbox が含まれないことを確認
- [ ] TypeScript エラーなし (tsc --noEmit)

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)