### PR TITLE
feat: AI Settings を LLM プロバイダ認証設定に統合

### DIFF
--- a/src/app/settings/personal/page.tsx
+++ b/src/app/settings/personal/page.tsx
@@ -535,8 +535,8 @@ export default function PersonalSettingsPage() {
           </SettingsAccordion>
 
           <SettingsAccordion
-            title="AI Settings"
-            description="Configure AI providers and models"
+            title="LLM プロバイダ認証設定"
+            description="Claude・Bedrock・Codex などの LLM プロバイダ認証を設定します"
             defaultOpen
           >
             <div className="space-y-6">
@@ -566,14 +566,19 @@ export default function PersonalSettingsPage() {
                   )}
                 </div>
               )}
-              <ClaudeOAuthSettings
-                hasToken={settings.has_claude_code_oauth_token ?? false}
-                authMode={settings.auth_mode}
-                onChange={handleClaudeOAuthChange}
-              />
+              <div>
+                <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">
+                  Claude (OAuth)
+                </h4>
+                <ClaudeOAuthSettings
+                  hasToken={settings.has_claude_code_oauth_token ?? false}
+                  authMode={settings.auth_mode}
+                  onChange={handleClaudeOAuthChange}
+                />
+              </div>
               <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
                 <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">
-                  Bedrock Settings
+                  Amazon Bedrock
                 </h4>
                 <BedrockSettings config={settings.bedrock} onChange={handleBedrockChange} />
               </div>

--- a/src/app/settings/team/page.tsx
+++ b/src/app/settings/team/page.tsx
@@ -282,11 +282,16 @@ export default function TeamSettingsPage() {
           </SettingsAccordion>
 
           <SettingsAccordion
-            title="AI Settings"
-            description="Configure AI providers and models"
+            title="LLM プロバイダ認証設定"
+            description="Amazon Bedrock などの LLM プロバイダ認証を設定します"
             defaultOpen
           >
-            <BedrockSettings config={settings.bedrock} onChange={handleBedrockChange} showCredentials />
+            <div className="space-y-4">
+              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Amazon Bedrock
+              </h4>
+              <BedrockSettings config={settings.bedrock} onChange={handleBedrockChange} showCredentials />
+            </div>
           </SettingsAccordion>
 
           <SettingsAccordion


### PR DESCRIPTION
## Summary

- Personal Settings・Team Settings の「AI Settings」アコーディオンを「LLM プロバイダ認証設定」に改名
- Personal Settings では各プロバイダを明確なサブ見出しで整理:
  - **Claude (OAuth)** — ClaudeOAuthSettings
  - **Amazon Bedrock** — BedrockSettings
  - **Codex 認証 (auth.json)** — CodexDeviceAuthSettings + 手動アップロード
- Team Settings でも「Amazon Bedrock」サブ見出しを追加

## Test plan

- [ ] Personal Settings の「LLM プロバイダ認証設定」アコーディオンが表示されることを確認
- [ ] Claude (OAuth)・Amazon Bedrock・Codex 認証の各セクションが正しく表示されることを確認
- [ ] Team Settings の「LLM プロバイダ認証設定」アコーディオンが表示されることを確認
- [ ] ビルドエラーがないことを確認 (CI)

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)