### PR TITLE
Edit session profile message templates

### DIFF
--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -101,6 +101,22 @@ export default function SessionProfileCard({
         {profile.config?.tags && Object.keys(profile.config.tags).length > 0 && (
           <span>タグ: <strong className="text-gray-700 dark:text-gray-300">{Object.keys(profile.config.tags).length}</strong></span>
         )}
+        {profile.config?.initial_message_template && (
+          <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+            </svg>
+            初期テンプレート
+          </span>
+        )}
+        {profile.config?.reuse_message_template && (
+          <span className="inline-flex items-center gap-1 text-teal-600 dark:text-teal-400">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M20 9A8 8 0 006.34 5.34L4 10m16 4l-2.34 4.66A8 8 0 014 15" />
+            </svg>
+            再利用テンプレート
+          </span>
+        )}
       </div>
 
       {/* Timestamps */}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -35,6 +35,8 @@ export default function SessionProfileFormModal({
   const [envPairs, setEnvPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [tagPairs, setTagPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [agentType, setAgentType] = useState('')
+  const [initialMessageTemplate, setInitialMessageTemplate] = useState('')
+  const [reuseMessageTemplate, setReuseMessageTemplate] = useState('')
 
   // Sandbox fields
   const [sandboxEnabled, setSandboxEnabled] = useState(false)
@@ -57,6 +59,8 @@ export default function SessionProfileFormModal({
 
       const cfg = editingProfile.config
       setAgentType(cfg?.params?.agent_type ?? '')
+      setInitialMessageTemplate(cfg?.initial_message_template ?? '')
+      setReuseMessageTemplate(cfg?.reuse_message_template ?? '')
 
       if (cfg?.environment && Object.keys(cfg.environment).length > 0) {
         setEnvPairs(Object.entries(cfg.environment).map(([key, value]) => ({ key, value })))
@@ -72,7 +76,7 @@ export default function SessionProfileFormModal({
         setTagPairs([{ key: '', value: '' }])
       }
 
-      if (cfg?.params?.agent_type) {
+      if (cfg?.params?.agent_type || cfg?.initial_message_template || cfg?.reuse_message_template) {
         setShowAdvanced(true)
       }
 
@@ -101,6 +105,8 @@ export default function SessionProfileFormModal({
       setEnvPairs([{ key: '', value: '' }])
       setTagPairs([{ key: '', value: '' }])
       setAgentType('')
+      setInitialMessageTemplate('')
+      setReuseMessageTemplate('')
       setSandboxEnabled(false)
       setSandboxMode('allowlist')
       setSandboxDomains('')
@@ -198,6 +204,8 @@ export default function SessionProfileFormModal({
       const config = {
         ...(Object.keys(environment).length > 0 ? { environment } : {}),
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
+        ...(initialMessageTemplate.trim() ? { initial_message_template: initialMessageTemplate.trim() } : {}),
+        ...(reuseMessageTemplate.trim() ? { reuse_message_template: reuseMessageTemplate.trim() } : {}),
         ...(params ? { params } : {}),
       }
 
@@ -439,6 +447,35 @@ export default function SessionProfileFormModal({
                         </svg>
                         追加
                       </button>
+                    </div>
+                  </div>
+
+                  {/* Message Templates */}
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                        初期メッセージテンプレート
+                      </label>
+                      <textarea
+                        value={initialMessageTemplate}
+                        onChange={(e) => setInitialMessageTemplate(e.target.value)}
+                        placeholder="例: {{ .tags.repository }} のレビューをしてください"
+                        rows={5}
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                        再利用メッセージテンプレート
+                      </label>
+                      <textarea
+                        value={reuseMessageTemplate}
+                        onChange={(e) => setReuseMessageTemplate(e.target.value)}
+                        placeholder="例: {{ .tags.repository }} に追加対応してください"
+                        rows={4}
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
+                      />
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary
- add initial/reuse message template fields to the session profile form
- preserve template values when editing and include them in create/update payloads
- show template badges in session profile cards

## Tests
- mise exec -- bun run type-check
- mise exec -- bun run lint