### PR TITLE
feat: セッション作成時にネットワークサンドボックスを設定できるようにする

### DIFF
--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -42,7 +42,8 @@ export default function NewSessionPage() {
   const [cycleMessage, setCycleMessage] = useState('')
   const [cycleMaxCount, setCycleMaxCount] = useState(10)
   const [sandboxEnabled, setSandboxEnabled] = useState(false)
-  const [sandboxDeniedDomains, setSandboxDeniedDomains] = useState('')
+  const [sandboxMode, setSandboxMode] = useState<'allowlist' | 'denylist'>('allowlist')
+  const [sandboxDomains, setSandboxDomains] = useState('')
 
   useEffect(() => {
     loadTemplates()
@@ -172,13 +173,14 @@ export default function NewSessionPage() {
 
       // サンドボックスが有効な場合はsandboxを送信
       if (sandboxEnabled) {
-        const deniedDomains = sandboxDeniedDomains
+        const domains = sandboxDomains
           .split('\n')
           .map(d => d.trim())
           .filter(d => d.length > 0)
         params.sandbox = {
           enabled: true,
-          ...(deniedDomains.length > 0 ? { denied_domains: deniedDomains } : {})
+          ...(sandboxMode === 'allowlist' && domains.length > 0 ? { allowed_domains: domains } : {}),
+          ...(sandboxMode === 'denylist' && domains.length > 0 ? { denied_domains: domains } : {}),
         }
       }
 
@@ -686,21 +688,48 @@ export default function NewSessionPage() {
                       iptables でセッションの外部ネットワークアクセスを制限します。ブロックするドメインを指定できます。
                     </p>
                     {sandboxEnabled && (
-                      <div className="pl-1">
-                        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
-                          ブロックするドメイン
-                        </label>
-                        <textarea
-                          value={sandboxDeniedDomains}
-                          onChange={(e) => setSandboxDeniedDomains(e.target.value)}
-                          placeholder={'github.com\n*.github.com'}
-                          rows={3}
-                          disabled={isCreating}
-                          className="w-full px-3 py-2 text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 dark:bg-gray-700 dark:text-white resize-y font-mono"
-                        />
-                        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                          1行に1ドメイン。ワイルドカード（<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">*.example.com</code>）も使用可能。空の場合はすべてのドメインをブロック。
-                        </p>
+                      <div className="pl-1 space-y-3">
+                        {/* モード選択 */}
+                        <div className="flex gap-3">
+                          {([
+                            { value: 'allowlist', label: '許可リスト', description: '指定ドメインのみ通過' },
+                            { value: 'denylist', label: 'ブロックリスト', description: '指定ドメインのみ拒否' },
+                          ] as { value: 'allowlist' | 'denylist'; label: string; description: string }[]).map(({ value, label, description }) => (
+                            <label key={value} className={`flex-1 flex items-start gap-2 p-2 rounded-lg border cursor-pointer transition-colors ${sandboxMode === value ? 'border-orange-400 bg-orange-50 dark:bg-orange-900/20' : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'}`}>
+                              <input
+                                type="radio"
+                                name="sandbox-mode"
+                                value={value}
+                                checked={sandboxMode === value}
+                                onChange={() => setSandboxMode(value)}
+                                disabled={isCreating}
+                                className="mt-0.5 w-3.5 h-3.5 text-orange-500 border-gray-300 dark:border-gray-600 focus:ring-orange-500 flex-shrink-0"
+                              />
+                              <span>
+                                <span className="block text-xs font-medium text-gray-700 dark:text-gray-300">{label}</span>
+                                <span className="block text-xs text-gray-400 dark:text-gray-500">{description}</span>
+                              </span>
+                            </label>
+                          ))}
+                        </div>
+                        {/* ドメイン入力 */}
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                            {sandboxMode === 'allowlist' ? '許可するドメイン' : 'ブロックするドメイン'}
+                          </label>
+                          <textarea
+                            value={sandboxDomains}
+                            onChange={(e) => setSandboxDomains(e.target.value)}
+                            placeholder={sandboxMode === 'allowlist' ? 'api.example.com\n*.trusted.com' : 'github.com\n*.github.com'}
+                            rows={3}
+                            disabled={isCreating}
+                            className="w-full px-3 py-2 text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 dark:bg-gray-700 dark:text-white resize-y font-mono"
+                          />
+                          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                            1行に1ドメイン。ワイルドカード（<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">*.example.com</code>）も使用可能。
+                            {sandboxMode === 'allowlist' && '空の場合はすべてのドメインをブロック。'}
+                          </p>
+                        </div>
                       </div>
                     )}
                   </div>

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -41,6 +41,8 @@ export default function NewSessionPage() {
   const [cycleEnabled, setCycleEnabled] = useState(false)
   const [cycleMessage, setCycleMessage] = useState('')
   const [cycleMaxCount, setCycleMaxCount] = useState(10)
+  const [sandboxEnabled, setSandboxEnabled] = useState(false)
+  const [sandboxDeniedDomains, setSandboxDeniedDomains] = useState('')
 
   useEffect(() => {
     loadTemplates()
@@ -165,6 +167,18 @@ export default function NewSessionPage() {
         params.cycle_message = cycleMessage.trim()
         if (cycleMaxCount > 0) {
           params.cycle_max_count = cycleMaxCount
+        }
+      }
+
+      // サンドボックスが有効な場合はsandboxを送信
+      if (sandboxEnabled) {
+        const deniedDomains = sandboxDeniedDomains
+          .split('\n')
+          .map(d => d.trim())
+          .filter(d => d.length > 0)
+        params.sandbox = {
+          enabled: true,
+          ...(deniedDomains.length > 0 ? { denied_domains: deniedDomains } : {})
         }
       }
 
@@ -503,6 +517,11 @@ export default function NewSessionPage() {
                     サイクル{cycleMaxCount > 0 ? ` (${cycleMaxCount}回)` : ''}
                   </span>
                 )}
+                {sandboxEnabled && (
+                  <span className="px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900/40 text-orange-600 dark:text-orange-400 text-xs rounded-full">
+                    サンドボックス
+                  </span>
+                )}
               </button>
 
               {showAdvancedSettings && (
@@ -633,6 +652,55 @@ export default function NewSessionPage() {
                             0 の場合は無制限。<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">/tmp/check/CYCLE_COUNT</code> で進捗を確認できます。
                           </p>
                         </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* サンドボックス */}
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <p className="text-xs font-medium text-gray-600 dark:text-gray-400">ネットワークサンドボックス</p>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                          {sandboxEnabled ? '有効' : '無効'}
+                        </span>
+                        <button
+                          type="button"
+                          role="switch"
+                          aria-checked={sandboxEnabled}
+                          onClick={() => setSandboxEnabled(!sandboxEnabled)}
+                          disabled={isCreating}
+                          className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${
+                            sandboxEnabled ? 'bg-orange-500' : 'bg-gray-300 dark:bg-gray-600'
+                          }`}
+                        >
+                          <span
+                            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                              sandboxEnabled ? 'translate-x-4' : 'translate-x-0'
+                            }`}
+                          />
+                        </button>
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">
+                      iptables でセッションの外部ネットワークアクセスを制限します。ブロックするドメインを指定できます。
+                    </p>
+                    {sandboxEnabled && (
+                      <div className="pl-1">
+                        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                          ブロックするドメイン
+                        </label>
+                        <textarea
+                          value={sandboxDeniedDomains}
+                          onChange={(e) => setSandboxDeniedDomains(e.target.value)}
+                          placeholder={'github.com\n*.github.com'}
+                          rows={3}
+                          disabled={isCreating}
+                          className="w-full px-3 py-2 text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 dark:bg-gray-700 dark:text-white resize-y font-mono"
+                        />
+                        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                          1行に1ドメイン。ワイルドカード（<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">*.example.com</code>）も使用可能。空の場合はすべてのドメインをブロック。
+                        </p>
                       </div>
                     )}
                   </div>

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -196,6 +196,7 @@ export interface SessionListResponse {
 
 export interface SandboxConfig {
   enabled: boolean;
+  allowed_domains?: string[];
   denied_domains?: string[];
 }
 

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -194,6 +194,11 @@ export interface SessionListResponse {
   limit: number;
 }
 
+export interface SandboxConfig {
+  enabled: boolean;
+  denied_domains?: string[];
+}
+
 export interface CreateSessionRequest {
   user_id: string;
   environment?: Record<string, string>;
@@ -203,6 +208,7 @@ export interface CreateSessionRequest {
     message?: string;
     github_token?: string;
     oneshot?: boolean;
+    sandbox?: SandboxConfig;
     [key: string]: unknown;
   };
   scope?: ResourceScope;


### PR DESCRIPTION
## Summary

- セッション作成画面の「その他の設定」にネットワークサンドボックスの設定を追加
- トグルで有効/無効を切り替え可能
- 有効時にブロックするドメインを1行1件で入力できるテキストエリアを表示（ワイルドカード対応）
- 有効時は「その他の設定」ボタンにオレンジ色のバッジを表示

## Related

- agentapi-proxy#762 (network sandbox sidecar 実装)
- agentapi-proxy#763 (マージ済み)

## Test plan

- [ ] サンドボックス無効でセッション作成 → sandbox params が送信されないことを確認
- [ ] サンドボックス有効・ドメイン指定でセッション作成 → `params.sandbox.enabled=true, denied_domains=[...]` が送信されることを確認
- [ ] 「その他の設定」バッジがサンドボックス有効時にオレンジで表示されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)