### PR TITLE
feat: add session profile CRUD UI

### DIFF
--- a/src/app/components/MemoryFilterSidebar.tsx
+++ b/src/app/components/MemoryFilterSidebar.tsx
@@ -74,17 +74,17 @@ export default function MemoryFilterSidebar({
       {/* Sidebar */}
       <div
         className={`
-          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
+          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out flex flex-col
           md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
           ${isVisible ? 'translate-x-0' : '-translate-x-full'}
         `}
       >
-        <div className="p-4">
-          {/* Navigation Tabs */}
-          <div className="mb-4">
-            <NavigationTabs />
-          </div>
+        {/* Navigation Tabs - outside overflow container so dropdown isn't clipped */}
+        <div className="flex-shrink-0 px-4 pt-4 pb-0">
+          <NavigationTabs />
+        </div>
 
+        <div className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
           {/* Tab Switcher */}
           <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
             <button

--- a/src/app/components/NavigationTabs.tsx
+++ b/src/app/components/NavigationTabs.tsx
@@ -52,6 +52,15 @@ const allTabs: Tab[] = [
     ),
   },
   {
+    label: 'Profiles',
+    href: '/session-profiles',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+    ),
+  },
+  {
     label: 'Memories',
     href: '/memories',
     icon: (

--- a/src/app/components/ScheduleFilterSidebar.tsx
+++ b/src/app/components/ScheduleFilterSidebar.tsx
@@ -46,17 +46,17 @@ export default function ScheduleFilterSidebar({
       {/* Sidebar */}
       <div
         className={`
-          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
+          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out flex flex-col
           md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
           ${isVisible ? 'translate-x-0' : '-translate-x-full'}
         `}
       >
-        <div className="p-4">
-          {/* Navigation Tabs */}
-          <div className="mb-4">
-            <NavigationTabs />
-          </div>
+        {/* Navigation Tabs - outside overflow container so dropdown isn't clipped */}
+        <div className="flex-shrink-0 px-4 pt-4 pb-0">
+          <NavigationTabs />
+        </div>
 
+        <div className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
           {/* Tab Switcher */}
           <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
             <button

--- a/src/app/components/ScheduleFormModal.tsx
+++ b/src/app/components/ScheduleFormModal.tsx
@@ -7,6 +7,7 @@ import CronExpressionInput from './CronExpressionInput'
 import { OrganizationHistory } from '../../utils/organizationHistory'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 import MemoryKeyInput, { MemoryKeyPair, memoryKeyPairsToRecord, recordToMemoryKeyPairs } from './MemoryKeyInput'
+import SessionProfileSelect from './SessionProfileSelect'
 
 interface ScheduleFormModalProps {
   isOpen: boolean
@@ -34,6 +35,7 @@ export default function ScheduleFormModal({
   const [repositorySuggestions, setRepositorySuggestions] = useState<string[]>([])
   const [showRepositorySuggestions, setShowRepositorySuggestions] = useState(false)
 
+  const [sessionProfileId, setSessionProfileId] = useState('')
   const [oneshot, setOneshot] = useState(false)
   const [reuseSession, setReuseSession] = useState(false)
   const [reuseMessage, setReuseMessage] = useState('')
@@ -52,6 +54,7 @@ export default function ScheduleFormModal({
       setTimezone(editingSchedule.timezone || 'Asia/Tokyo')
       setMessage(editingSchedule.session_config?.params?.message || '')
       setRepository(editingSchedule.session_config?.tags?.repository || '')
+      setSessionProfileId(editingSchedule.session_config?.session_profile_id || '')
       setOneshot(editingSchedule.session_config?.params?.oneshot === true)
       setReuseSession(editingSchedule.session_config?.reuse_session === true)
       setReuseMessage(editingSchedule.session_config?.reuse_message || '')
@@ -103,6 +106,7 @@ export default function ScheduleFormModal({
     setTimezone('Asia/Tokyo')
     setMessage('')
     setRepository('')
+    setSessionProfileId('')
     setOneshot(false)
     setReuseSession(false)
     setReuseMessage('')
@@ -202,6 +206,7 @@ export default function ScheduleFormModal({
           reuse_session: reuseSession || undefined,
           reuse_message: (reuseSession && reuseMessage.trim()) ? reuseMessage.trim() : undefined,
           environment: environment || undefined,
+          session_profile_id: sessionProfileId.trim() || undefined,
         },
         ...scopeParams,
       }
@@ -577,6 +582,21 @@ export default function ScheduleFormModal({
               disabled={isSubmitting}
               helpText="KEY=VALUE 形式で環境変数を入力してください"
             />
+          </div>
+
+          {/* Session Profile */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              セッションプロファイル
+            </label>
+            <SessionProfileSelect
+              value={sessionProfileId}
+              onChange={setSessionProfileId}
+              disabled={isSubmitting}
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              プロファイルを選択すると、環境変数・タグ・テンプレートなどの設定を適用します
+            </p>
           </div>
 
           {/* Error */}

--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -89,12 +89,12 @@ export default function SessionProfileCard({
 
       {/* Config summary */}
       <div className="flex items-center gap-4 mb-3 text-xs text-gray-500 dark:text-gray-400 flex-wrap">
-        {profile.config?.reuse_session && (
-          <span className="inline-flex items-center gap-1">
+        {profile.config?.params?.agent_type && (
+          <span className="inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-400">
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
             </svg>
-            セッション再利用
+            {profile.config.params.agent_type}
           </span>
         )}
         {profile.config?.params?.sandbox?.enabled && (

--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -77,16 +77,6 @@ export default function SessionProfileCard({
         </div>
       )}
 
-      {/* Initial message template */}
-      {profile.config?.initial_message_template && (
-        <div className="mb-3">
-          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">初期メッセージテンプレート</div>
-          <p className="text-xs text-gray-700 dark:text-gray-300 line-clamp-2 bg-gray-50 dark:bg-gray-700/50 px-2 py-1.5 rounded font-mono">
-            {profile.config.initial_message_template}
-          </p>
-        </div>
-      )}
-
       {/* Config summary */}
       <div className="flex items-center gap-4 mb-3 text-xs text-gray-500 dark:text-gray-400 flex-wrap">
         {profile.config?.params?.agent_type && (

--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { SessionProfile } from '../../types/session_profile'
+
+interface SessionProfileCardProps {
+  profile: SessionProfile
+  onEdit: (profile: SessionProfile) => void
+  onDelete: (profileId: string) => void
+  isDeleting?: boolean
+}
+
+export default function SessionProfileCard({
+  profile,
+  onEdit,
+  onDelete,
+  isDeleting = false,
+}: SessionProfileCardProps) {
+  const handleDelete = () => {
+    if (confirm(`"${profile.name}" を削除してもよいですか？`)) {
+      onDelete(profile.id)
+    }
+  }
+
+  const formatDate = (dateStr: string) => {
+    try {
+      return new Date(dateStr).toLocaleString('ja-JP', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    } catch {
+      return dateStr
+    }
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-5 shadow-sm hover:shadow-md transition-shadow">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          {/* Profile icon */}
+          <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center">
+            <svg className="w-4 h-4 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+          </div>
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white truncate">
+            {profile.name}
+          </h3>
+        </div>
+        <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
+          {profile.is_default && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300">
+              デフォルト
+            </span>
+          )}
+          {profile.scope === 'team' ? (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300">
+              チーム
+            </span>
+          ) : (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+              個人
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Description */}
+      {profile.description && (
+        <div className="mb-3">
+          <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+            {profile.description}
+          </p>
+        </div>
+      )}
+
+      {/* Initial message template */}
+      {profile.config?.initial_message_template && (
+        <div className="mb-3">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">初期メッセージテンプレート</div>
+          <p className="text-xs text-gray-700 dark:text-gray-300 line-clamp-2 bg-gray-50 dark:bg-gray-700/50 px-2 py-1.5 rounded font-mono">
+            {profile.config.initial_message_template}
+          </p>
+        </div>
+      )}
+
+      {/* Config summary */}
+      <div className="flex items-center gap-4 mb-3 text-xs text-gray-500 dark:text-gray-400">
+        {profile.config?.reuse_session && (
+          <span className="inline-flex items-center gap-1">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            セッション再利用
+          </span>
+        )}
+        {profile.config?.environment && Object.keys(profile.config.environment).length > 0 && (
+          <span>環境変数: <strong className="text-gray-700 dark:text-gray-300">{Object.keys(profile.config.environment).length}</strong></span>
+        )}
+        {profile.config?.tags && Object.keys(profile.config.tags).length > 0 && (
+          <span>タグ: <strong className="text-gray-700 dark:text-gray-300">{Object.keys(profile.config.tags).length}</strong></span>
+        )}
+      </div>
+
+      {/* Timestamps */}
+      <div className="text-xs text-gray-400 dark:text-gray-500 mt-3 mb-4">
+        作成: {formatDate(profile.created_at)}
+        {profile.updated_at !== profile.created_at && (
+          <span className="ml-3">更新: {formatDate(profile.updated_at)}</span>
+        )}
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex items-center gap-2 pt-3 border-t border-gray-100 dark:border-gray-700">
+        {/* Edit */}
+        <button
+          onClick={() => onEdit(profile)}
+          className="flex-1 inline-flex items-center justify-center px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md transition-colors"
+        >
+          <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+          </svg>
+          編集
+        </button>
+
+        {/* Delete */}
+        <button
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="flex-1 inline-flex items-center justify-center px-3 py-1.5 text-sm text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 rounded-md transition-colors disabled:opacity-50"
+        >
+          {isDeleting ? (
+            <svg className="w-4 h-4 mr-1 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+          ) : (
+            <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          )}
+          削除
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -88,13 +88,21 @@ export default function SessionProfileCard({
       )}
 
       {/* Config summary */}
-      <div className="flex items-center gap-4 mb-3 text-xs text-gray-500 dark:text-gray-400">
+      <div className="flex items-center gap-4 mb-3 text-xs text-gray-500 dark:text-gray-400 flex-wrap">
         {profile.config?.reuse_session && (
           <span className="inline-flex items-center gap-1">
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
             </svg>
             セッション再利用
+          </span>
+        )}
+        {profile.config?.params?.sandbox?.enabled && (
+          <span className="inline-flex items-center gap-1 text-orange-600 dark:text-orange-400">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            サンドボックス
           </span>
         )}
         {profile.config?.environment && Object.keys(profile.config.environment).length > 0 && (

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -1,0 +1,493 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  SessionProfile,
+  CreateSessionProfileRequest,
+  UpdateSessionProfileRequest,
+} from '../../types/session_profile'
+import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
+import { useTeamScope } from '../../contexts/TeamScopeContext'
+
+interface SessionProfileFormModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+  editingProfile?: SessionProfile | null
+}
+
+type KeyValuePair = { key: string; value: string }
+
+export default function SessionProfileFormModal({
+  isOpen,
+  onClose,
+  onSuccess,
+  editingProfile,
+}: SessionProfileFormModalProps) {
+  const { getScopeParams } = useTeamScope()
+
+  // Basic fields
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [isDefault, setIsDefault] = useState(false)
+
+  // Config fields
+  const [envPairs, setEnvPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
+  const [tagPairs, setTagPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
+  const [initialMessageTemplate, setInitialMessageTemplate] = useState('')
+  const [reuseMessageTemplate, setReuseMessageTemplate] = useState('')
+  const [reuseSession, setReuseSession] = useState(false)
+
+  // UI state
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+
+  const isEditing = !!editingProfile
+
+  // Initialize form when editing
+  useEffect(() => {
+    if (editingProfile) {
+      setName(editingProfile.name)
+      setDescription(editingProfile.description ?? '')
+      setIsDefault(editingProfile.is_default ?? false)
+
+      const cfg = editingProfile.config
+      setInitialMessageTemplate(cfg?.initial_message_template ?? '')
+      setReuseMessageTemplate(cfg?.reuse_message_template ?? '')
+      setReuseSession(cfg?.reuse_session ?? false)
+
+      if (cfg?.environment && Object.keys(cfg.environment).length > 0) {
+        setEnvPairs(Object.entries(cfg.environment).map(([key, value]) => ({ key, value })))
+        setShowAdvanced(true)
+      } else {
+        setEnvPairs([{ key: '', value: '' }])
+      }
+
+      if (cfg?.tags && Object.keys(cfg.tags).length > 0) {
+        setTagPairs(Object.entries(cfg.tags).map(([key, value]) => ({ key, value })))
+        setShowAdvanced(true)
+      } else {
+        setTagPairs([{ key: '', value: '' }])
+      }
+
+      if (cfg?.initial_message_template || cfg?.reuse_message_template || cfg?.reuse_session) {
+        setShowAdvanced(true)
+      }
+    } else {
+      // Reset form
+      setName('')
+      setDescription('')
+      setIsDefault(false)
+      setEnvPairs([{ key: '', value: '' }])
+      setTagPairs([{ key: '', value: '' }])
+      setInitialMessageTemplate('')
+      setReuseMessageTemplate('')
+      setReuseSession(false)
+      setShowAdvanced(false)
+    }
+    setError(null)
+  }, [editingProfile, isOpen])
+
+  // Keyboard handler
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    },
+    [onClose]
+  )
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown)
+    }
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, handleKeyDown])
+
+  // Key-value pair helpers
+  const updatePair = (
+    pairs: KeyValuePair[],
+    setPairs: React.Dispatch<React.SetStateAction<KeyValuePair[]>>,
+    index: number,
+    field: 'key' | 'value',
+    val: string
+  ) => {
+    const next = [...pairs]
+    next[index] = { ...next[index], [field]: val }
+    setPairs(next)
+  }
+
+  const addPair = (setPairs: React.Dispatch<React.SetStateAction<KeyValuePair[]>>) => {
+    setPairs((prev) => [...prev, { key: '', value: '' }])
+  }
+
+  const removePair = (
+    pairs: KeyValuePair[],
+    setPairs: React.Dispatch<React.SetStateAction<KeyValuePair[]>>,
+    index: number
+  ) => {
+    if (pairs.length === 1) {
+      setPairs([{ key: '', value: '' }])
+    } else {
+      setPairs((prev) => prev.filter((_, i) => i !== index))
+    }
+  }
+
+  const pairsToRecord = (pairs: KeyValuePair[]): Record<string, string> => {
+    const record: Record<string, string> = {}
+    pairs.forEach(({ key, value }) => {
+      if (key.trim()) record[key.trim()] = value
+    })
+    return record
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!name.trim()) {
+      setError('名前は必須です')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+
+      const environment = pairsToRecord(envPairs)
+      const tags = pairsToRecord(tagPairs)
+
+      const config = {
+        ...(initialMessageTemplate.trim() ? { initial_message_template: initialMessageTemplate.trim() } : {}),
+        ...(reuseMessageTemplate.trim() ? { reuse_message_template: reuseMessageTemplate.trim() } : {}),
+        ...(reuseSession ? { reuse_session: reuseSession } : {}),
+        ...(Object.keys(environment).length > 0 ? { environment } : {}),
+        ...(Object.keys(tags).length > 0 ? { tags } : {}),
+      }
+
+      if (isEditing && editingProfile) {
+        const updateData: UpdateSessionProfileRequest = {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          is_default: isDefault,
+          config: Object.keys(config).length > 0 ? config : undefined,
+        }
+        await client.updateSessionProfile(editingProfile.id, updateData)
+      } else {
+        const scopeParams = getScopeParams()
+        const createData: CreateSessionProfileRequest = {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          is_default: isDefault,
+          ...(Object.keys(config).length > 0 ? { config } : {}),
+          ...scopeParams,
+        }
+        await client.createSessionProfile(createData)
+      }
+
+      onSuccess()
+    } catch (err) {
+      console.error('Failed to save session profile:', err)
+      setError(err instanceof Error ? err.message : 'セッションプロファイルの保存に失敗しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative min-h-full flex items-center justify-center p-4">
+        <div
+          className="relative bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-2xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <div className="flex items-center gap-2">
+              <div className="w-7 h-7 rounded-lg bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center">
+                <svg className="w-4 h-4 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+              </div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                {isEditing ? 'プロファイルを編集' : '新しいプロファイル'}
+              </h2>
+            </div>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="px-6 py-5 space-y-5 max-h-[70vh] overflow-y-auto">
+            {/* Error */}
+            {error && (
+              <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
+              </div>
+            )}
+
+            {/* Name */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                名前 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="例: my-profile"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
+                required
+              />
+            </div>
+
+            {/* Description */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                説明
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="このプロファイルの用途を説明してください"
+                rows={2}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y"
+              />
+            </div>
+
+            {/* is_default */}
+            <div>
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={isDefault}
+                  onChange={(e) => setIsDefault(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                />
+                <div>
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    デフォルトプロファイルに設定する
+                  </span>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    セッション作成時にこのプロファイルをデフォルトとして使用します。
+                  </p>
+                </div>
+              </label>
+            </div>
+
+            {/* Config Section */}
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowAdvanced(!showAdvanced)}
+                className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+              >
+                <svg
+                  className={`w-4 h-4 transition-transform ${showAdvanced ? 'rotate-90' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+                設定（Config）
+              </button>
+
+              {showAdvanced && (
+                <div className="mt-4 space-y-5 pl-4 border-l-2 border-gray-200 dark:border-gray-700">
+                  {/* Environment Variables */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      環境変数
+                    </label>
+                    <div className="space-y-2">
+                      {envPairs.map((pair, idx) => (
+                        <div key={idx} className="flex items-center gap-2">
+                          <input
+                            type="text"
+                            value={pair.key}
+                            onChange={(e) => updatePair(envPairs, setEnvPairs, idx, 'key', e.target.value)}
+                            placeholder="KEY"
+                            className="flex-1 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          />
+                          <span className="text-gray-400 dark:text-gray-500 text-xs">=</span>
+                          <input
+                            type="text"
+                            value={pair.value}
+                            onChange={(e) => updatePair(envPairs, setEnvPairs, idx, 'value', e.target.value)}
+                            placeholder="value"
+                            className="flex-1 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removePair(envPairs, setEnvPairs, idx)}
+                            className="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400"
+                          >
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={() => addPair(setEnvPairs)}
+                        className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 flex items-center gap-1"
+                      >
+                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                        </svg>
+                        追加
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Tags */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      タグ
+                    </label>
+                    <div className="space-y-2">
+                      {tagPairs.map((pair, idx) => (
+                        <div key={idx} className="flex items-center gap-2">
+                          <input
+                            type="text"
+                            value={pair.key}
+                            onChange={(e) => updatePair(tagPairs, setTagPairs, idx, 'key', e.target.value)}
+                            placeholder="key"
+                            className="flex-1 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          />
+                          <span className="text-gray-400 dark:text-gray-500 text-xs">=</span>
+                          <input
+                            type="text"
+                            value={pair.value}
+                            onChange={(e) => updatePair(tagPairs, setTagPairs, idx, 'value', e.target.value)}
+                            placeholder="value"
+                            className="flex-1 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removePair(tagPairs, setTagPairs, idx)}
+                            className="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400"
+                          >
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={() => addPair(setTagPairs)}
+                        className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 flex items-center gap-1"
+                      >
+                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                        </svg>
+                        追加
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Initial Message Template */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      初期メッセージテンプレート
+                    </label>
+                    <textarea
+                      value={initialMessageTemplate}
+                      onChange={(e) => setInitialMessageTemplate(e.target.value)}
+                      placeholder="例: 以下のタスクを実行してください: ..."
+                      rows={3}
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
+                    />
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      新規セッション作成時に送信されるメッセージのテンプレート。
+                    </p>
+                  </div>
+
+                  {/* Reuse Message Template */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      再利用メッセージテンプレート
+                    </label>
+                    <textarea
+                      value={reuseMessageTemplate}
+                      onChange={(e) => setReuseMessageTemplate(e.target.value)}
+                      placeholder="例: 続きのタスクを実行してください: ..."
+                      rows={3}
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
+                    />
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      既存セッションを再利用する際に送信されるメッセージのテンプレート。
+                    </p>
+                  </div>
+
+                  {/* Reuse Session */}
+                  <div>
+                    <label className="flex items-start gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={reuseSession}
+                        onChange={(e) => setReuseSession(e.target.checked)}
+                        className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                      />
+                      <div>
+                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          セッションを再利用する
+                        </span>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          有効にすると、既存のセッションを再利用して新しいメッセージを送信します。
+                        </p>
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              )}
+            </div>
+          </form>
+
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors disabled:opacity-50"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="px-4 py-2 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+            >
+              {isSubmitting && (
+                <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              )}
+              {isEditing ? '保存' : '作成'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -463,23 +463,37 @@ export default function SessionProfileFormModal({
 
                   {/* Agent Type */}
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                       エージェントタイプ
                     </label>
-                    <select
-                      value={agentType}
-                      onChange={(e) => setAgentType(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    >
-                      <option value="">指定しない（サーバーデフォルト）</option>
-                      <option value="claude-agentapi">Claude AgentAPI</option>
-                      <option value="codex-agentapi">Codex AgentAPI</option>
-                      <option value="claude-acp">Claude ACP</option>
-                      <option value="codex-acp">Codex ACP</option>
-                    </select>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      セッション作成時に使用するエージェントの種類を指定します。
-                    </p>
+                    <div className="space-y-2">
+                      {([
+                        { value: '', label: 'デフォルト', description: 'agent_type を送信しない' },
+                        { value: 'claude-agentapi', label: 'Claude AgentAPI', description: 'agent_type=claude-agentapi を送信' },
+                        { value: 'codex-agentapi', label: 'Codex AgentAPI', description: 'agent_type=codex-agentapi を送信' },
+                        { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
+                        { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
+                      ]).map(({ value: v, label, description }) => (
+                        <label key={v} className="flex items-start cursor-pointer group">
+                          <input
+                            type="radio"
+                            name="profile-agent-type"
+                            value={v}
+                            checked={agentType === v}
+                            onChange={() => setAgentType(v)}
+                            className="mt-0.5 w-3.5 h-3.5 text-blue-600 border-gray-300 dark:border-gray-600 focus:ring-blue-500"
+                          />
+                          <span className="ml-2">
+                            <span className="block text-xs font-medium text-gray-600 dark:text-gray-400 group-hover:text-gray-800 dark:group-hover:text-gray-200">
+                              {label}
+                            </span>
+                            <span className="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+                              {description}
+                            </span>
+                          </span>
+                        </label>
+                      ))}
+                    </div>
                   </div>
 
                   {/* Sandbox */}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -34,7 +34,6 @@ export default function SessionProfileFormModal({
   // Config fields
   const [envPairs, setEnvPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [tagPairs, setTagPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
-  const [initialMessageTemplate, setInitialMessageTemplate] = useState('')
   const [agentType, setAgentType] = useState('')
 
   // Sandbox fields
@@ -57,7 +56,6 @@ export default function SessionProfileFormModal({
       setIsDefault(editingProfile.is_default ?? false)
 
       const cfg = editingProfile.config
-      setInitialMessageTemplate(cfg?.initial_message_template ?? '')
       setAgentType(cfg?.params?.agent_type ?? '')
 
       if (cfg?.environment && Object.keys(cfg.environment).length > 0) {
@@ -74,7 +72,7 @@ export default function SessionProfileFormModal({
         setTagPairs([{ key: '', value: '' }])
       }
 
-      if (cfg?.initial_message_template || cfg?.params?.agent_type) {
+      if (cfg?.params?.agent_type) {
         setShowAdvanced(true)
       }
 
@@ -102,7 +100,6 @@ export default function SessionProfileFormModal({
       setIsDefault(false)
       setEnvPairs([{ key: '', value: '' }])
       setTagPairs([{ key: '', value: '' }])
-      setInitialMessageTemplate('')
       setAgentType('')
       setSandboxEnabled(false)
       setSandboxMode('allowlist')
@@ -199,7 +196,6 @@ export default function SessionProfileFormModal({
       } : undefined
 
       const config = {
-        ...(initialMessageTemplate.trim() ? { initial_message_template: initialMessageTemplate.trim() } : {}),
         ...(Object.keys(environment).length > 0 ? { environment } : {}),
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
         ...(params ? { params } : {}),
@@ -442,23 +438,6 @@ export default function SessionProfileFormModal({
                         追加
                       </button>
                     </div>
-                  </div>
-
-                  {/* Initial Message Template */}
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      初期メッセージテンプレート
-                    </label>
-                    <textarea
-                      value={initialMessageTemplate}
-                      onChange={(e) => setInitialMessageTemplate(e.target.value)}
-                      placeholder="例: 以下のタスクを実行してください: ..."
-                      rows={3}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
-                    />
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      新規セッション作成時に送信されるメッセージのテンプレート。
-                    </p>
                   </div>
 
                   {/* Agent Type */}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -35,8 +35,7 @@ export default function SessionProfileFormModal({
   const [envPairs, setEnvPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [tagPairs, setTagPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [initialMessageTemplate, setInitialMessageTemplate] = useState('')
-  const [reuseMessageTemplate, setReuseMessageTemplate] = useState('')
-  const [reuseSession, setReuseSession] = useState(false)
+  const [agentType, setAgentType] = useState('')
 
   // Sandbox fields
   const [sandboxEnabled, setSandboxEnabled] = useState(false)
@@ -59,8 +58,7 @@ export default function SessionProfileFormModal({
 
       const cfg = editingProfile.config
       setInitialMessageTemplate(cfg?.initial_message_template ?? '')
-      setReuseMessageTemplate(cfg?.reuse_message_template ?? '')
-      setReuseSession(cfg?.reuse_session ?? false)
+      setAgentType(cfg?.params?.agent_type ?? '')
 
       if (cfg?.environment && Object.keys(cfg.environment).length > 0) {
         setEnvPairs(Object.entries(cfg.environment).map(([key, value]) => ({ key, value })))
@@ -76,7 +74,7 @@ export default function SessionProfileFormModal({
         setTagPairs([{ key: '', value: '' }])
       }
 
-      if (cfg?.initial_message_template || cfg?.reuse_message_template || cfg?.reuse_session) {
+      if (cfg?.initial_message_template || cfg?.params?.agent_type) {
         setShowAdvanced(true)
       }
 
@@ -105,8 +103,7 @@ export default function SessionProfileFormModal({
       setEnvPairs([{ key: '', value: '' }])
       setTagPairs([{ key: '', value: '' }])
       setInitialMessageTemplate('')
-      setReuseMessageTemplate('')
-      setReuseSession(false)
+      setAgentType('')
       setSandboxEnabled(false)
       setSandboxMode('allowlist')
       setSandboxDomains('')
@@ -194,13 +191,18 @@ export default function SessionProfileFormModal({
         }
       }
 
+      // Build params if any param is set
+      const hasParams = agentType.trim() || sandboxConfig
+      const params = hasParams ? {
+        ...(agentType.trim() ? { agent_type: agentType.trim() } : {}),
+        ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
+      } : undefined
+
       const config = {
         ...(initialMessageTemplate.trim() ? { initial_message_template: initialMessageTemplate.trim() } : {}),
-        ...(reuseMessageTemplate.trim() ? { reuse_message_template: reuseMessageTemplate.trim() } : {}),
-        ...(reuseSession ? { reuse_session: reuseSession } : {}),
         ...(Object.keys(environment).length > 0 ? { environment } : {}),
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
-        ...(sandboxConfig ? { params: { sandbox: sandboxConfig } } : {}),
+        ...(params ? { params } : {}),
       }
 
       if (isEditing && editingProfile) {
@@ -459,41 +461,25 @@ export default function SessionProfileFormModal({
                     </p>
                   </div>
 
-                  {/* Reuse Message Template */}
+                  {/* Agent Type */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      再利用メッセージテンプレート
+                      エージェントタイプ
                     </label>
-                    <textarea
-                      value={reuseMessageTemplate}
-                      onChange={(e) => setReuseMessageTemplate(e.target.value)}
-                      placeholder="例: 続きのタスクを実行してください: ..."
-                      rows={3}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
-                    />
+                    <select
+                      value={agentType}
+                      onChange={(e) => setAgentType(e.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      <option value="">指定しない（サーバーデフォルト）</option>
+                      <option value="claude-agentapi">Claude AgentAPI</option>
+                      <option value="codex-agentapi">Codex AgentAPI</option>
+                      <option value="claude-acp">Claude ACP</option>
+                      <option value="codex-acp">Codex ACP</option>
+                    </select>
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      既存セッションを再利用する際に送信されるメッセージのテンプレート。
+                      セッション作成時に使用するエージェントの種類を指定します。
                     </p>
-                  </div>
-
-                  {/* Reuse Session */}
-                  <div>
-                    <label className="flex items-start gap-2 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={reuseSession}
-                        onChange={(e) => setReuseSession(e.target.checked)}
-                        className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
-                      />
-                      <div>
-                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                          セッションを再利用する
-                        </span>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                          有効にすると、既存のセッションを再利用して新しいメッセージを送信します。
-                        </p>
-                      </div>
-                    </label>
                   </div>
 
                   {/* Sandbox */}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -38,6 +38,11 @@ export default function SessionProfileFormModal({
   const [reuseMessageTemplate, setReuseMessageTemplate] = useState('')
   const [reuseSession, setReuseSession] = useState(false)
 
+  // Sandbox fields
+  const [sandboxEnabled, setSandboxEnabled] = useState(false)
+  const [sandboxMode, setSandboxMode] = useState<'allowlist' | 'denylist'>('allowlist')
+  const [sandboxDomains, setSandboxDomains] = useState('')
+
   // UI state
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -74,6 +79,24 @@ export default function SessionProfileFormModal({
       if (cfg?.initial_message_template || cfg?.reuse_message_template || cfg?.reuse_session) {
         setShowAdvanced(true)
       }
+
+      // Initialize sandbox from profile params
+      const sandbox = cfg?.params?.sandbox
+      if (sandbox) {
+        setSandboxEnabled(sandbox.enabled)
+        if (sandbox.allowed_domains && sandbox.allowed_domains.length > 0) {
+          setSandboxMode('allowlist')
+          setSandboxDomains(sandbox.allowed_domains.join('\n'))
+        } else if (sandbox.denied_domains && sandbox.denied_domains.length > 0) {
+          setSandboxMode('denylist')
+          setSandboxDomains(sandbox.denied_domains.join('\n'))
+        }
+        if (sandbox.enabled) setShowAdvanced(true)
+      } else {
+        setSandboxEnabled(false)
+        setSandboxMode('allowlist')
+        setSandboxDomains('')
+      }
     } else {
       // Reset form
       setName('')
@@ -84,6 +107,9 @@ export default function SessionProfileFormModal({
       setInitialMessageTemplate('')
       setReuseMessageTemplate('')
       setReuseSession(false)
+      setSandboxEnabled(false)
+      setSandboxMode('allowlist')
+      setSandboxDomains('')
       setShowAdvanced(false)
     }
     setError(null)
@@ -157,12 +183,24 @@ export default function SessionProfileFormModal({
       const environment = pairsToRecord(envPairs)
       const tags = pairsToRecord(tagPairs)
 
+      // Build sandbox config if enabled
+      let sandboxConfig: { enabled: boolean; allowed_domains?: string[]; denied_domains?: string[] } | undefined
+      if (sandboxEnabled) {
+        const domainList = sandboxDomains.split('\n').map(d => d.trim()).filter(Boolean)
+        sandboxConfig = {
+          enabled: true,
+          ...(sandboxMode === 'allowlist' && domainList.length > 0 ? { allowed_domains: domainList } : {}),
+          ...(sandboxMode === 'denylist' && domainList.length > 0 ? { denied_domains: domainList } : {}),
+        }
+      }
+
       const config = {
         ...(initialMessageTemplate.trim() ? { initial_message_template: initialMessageTemplate.trim() } : {}),
         ...(reuseMessageTemplate.trim() ? { reuse_message_template: reuseMessageTemplate.trim() } : {}),
         ...(reuseSession ? { reuse_session: reuseSession } : {}),
         ...(Object.keys(environment).length > 0 ? { environment } : {}),
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
+        ...(sandboxConfig ? { params: { sandbox: sandboxConfig } } : {}),
       }
 
       if (isEditing && editingProfile) {
@@ -456,6 +494,70 @@ export default function SessionProfileFormModal({
                         </p>
                       </div>
                     </label>
+                  </div>
+
+                  {/* Sandbox */}
+                  <div>
+                    <label className="flex items-start gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={sandboxEnabled}
+                        onChange={(e) => setSandboxEnabled(e.target.checked)}
+                        className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                      />
+                      <div>
+                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          サンドボックス（ネットワーク制限）を有効にする
+                        </span>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          セッションのアウトバウンドネットワークアクセスをドメインレベルで制限します。
+                        </p>
+                      </div>
+                    </label>
+
+                    {sandboxEnabled && (
+                      <div className="mt-3 ml-6 space-y-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                            モード
+                          </label>
+                          <div className="flex gap-4">
+                            <label className="flex items-center gap-1.5 cursor-pointer">
+                              <input
+                                type="radio"
+                                value="allowlist"
+                                checked={sandboxMode === 'allowlist'}
+                                onChange={() => setSandboxMode('allowlist')}
+                                className="h-3.5 w-3.5 text-blue-600 focus:ring-blue-500"
+                              />
+                              <span className="text-xs text-gray-700 dark:text-gray-300">許可リスト（指定ドメインのみ許可）</span>
+                            </label>
+                            <label className="flex items-center gap-1.5 cursor-pointer">
+                              <input
+                                type="radio"
+                                value="denylist"
+                                checked={sandboxMode === 'denylist'}
+                                onChange={() => setSandboxMode('denylist')}
+                                className="h-3.5 w-3.5 text-blue-600 focus:ring-blue-500"
+                              />
+                              <span className="text-xs text-gray-700 dark:text-gray-300">拒否リスト（指定ドメインをブロック）</span>
+                            </label>
+                          </div>
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                            ドメインリスト（1行に1ドメイン）
+                          </label>
+                          <textarea
+                            value={sandboxDomains}
+                            onChange={(e) => setSandboxDomains(e.target.value)}
+                            placeholder={sandboxMode === 'allowlist' ? 'example.com\napi.github.com' : 'example.com\nbad-domain.com'}
+                            rows={4}
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
+                          />
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}

--- a/src/app/components/SessionProfileListView.tsx
+++ b/src/app/components/SessionProfileListView.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { SessionProfile } from '../../types/session_profile'
+import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
+import SessionProfileCard from './SessionProfileCard'
+import { useTeamScope } from '../../contexts/TeamScopeContext'
+
+interface SessionProfileListViewProps {
+  onProfileEdit: (profile: SessionProfile) => void
+  onProfilesUpdate?: () => void
+}
+
+export default function SessionProfileListView({
+  onProfileEdit,
+  onProfilesUpdate,
+}: SessionProfileListViewProps) {
+  const { getScopeParams } = useTeamScope()
+  const [profiles, setProfiles] = useState<SessionProfile[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
+  const fetchIdRef = useRef(0)
+
+  const fetchProfiles = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current
+    try {
+      setLoading(true)
+      setError(null)
+
+      const scopeParams = getScopeParams()
+
+      const client = createAgentAPIProxyClientFromStorage()
+      const response = await client.getSessionProfiles({
+        ...scopeParams,
+      })
+
+      if (fetchId !== fetchIdRef.current) return
+      setProfiles(response.session_profiles || [])
+    } catch (err) {
+      if (fetchId !== fetchIdRef.current) return
+      console.error('Failed to fetch session profiles:', err)
+      setError(err instanceof Error ? err.message : 'セッションプロファイルの取得に失敗しました')
+    } finally {
+      if (fetchId === fetchIdRef.current) {
+        setLoading(false)
+      }
+    }
+  }, [getScopeParams])
+
+  // Refetch profiles when team scope changes
+  useEffect(() => {
+    fetchProfiles()
+  }, [fetchProfiles])
+
+  const handleDelete = async (profileId: string) => {
+    setDeletingIds((prev) => new Set(prev).add(profileId))
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      await client.deleteSessionProfile(profileId)
+      setProfiles((prev) => prev.filter((p) => p.id !== profileId))
+      onProfilesUpdate?.()
+    } catch (err) {
+      console.error('Failed to delete session profile:', err)
+      alert(err instanceof Error ? err.message : 'セッションプロファイルの削除に失敗しました')
+    } finally {
+      setDeletingIds((prev) => {
+        const next = new Set(prev)
+        next.delete(profileId)
+        return next
+      })
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="flex items-center gap-3 text-gray-500 dark:text-gray-400">
+          <svg className="w-5 h-5 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          <span className="text-sm">セッションプロファイルを読み込み中...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-center">
+          <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+            <svg className="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <p className="text-sm text-red-600 dark:text-red-400 mb-3">{error}</p>
+          <button
+            onClick={fetchProfiles}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            再試行
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (profiles.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-center">
+          <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+            <svg className="w-6 h-6 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+          </div>
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            セッションプロファイルがまだありません
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            右上の「新しいプロファイル」ボタンから作成してください
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {profiles.map((profile) => (
+        <SessionProfileCard
+          key={profile.id}
+          profile={profile}
+          onEdit={onProfileEdit}
+          onDelete={handleDelete}
+          isDeleting={deletingIds.has(profile.id)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/app/components/SessionProfileSelect.tsx
+++ b/src/app/components/SessionProfileSelect.tsx
@@ -80,7 +80,7 @@ export default function SessionProfileSelect({
               {profiles.map((profile) => (
                 <option key={profile.id} value={profile.id}>
                   {profile.name}
-                  {profile.is_default ? ' ★' : ''}
+                  {profile.is_default ? ' (default)' : ''}
                   {profile.scope === 'team' ? ' [チーム]' : ''}
                 </option>
               ))}
@@ -99,11 +99,8 @@ export default function SessionProfileSelect({
       {selected && (
         <div className="px-3 py-1.5 bg-blue-50 dark:bg-blue-900/20 border-t border-gray-100 dark:border-gray-700 flex items-center gap-2 flex-wrap">
           {selected.is_default && (
-            <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
-              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-              </svg>
-              デフォルト
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+              default
             </span>
           )}
           {selected.scope === 'team' && (

--- a/src/app/components/SessionProfileSelect.tsx
+++ b/src/app/components/SessionProfileSelect.tsx
@@ -18,7 +18,7 @@ export default function SessionProfileSelect({
   onChange,
   disabled = false,
   className = '',
-  placeholder = 'プロファイルを選択（任意）',
+  placeholder = 'プロファイルなし',
 }: SessionProfileSelectProps) {
   const { getScopeParams } = useTeamScope()
   const [profiles, setProfiles] = useState<SessionProfile[]>([])
@@ -48,32 +48,94 @@ export default function SessionProfileSelect({
     fetchProfiles()
   }, [getScopeParams]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (loading) {
-    return (
-      <select
-        disabled
-        className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white opacity-50 ${className}`}
-      >
-        <option>読み込み中...</option>
-      </select>
-    )
-  }
+  const selected = profiles.find((p) => p.id === value)
 
   return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      disabled={disabled}
-      className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white disabled:opacity-50 ${className}`}
-    >
-      <option value="">{placeholder}</option>
-      {profiles.map((profile) => (
-        <option key={profile.id} value={profile.id}>
-          {profile.name}
-          {profile.is_default ? ' (デフォルト)' : ''}
-          {profile.scope === 'team' ? ' [チーム]' : ''}
-        </option>
-      ))}
-    </select>
+    <div className={`rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden ${disabled ? 'opacity-50' : ''} ${className}`}>
+      {/* Select row */}
+      <div className="relative flex items-center bg-white dark:bg-gray-800">
+        {/* Profile icon */}
+        <div className="flex-shrink-0 pl-3 text-gray-400 dark:text-gray-500">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+          </svg>
+        </div>
+
+        {loading ? (
+          <div className="flex-1 flex items-center gap-2 px-3 py-2.5 text-sm text-gray-400 dark:text-gray-500">
+            <svg className="w-3.5 h-3.5 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            読み込み中...
+          </div>
+        ) : (
+          <>
+            <select
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              disabled={disabled}
+              className="flex-1 appearance-none bg-transparent pl-2 pr-8 py-2.5 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed"
+            >
+              <option value="">{placeholder}</option>
+              {profiles.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {profile.name}
+                  {profile.is_default ? ' ★' : ''}
+                  {profile.scope === 'team' ? ' [チーム]' : ''}
+                </option>
+              ))}
+            </select>
+            {/* Chevron */}
+            <div className="absolute right-2.5 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400 dark:text-gray-500">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Selected profile info strip */}
+      {selected && (
+        <div className="px-3 py-1.5 bg-blue-50 dark:bg-blue-900/20 border-t border-gray-100 dark:border-gray-700 flex items-center gap-2 flex-wrap">
+          {selected.is_default && (
+            <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+              </svg>
+              デフォルト
+            </span>
+          )}
+          {selected.scope === 'team' && (
+            <span className="text-[10px] font-medium text-purple-600 dark:text-purple-400">
+              チーム
+            </span>
+          )}
+          {selected.config?.params?.agent_type && (
+            <span className="text-[10px] font-medium text-indigo-600 dark:text-indigo-400">
+              {selected.config.params.agent_type}
+            </span>
+          )}
+          {selected.config?.params?.sandbox?.enabled && (
+            <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-orange-600 dark:text-orange-400">
+              <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+              サンドボックス
+            </span>
+          )}
+          {selected.config?.environment && Object.keys(selected.config.environment).length > 0 && (
+            <span className="text-[10px] text-gray-500 dark:text-gray-400">
+              ENV×{Object.keys(selected.config.environment).length}
+            </span>
+          )}
+          {selected.description && (
+            <span className="text-[10px] text-gray-400 dark:text-gray-500 truncate max-w-[180px]">
+              {selected.description}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
   )
 }

--- a/src/app/components/SessionProfileSelect.tsx
+++ b/src/app/components/SessionProfileSelect.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { SessionProfile } from '../../types/session_profile'
+import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
+import { useTeamScope } from '../../contexts/TeamScopeContext'
+
+interface SessionProfileSelectProps {
+  value: string
+  onChange: (profileId: string) => void
+  disabled?: boolean
+  className?: string
+  placeholder?: string
+}
+
+export default function SessionProfileSelect({
+  value,
+  onChange,
+  disabled = false,
+  className = '',
+  placeholder = 'プロファイルを選択（任意）',
+}: SessionProfileSelectProps) {
+  const { getScopeParams } = useTeamScope()
+  const [profiles, setProfiles] = useState<SessionProfile[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const fetchProfiles = async () => {
+      try {
+        setLoading(true)
+        const client = createAgentAPIProxyClientFromStorage()
+        const response = await client.getSessionProfiles({ ...getScopeParams() })
+        setProfiles(response.session_profiles || [])
+      } catch {
+        // silently ignore fetch errors
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchProfiles()
+  }, [getScopeParams])
+
+  if (loading) {
+    return (
+      <select
+        disabled
+        className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white opacity-50 ${className}`}
+      >
+        <option>読み込み中...</option>
+      </select>
+    )
+  }
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white disabled:opacity-50 ${className}`}
+    >
+      <option value="">{placeholder}</option>
+      {profiles.map((profile) => (
+        <option key={profile.id} value={profile.id}>
+          {profile.name}
+          {profile.is_default ? ' (デフォルト)' : ''}
+          {profile.scope === 'team' ? ' [チーム]' : ''}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/src/app/components/SessionProfileSelect.tsx
+++ b/src/app/components/SessionProfileSelect.tsx
@@ -30,7 +30,15 @@ export default function SessionProfileSelect({
         setLoading(true)
         const client = createAgentAPIProxyClientFromStorage()
         const response = await client.getSessionProfiles({ ...getScopeParams() })
-        setProfiles(response.session_profiles || [])
+        const fetched = response.session_profiles || []
+        setProfiles(fetched)
+        // Auto-select the default profile if nothing is selected yet
+        if (!value) {
+          const defaultProfile = fetched.find((p) => p.is_default)
+          if (defaultProfile) {
+            onChange(defaultProfile.id)
+          }
+        }
       } catch {
         // silently ignore fetch errors
       } finally {
@@ -38,7 +46,7 @@ export default function SessionProfileSelect({
       }
     }
     fetchProfiles()
-  }, [getScopeParams])
+  }, [getScopeParams]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) {
     return (

--- a/src/app/components/SessionProfileSelect.tsx
+++ b/src/app/components/SessionProfileSelect.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { SessionProfile } from '../../types/session_profile'
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
@@ -23,6 +23,8 @@ export default function SessionProfileSelect({
   const { getScopeParams } = useTeamScope()
   const [profiles, setProfiles] = useState<SessionProfile[]>([])
   const [loading, setLoading] = useState(false)
+  // Prevent auto-select from firing more than once per mount
+  const autoSelectedRef = useRef(false)
 
   useEffect(() => {
     const fetchProfiles = async () => {
@@ -30,15 +32,7 @@ export default function SessionProfileSelect({
         setLoading(true)
         const client = createAgentAPIProxyClientFromStorage()
         const response = await client.getSessionProfiles({ ...getScopeParams() })
-        const fetched = response.session_profiles || []
-        setProfiles(fetched)
-        // Auto-select the default profile if nothing is selected yet
-        if (!value) {
-          const defaultProfile = fetched.find((p) => p.is_default)
-          if (defaultProfile) {
-            onChange(defaultProfile.id)
-          }
-        }
+        setProfiles(response.session_profiles || [])
       } catch {
         // silently ignore fetch errors
       } finally {
@@ -47,6 +41,18 @@ export default function SessionProfileSelect({
     }
     fetchProfiles()
   }, [getScopeParams]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-select the default profile only when no value is set.
+  // This runs after the fetch settles and after the parent may have initialised `value`,
+  // so `value` here is always the current prop (not a stale closure capture).
+  useEffect(() => {
+    if (autoSelectedRef.current || value || loading || profiles.length === 0) return
+    const defaultProfile = profiles.find((p) => p.is_default)
+    if (defaultProfile) {
+      autoSelectedRef.current = true
+      onChange(defaultProfile.id)
+    }
+  }, [profiles, value, loading, onChange])
 
   const selected = profiles.find((p) => p.id === value)
 

--- a/src/app/components/SessionProfileSidebar.tsx
+++ b/src/app/components/SessionProfileSidebar.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import NavigationTabs from './NavigationTabs'
+import TaskListPanel from './TaskListPanel'
+
+const SIDEBAR_ACTIVE_TAB_KEY = 'sidebar_active_tab'
+
+interface SessionProfileSidebarProps {
+  isVisible?: boolean
+  onToggleVisibility?: () => void
+}
+
+export default function SessionProfileSidebar({
+  isVisible = true,
+  onToggleVisibility,
+}: SessionProfileSidebarProps) {
+  const [activeTab, setActiveTab] = useState<'info' | 'tasks'>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem(SIDEBAR_ACTIVE_TAB_KEY)
+      if (saved === 'tasks') return 'tasks'
+    }
+    return 'info'
+  })
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(SIDEBAR_ACTIVE_TAB_KEY, activeTab)
+    }
+  }, [activeTab])
+
+  return (
+    <>
+      {/* Sidebar */}
+      <div
+        className={`
+          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
+          md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
+          ${isVisible ? 'translate-x-0' : '-translate-x-full'}
+        `}
+      >
+        <div className="p-4">
+          {/* Navigation Tabs */}
+          <div className="mb-4">
+            <NavigationTabs />
+          </div>
+
+          {/* Tab Switcher */}
+          <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
+            <button
+              onClick={() => setActiveTab('info')}
+              className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                activeTab === 'info'
+                  ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+              }`}
+            >
+              プロファイル
+            </button>
+            <button
+              onClick={() => setActiveTab('tasks')}
+              className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                activeTab === 'tasks'
+                  ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+              }`}
+            >
+              タスク
+            </button>
+          </div>
+
+          {/* Close button for mobile */}
+          {onToggleVisibility && (
+            <div className="flex justify-end mb-2">
+              <button
+                onClick={onToggleVisibility}
+                className="md:hidden text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          )}
+
+          {activeTab === 'info' ? (
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+                セッションプロファイル
+              </h2>
+              <div className="space-y-3 text-sm text-gray-600 dark:text-gray-400">
+                <p>
+                  セッションプロファイルを使って、セッション設定（環境変数、タグ、初期メッセージなど）を再利用可能なテンプレートとして保存できます。
+                </p>
+                <p>
+                  セッション作成時やWebhook・スケジュールの設定でプロファイルを選択して使用します。
+                </p>
+              </div>
+            </div>
+          ) : (
+            <TaskListPanel />
+          )}
+        </div>
+      </div>
+
+      {/* Mobile overlay */}
+      {isVisible && onToggleVisibility && (
+        <div
+          className="md:hidden fixed inset-0 bg-black bg-opacity-50 z-[5]"
+          onClick={onToggleVisibility}
+        />
+      )}
+    </>
+  )
+}

--- a/src/app/components/SessionProfileSidebar.tsx
+++ b/src/app/components/SessionProfileSidebar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import NavigationTabs from './NavigationTabs'
 import TaskListPanel from './TaskListPanel'
 
-const SIDEBAR_ACTIVE_TAB_KEY = 'sidebar_active_tab'
+const SIDEBAR_ACTIVE_TAB_KEY = 'session_profile_sidebar_active_tab'
 
 interface SessionProfileSidebarProps {
   isVisible?: boolean
@@ -34,17 +34,18 @@ export default function SessionProfileSidebar({
       {/* Sidebar */}
       <div
         className={`
-          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
+          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out flex flex-col
           md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
           ${isVisible ? 'translate-x-0' : '-translate-x-full'}
         `}
       >
-        <div className="p-4">
-          {/* Navigation Tabs */}
-          <div className="mb-4">
-            <NavigationTabs />
-          </div>
+        {/* Navigation Tabs - outside overflow container so dropdown isn't clipped */}
+        <div className="flex-shrink-0 px-4 pt-4 pb-0">
+          <NavigationTabs />
+        </div>
 
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
           {/* Tab Switcher */}
           <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
             <button

--- a/src/app/components/SlackbotFilterSidebar.tsx
+++ b/src/app/components/SlackbotFilterSidebar.tsx
@@ -47,17 +47,17 @@ export default function SlackbotFilterSidebar({
       {/* Sidebar */}
       <div
         className={`
-          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
+          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out flex flex-col
           md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
           ${isVisible ? 'translate-x-0' : '-translate-x-full'}
         `}
       >
-        <div className="p-4">
-          {/* Navigation Tabs */}
-          <div className="mb-4">
-            <NavigationTabs />
-          </div>
+        {/* Navigation Tabs - outside overflow container so dropdown isn't clipped */}
+        <div className="flex-shrink-0 px-4 pt-4 pb-0">
+          <NavigationTabs />
+        </div>
 
+        <div className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
           {/* Tab Switcher */}
           <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
             <button

--- a/src/app/components/SlackbotFormModal.tsx
+++ b/src/app/components/SlackbotFormModal.tsx
@@ -9,6 +9,7 @@ import {
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 import MemoryKeyInput, { MemoryKeyPair, memoryKeyPairsToRecord, recordToMemoryKeyPairs } from './MemoryKeyInput'
+import SessionProfileSelect from './SessionProfileSelect'
 
 interface SlackbotFormModalProps {
   isOpen: boolean
@@ -55,6 +56,7 @@ export default function SlackbotFormModal({
   // Memory key
   const [memoryKeyPairs, setMemoryKeyPairs] = useState<MemoryKeyPair[]>([{ key: '', value: '' }])
   const [showCustomMemory, setShowCustomMemory] = useState(false)
+  const [sessionProfileId, setSessionProfileId] = useState('')
 
   // UI state
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -75,6 +77,7 @@ export default function SlackbotFormModal({
       setAllowedUserIDs(editingSlackbot.allowed_user_ids || [])
 
       const sc = editingSlackbot.session_config
+      setSessionProfileId(sc?.session_profile_id || '')
       setInitialMessageTemplate(sc?.initial_message_template ?? '{{ .event.text }}')
       setReuseMessageTemplate(sc?.reuse_message_template ?? '{{ .event.text }}')
 
@@ -148,6 +151,7 @@ export default function SlackbotFormModal({
       setShowBotTokenSection(false)
       setShowAdvanced(false)
       setRepoFullName('')
+      setSessionProfileId('')
     }
     setError(null)
   }, [editingSlackbot, isOpen])
@@ -278,6 +282,7 @@ export default function SlackbotFormModal({
         ...(Object.keys(environment).length > 0 ? { environment } : {}),
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
         ...(Object.keys(sessionParams).length > 0 ? { params: sessionParams } : {}),
+        ...(sessionProfileId.trim() ? { session_profile_id: sessionProfileId.trim() } : {}),
       }
 
       if (isEditing && editingSlackbot) {
@@ -802,6 +807,21 @@ export default function SlackbotFormModal({
                         />
                       </div>
                     )}
+                  </div>
+
+                  {/* Session Profile */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      セッションプロファイル
+                    </label>
+                    <SessionProfileSelect
+                      value={sessionProfileId}
+                      onChange={setSessionProfileId}
+                      disabled={isSubmitting}
+                    />
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      プロファイルを選択すると、環境変数・タグ・テンプレートなどの設定を適用します
+                    </p>
                   </div>
 
                   {/* Tags */}

--- a/src/app/components/TagFilterSidebar.tsx
+++ b/src/app/components/TagFilterSidebar.tsx
@@ -182,16 +182,16 @@ export default function TagFilterSidebar({
     <>
       {/* Sidebar */}
       <div className={`
-        fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
+        fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out flex flex-col
         md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
         ${isVisible ? 'translate-x-0' : '-translate-x-full'}
       `}>
-        <div className="p-4">
-          {/* Navigation Tabs */}
-          <div className="mb-4">
-            <NavigationTabs />
-          </div>
+        {/* Navigation Tabs - outside overflow container so dropdown isn't clipped */}
+        <div className="flex-shrink-0 px-4 pt-4 pb-0">
+          <NavigationTabs />
+        </div>
 
+        <div className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
           {/* Tab Switcher */}
           <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
             <button

--- a/src/app/components/WebhookFilterSidebar.tsx
+++ b/src/app/components/WebhookFilterSidebar.tsx
@@ -56,17 +56,17 @@ export default function WebhookFilterSidebar({
       {/* Sidebar */}
       <div
         className={`
-          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-y-auto
+          fixed inset-y-0 left-0 z-10 w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out flex flex-col
           md:relative md:translate-x-0 md:inset-auto md:w-80 md:h-screen
           ${isVisible ? 'translate-x-0' : '-translate-x-full'}
         `}
       >
-        <div className="p-4">
-          {/* Navigation Tabs */}
-          <div className="mb-4">
-            <NavigationTabs />
-          </div>
+        {/* Navigation Tabs - outside overflow container so dropdown isn't clipped */}
+        <div className="flex-shrink-0 px-4 pt-4 pb-0">
+          <NavigationTabs />
+        </div>
 
+        <div className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
           {/* Tab Switcher */}
           <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
             <button

--- a/src/app/components/WebhookFormModal.tsx
+++ b/src/app/components/WebhookFormModal.tsx
@@ -15,6 +15,7 @@ import {
 import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
 import { OrganizationHistory } from '../../utils/organizationHistory'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
+import SessionProfileSelect from './SessionProfileSelect'
 
 interface WebhookFormModalProps {
   isOpen: boolean
@@ -39,6 +40,7 @@ interface TriggerFormData {
   environment: Record<string, string>
   tags: Record<string, string>
   showAdvanced: boolean
+  sessionProfileId: string
 }
 
 const emptyTrigger: TriggerFormData = {
@@ -56,6 +58,7 @@ const emptyTrigger: TriggerFormData = {
   environment: {},
   tags: {},
   showAdvanced: false,
+  sessionProfileId: '',
 }
 
 export default function WebhookFormModal({
@@ -113,6 +116,7 @@ export default function WebhookFormModal({
             environment: t.session_config?.environment || {},
             tags: t.session_config?.tags || {},
             showAdvanced: false,
+            sessionProfileId: t.session_config?.session_profile_id || '',
           }))
         )
       } else {
@@ -372,6 +376,11 @@ export default function WebhookFormModal({
         // Add tags if present
         if (Object.keys(t.tags).length > 0) {
           session_config.tags = t.tags
+        }
+
+        // Add session profile if present
+        if (t.sessionProfileId.trim()) {
+          session_config.session_profile_id = t.sessionProfileId.trim()
         }
 
         // Build params
@@ -900,6 +909,21 @@ export default function WebhookFormModal({
                         />
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                           Goテンプレート形式。例: {'{{.pull_request.Number}}'}
+                        </p>
+                      </div>
+
+                      {/* Session Profile */}
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          セッションプロファイル
+                        </label>
+                        <SessionProfileSelect
+                          value={trigger.sessionProfileId}
+                          onChange={(val) => updateTrigger(index, 'sessionProfileId', val)}
+                          disabled={isSubmitting}
+                        />
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          プロファイルを選択すると、環境変数・タグ・テンプレートなどの設定を適用します
                         </p>
                       </div>
 

--- a/src/app/session-profiles/page.tsx
+++ b/src/app/session-profiles/page.tsx
@@ -4,13 +4,14 @@ import { useState, useCallback } from 'react'
 import { SessionProfile } from '../../types/session_profile'
 import SessionProfileListView from '../components/SessionProfileListView'
 import SessionProfileFormModal from '../components/SessionProfileFormModal'
+import SessionProfileSidebar from '../components/SessionProfileSidebar'
 import TopBar from '../components/TopBar'
-import NavigationTabs from '../components/NavigationTabs'
 
 export default function SessionProfilesPage() {
   const [refreshKey, setRefreshKey] = useState(0)
   const [isFormModalOpen, setIsFormModalOpen] = useState(false)
   const [editingProfile, setEditingProfile] = useState<SessionProfile | null>(null)
+  const [sidebarVisible, setSidebarVisible] = useState(false)
 
   const handleProfilesUpdate = useCallback(() => {
     setRefreshKey((prev) => prev + 1)
@@ -40,16 +41,18 @@ export default function SessionProfilesPage() {
     <main className="min-h-dvh bg-gray-50 dark:bg-gray-900">
       <TopBar
         title="Session Profiles"
-        showFilterButton={false}
+        showFilterButton={true}
         showSettingsButton={true}
-      >
-        {/* Mobile Navigation Tabs */}
-        <div className="md:hidden">
-          <NavigationTabs />
-        </div>
-      </TopBar>
+        onFilterToggle={() => setSidebarVisible((prev) => !prev)}
+      />
 
       <div className="flex">
+        {/* Sidebar */}
+        <SessionProfileSidebar
+          isVisible={sidebarVisible}
+          onToggleVisibility={() => setSidebarVisible((prev) => !prev)}
+        />
+
         {/* Main Content */}
         <div className="flex-1 px-4 md:px-6 lg:px-8 pt-6 md:pt-8 pb-6 md:pb-8">
           {/* New Profile Button (Desktop) */}

--- a/src/app/session-profiles/page.tsx
+++ b/src/app/session-profiles/page.tsx
@@ -41,7 +41,7 @@ export default function SessionProfilesPage() {
   return (
     <main className="min-h-dvh bg-gray-50 dark:bg-gray-900">
       <TopBar
-        title="Session Profiles"
+        title="Profiles"
         showFilterButton={true}
         showSettingsButton={true}
         onFilterToggle={() => setSidebarVisible((prev) => !prev)}

--- a/src/app/session-profiles/page.tsx
+++ b/src/app/session-profiles/page.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { SessionProfile } from '../../types/session_profile'
+import SessionProfileListView from '../components/SessionProfileListView'
+import SessionProfileFormModal from '../components/SessionProfileFormModal'
+import TopBar from '../components/TopBar'
+import NavigationTabs from '../components/NavigationTabs'
+
+export default function SessionProfilesPage() {
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [isFormModalOpen, setIsFormModalOpen] = useState(false)
+  const [editingProfile, setEditingProfile] = useState<SessionProfile | null>(null)
+
+  const handleProfilesUpdate = useCallback(() => {
+    setRefreshKey((prev) => prev + 1)
+  }, [])
+
+  const handleProfileEdit = useCallback((profile: SessionProfile) => {
+    setEditingProfile(profile)
+    setIsFormModalOpen(true)
+  }, [])
+
+  const handleFormModalClose = useCallback(() => {
+    setIsFormModalOpen(false)
+    setEditingProfile(null)
+  }, [])
+
+  const handleFormModalSuccess = useCallback(() => {
+    handleProfilesUpdate()
+    handleFormModalClose()
+  }, [handleProfilesUpdate, handleFormModalClose])
+
+  const handleNewProfile = useCallback(() => {
+    setEditingProfile(null)
+    setIsFormModalOpen(true)
+  }, [])
+
+  return (
+    <main className="min-h-dvh bg-gray-50 dark:bg-gray-900">
+      <TopBar
+        title="Session Profiles"
+        showFilterButton={false}
+        showSettingsButton={true}
+      >
+        {/* Mobile Navigation Tabs */}
+        <div className="md:hidden">
+          <NavigationTabs />
+        </div>
+      </TopBar>
+
+      <div className="flex">
+        {/* Main Content */}
+        <div className="flex-1 px-4 md:px-6 lg:px-8 pt-6 md:pt-8 pb-6 md:pb-8">
+          {/* New Profile Button (Desktop) */}
+          <div className="mb-6 flex justify-end hidden md:flex">
+            <button
+              onClick={handleNewProfile}
+              className="inline-flex items-center px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+              </svg>
+              新しいプロファイル
+            </button>
+          </div>
+
+          {/* Session Profile List */}
+          <SessionProfileListView
+            onProfileEdit={handleProfileEdit}
+            onProfilesUpdate={handleProfilesUpdate}
+            key={refreshKey}
+          />
+        </div>
+      </div>
+
+      {/* Floating New Profile Button (Mobile) */}
+      <button
+        onClick={handleNewProfile}
+        className="md:hidden fixed bottom-6 right-6 w-14 h-14 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg flex items-center justify-center z-50 transition-colors"
+        aria-label="新しいプロファイル"
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+        </svg>
+      </button>
+
+      {/* Session Profile Form Modal */}
+      <SessionProfileFormModal
+        isOpen={isFormModalOpen}
+        onClose={handleFormModalClose}
+        onSuccess={handleFormModalSuccess}
+        editingProfile={editingProfile}
+      />
+    </main>
+  )
+}

--- a/src/app/session-profiles/page.tsx
+++ b/src/app/session-profiles/page.tsx
@@ -6,6 +6,7 @@ import SessionProfileListView from '../components/SessionProfileListView'
 import SessionProfileFormModal from '../components/SessionProfileFormModal'
 import SessionProfileSidebar from '../components/SessionProfileSidebar'
 import TopBar from '../components/TopBar'
+import NavigationTabs from '../components/NavigationTabs'
 
 export default function SessionProfilesPage() {
   const [refreshKey, setRefreshKey] = useState(0)
@@ -44,7 +45,12 @@ export default function SessionProfilesPage() {
         showFilterButton={true}
         showSettingsButton={true}
         onFilterToggle={() => setSidebarVisible((prev) => !prev)}
-      />
+      >
+        {/* Mobile Navigation Tabs */}
+        <div className="md:hidden">
+          <NavigationTabs />
+        </div>
+      </TopBar>
 
       <div className="flex">
         {/* Sidebar */}

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -15,6 +15,7 @@ import { createAgentAPIProxyClientFromStorage } from '../../../lib/agentapi-prox
 import { createACPServerClientFromStorage } from '../../../lib/acp-server-client'
 import TopBar from '../../components/TopBar'
 import SessionCreationProgressModal from '../../components/SessionCreationProgressModal'
+import SessionProfileSelect from '../../components/SessionProfileSelect'
 import { SessionCreationProgress, SessionCreationStatus } from '../../../types/sessionProgress'
 import { useTeamScope } from '../../../contexts/TeamScopeContext'
 
@@ -41,6 +42,7 @@ export default function NewSessionPage() {
   const [cycleEnabled, setCycleEnabled] = useState(false)
   const [cycleMessage, setCycleMessage] = useState('')
   const [cycleMaxCount, setCycleMaxCount] = useState(10)
+  const [sessionProfileId, setSessionProfileId] = useState('')
 
   useEffect(() => {
     loadTemplates()
@@ -177,6 +179,7 @@ export default function NewSessionPage() {
         },
         tags: Object.keys(tags).length > 0 ? tags : undefined,
         params,
+        ...(sessionProfileId ? { session_profile_id: sessionProfileId } : {}),
         ...scopeParams
       })
       console.log('Session created with initial message:', session)
@@ -464,6 +467,21 @@ export default function NewSessionPage() {
 
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
                 リポジトリを指定しない場合は一般的なチャットになります
+              </p>
+            </div>
+
+            {/* セッションプロファイル */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                セッションプロファイル
+              </label>
+              <SessionProfileSelect
+                value={sessionProfileId}
+                onChange={setSessionProfileId}
+                disabled={isCreating}
+              />
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                プロファイルを選択すると、環境変数・タグ・テンプレートなどの設定を適用します
               </p>
             </div>
 

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -43,6 +43,13 @@ import {
   UpdateSlackBotRequest
 } from '../types/slackbot';
 import {
+  SessionProfile,
+  SessionProfileListParams,
+  SessionProfileListResponse,
+  CreateSessionProfileRequest,
+  UpdateSessionProfileRequest
+} from '../types/session_profile';
+import {
   Memory,
   MemoryListParams,
   MemoryListResponse,
@@ -1659,6 +1666,95 @@ export class AgentAPIProxyClient {
 
     if (this.debug) {
       console.log(`[AgentAPIProxy] Deleted slackbot: ${slackbotId}`);
+    }
+  }
+
+  // Session Profile methods
+
+  /**
+   * Create a new Session Profile
+   */
+  async createSessionProfile(data: CreateSessionProfileRequest): Promise<SessionProfile> {
+    if (this.debug) {
+      console.log('[AgentAPIProxy] Creating session profile:', data);
+    }
+
+    const profile = await this.makeRequest<SessionProfile>('/session-profiles', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Created session profile: ${profile.id}`);
+    }
+
+    return profile;
+  }
+
+  /**
+   * Get list of Session Profiles
+   */
+  async getSessionProfiles(params?: SessionProfileListParams): Promise<SessionProfileListResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (params?.scope) searchParams.set('scope', params.scope);
+    if (params?.team_id) searchParams.set('team_id', params.team_id);
+
+    const endpoint = `/session-profiles${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
+    const result = await this.makeRequest<SessionProfile[] | SessionProfileListResponse>(endpoint);
+
+    // API may return array directly (not wrapped in object)
+    if (Array.isArray(result)) {
+      return { session_profiles: result };
+    }
+
+    return {
+      ...result,
+      session_profiles: result.session_profiles || []
+    };
+  }
+
+  /**
+   * Get a specific Session Profile by ID
+   */
+  async getSessionProfile(profileId: string): Promise<SessionProfile> {
+    return this.makeRequest<SessionProfile>(`/session-profiles/${profileId}`);
+  }
+
+  /**
+   * Update a Session Profile
+   */
+  async updateSessionProfile(profileId: string, data: UpdateSessionProfileRequest): Promise<SessionProfile> {
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Updating session profile ${profileId}:`, data);
+    }
+
+    const profile = await this.makeRequest<SessionProfile>(`/session-profiles/${profileId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Updated session profile: ${profile.id}`);
+    }
+
+    return profile;
+  }
+
+  /**
+   * Delete a Session Profile
+   */
+  async deleteSessionProfile(profileId: string): Promise<void> {
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Deleting session profile: ${profileId}`);
+    }
+
+    await this.makeRequest<void>(`/session-profiles/${profileId}`, {
+      method: 'DELETE',
+    });
+
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Deleted session profile: ${profileId}`);
     }
   }
 

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -582,7 +582,7 @@ export class AgentAPIProxyClient {
     // Handle backward compatibility and new format
     let data: Partial<CreateSessionRequest>;
 
-    if (sessionData && (sessionData.environment || sessionData.tags || sessionData.metadata || sessionData.params || sessionData.scope || sessionData.team_id)) {
+    if (sessionData && (sessionData.environment || sessionData.tags || sessionData.metadata || sessionData.params || sessionData.scope || sessionData.team_id || sessionData.session_profile_id)) {
       // New format: sessionData contains environment, metadata, tags, params, scope, and/or team_id
       data = {
         environment: sessionData.environment as Record<string, string> | undefined,
@@ -590,7 +590,8 @@ export class AgentAPIProxyClient {
         tags: sessionData.tags as Record<string, string> | undefined,
         params: sessionData.params as { message?: string; github_token?: string; [key: string]: unknown } | undefined,
         scope: sessionData.scope as CreateSessionRequest['scope'],
-        team_id: sessionData.team_id as string | undefined
+        team_id: sessionData.team_id as string | undefined,
+        session_profile_id: sessionData.session_profile_id as string | undefined,
       };
     } else {
       // Backward compatibility: sessionData is just metadata

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -209,6 +209,7 @@ export interface CreateSessionRequest {
   team_id?: string;
   memory_key?: Record<string, string>;
   memory_summarize_drafts?: boolean;
+  session_profile_id?: string;
 }
 
 // Session message types

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -18,6 +18,7 @@ export interface ScheduleSessionConfig {
   reuse_session?: boolean;
   /** Message sent to the reused session. Falls back to params.message when empty. */
   reuse_message?: string;
+  session_profile_id?: string;
 }
 
 // Schedule entity

--- a/src/types/session_profile.ts
+++ b/src/types/session_profile.ts
@@ -4,6 +4,7 @@ import { ResourceScope, SandboxConfig } from './agentapi';
 export interface SessionProfileParams {
   initial_message?: string;
   github_token?: string;
+  agent_type?: string;
   sandbox?: SandboxConfig;
 }
 

--- a/src/types/session_profile.ts
+++ b/src/types/session_profile.ts
@@ -1,0 +1,64 @@
+import { ResourceScope } from './agentapi';
+
+// Session profile params
+export interface SessionProfileParams {
+  initial_message?: string;
+  github_token?: string;
+}
+
+// Session profile config
+export interface SessionProfileConfig {
+  environment?: Record<string, string>;
+  tags?: Record<string, string>;
+  initial_message_template?: string;
+  reuse_message_template?: string;
+  reuse_session?: boolean;
+  memory_key?: Record<string, string>;
+  params?: SessionProfileParams;
+}
+
+// SessionProfile entity
+export interface SessionProfile {
+  id: string;
+  name: string;
+  description?: string;
+  user_id?: string;
+  scope?: ResourceScope;
+  team_id?: string;
+  is_default?: boolean;
+  config?: SessionProfileConfig;
+  created_at: string;
+  updated_at: string;
+}
+
+// Create SessionProfile request
+export interface CreateSessionProfileRequest {
+  name: string;
+  description?: string;
+  scope?: ResourceScope;
+  team_id?: string;
+  is_default?: boolean;
+  config?: SessionProfileConfig;
+}
+
+// Update SessionProfile request
+export interface UpdateSessionProfileRequest {
+  name?: string;
+  description?: string;
+  is_default?: boolean;
+  config?: SessionProfileConfig;
+}
+
+// SessionProfile list parameters
+export interface SessionProfileListParams {
+  scope?: ResourceScope;
+  team_id?: string;
+}
+
+// SessionProfile list response
+export interface SessionProfileListResponse {
+  session_profiles: SessionProfile[];
+  total?: number;
+  page?: number;
+  limit?: number;
+}

--- a/src/types/session_profile.ts
+++ b/src/types/session_profile.ts
@@ -1,9 +1,10 @@
-import { ResourceScope } from './agentapi';
+import { ResourceScope, SandboxConfig } from './agentapi';
 
 // Session profile params
 export interface SessionProfileParams {
   initial_message?: string;
   github_token?: string;
+  sandbox?: SandboxConfig;
 }
 
 // Session profile config

--- a/src/types/slackbot.ts
+++ b/src/types/slackbot.ts
@@ -19,6 +19,7 @@ export interface SlackBotSessionConfig {
   environment?: Record<string, string>;
   params?: SlackBotSessionParams;
   memory_key?: Record<string, string>;
+  session_profile_id?: string;
 }
 
 // SlackBot entity

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -48,6 +48,7 @@ export interface WebhookSessionConfig {
   reuse_session?: boolean;
   mount_payload?: boolean;
   params?: SessionParams;
+  session_profile_id?: string;
 }
 
 // Webhook trigger


### PR DESCRIPTION
## Summary

Adds full session profile management UI for the agentapi-proxy session profile feature (backend PR: takutakahashi/agentapi-proxy#760).

- **New `/session-profiles` page**: list view with create/edit/delete, follows the same pattern as `/slackbots`
- **`SessionProfileCard`**: displays name, scope badge (個人/チーム), is_default badge (デフォルト), config summary (env count, tag count, reuse session), timestamps, Edit/Delete buttons
- **`SessionProfileListView`**: fetches profiles with team scope context, handles loading/error/empty states, delete confirmation
- **`SessionProfileFormModal`**: create/edit modal with name, description, is_default checkbox, and collapsible config section (environment key-value pairs, tags key-value pairs, initial message template, reuse message template, reuse session toggle)
- **`src/types/session_profile.ts`**: TypeScript types for SessionProfile, SessionProfileConfig, CreateSessionProfileRequest, UpdateSessionProfileRequest
- **`agentapi-proxy-client.ts`**: added `createSessionProfile`, `getSessionProfiles`, `getSessionProfile`, `updateSessionProfile`, `deleteSessionProfile` methods
- **`NavigationTabs.tsx`**: added "Profiles" tab with clipboard icon linking to `/session-profiles`

## Test plan

- [ ] `bun run lint` — warnings only (pre-existing), no new errors ✓
- [ ] TypeScript check — no new errors ✓
- [ ] Create a session profile via the UI
- [ ] Edit the session profile
- [ ] Delete the session profile
- [ ] Verify the "Profiles" tab appears in the navigation

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)