### PR TITLE
feat(sandbox): add sandbox domain viewer button to chat UI

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -15,7 +15,6 @@ import { recentMessagesManager } from '../../utils/recentMessagesManager';
 import { pushNotificationManager } from '../../utils/pushNotification';
 import { getEnterKeyBehavior, getFontSettings, FontSettings, setFontSettings as saveFontSettings, FontFamily } from '../../types/settings';
 import ShareSessionButton from './ShareSessionButton';
-import SandboxDomainsButton from './SandboxDomainsButton';
 import MessageItem from './MessageItem';
 import ToolExecutionPane from './ToolExecutionPane';
 import PlanApprovalModal from './PlanApprovalModal';
@@ -1372,11 +1371,6 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               </button>
             )}
 
-
-            {/* Sandbox Domains Button */}
-            {sessionId && agentAPI && (
-              <SandboxDomainsButton sessionId={sessionId} agentAPI={agentAPI} />
-            )}
 
             {/* Share Session Button */}
             {sessionId && agentAPI && (

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -15,6 +15,7 @@ import { recentMessagesManager } from '../../utils/recentMessagesManager';
 import { pushNotificationManager } from '../../utils/pushNotification';
 import { getEnterKeyBehavior, getFontSettings, FontSettings, setFontSettings as saveFontSettings, FontFamily } from '../../types/settings';
 import ShareSessionButton from './ShareSessionButton';
+import SandboxDomainsButton from './SandboxDomainsButton';
 import MessageItem from './MessageItem';
 import ToolExecutionPane from './ToolExecutionPane';
 import PlanApprovalModal from './PlanApprovalModal';
@@ -1371,6 +1372,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               </button>
             )}
 
+
+            {/* Sandbox Domains Button */}
+            {sessionId && agentAPI && (
+              <SandboxDomainsButton sessionId={sessionId} agentAPI={agentAPI} />
+            )}
 
             {/* Share Session Button */}
             {sessionId && agentAPI && (

--- a/src/app/components/SandboxDomainsButton.tsx
+++ b/src/app/components/SandboxDomainsButton.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { AgentAPIProxyClient, AgentAPIProxyError } from '../../lib/agentapi-proxy-client';
+import { SandboxPolicy, UpdateSandboxPolicyRequest } from '../../types/sandbox_policy';
+
+interface SandboxDomainsButtonProps {
+  sessionId: string;
+  agentAPI: AgentAPIProxyClient;
+}
+
+export default function SandboxDomainsButton({ sessionId, agentAPI }: SandboxDomainsButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [allowed, setAllowed] = useState<string[]>([]);
+  const [denied, setDenied] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [policies, setPolicies] = useState<SandboxPolicy[]>([]);
+  const [selectedPolicyId, setSelectedPolicyId] = useState('');
+  const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set());
+  const [addSuccess, setAddSuccess] = useState<string | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
+  const [activeTab, setActiveTab] = useState<'denied' | 'allowed'>('denied');
+
+  const fetchDomains = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await agentAPI.getSessionSandboxDomains(sessionId);
+      setAllowed(result.allowed ?? []);
+      setDenied(result.denied ?? []);
+    } catch (err) {
+      if (err instanceof AgentAPIProxyError && err.status === 503) {
+        setError('このセッションにはネットワークフィルター（サンドボックス）が設定されていません');
+      } else if (err instanceof AgentAPIProxyError && err.status === 501) {
+        setError('このセッションタイプではサンドボックスドメインの取得はサポートされていません');
+      } else {
+        setError('ドメインリストの取得に失敗しました');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [agentAPI, sessionId]);
+
+  const fetchPolicies = useCallback(async () => {
+    try {
+      const result = await agentAPI.getSandboxPolicies();
+      setPolicies(result.sandbox_policies ?? []);
+      if (result.sandbox_policies?.length > 0 && !selectedPolicyId) {
+        setSelectedPolicyId(result.sandbox_policies[0].id);
+      }
+    } catch {
+      // ignore — policies are optional for this flow
+    }
+  }, [agentAPI, selectedPolicyId]);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchDomains();
+      fetchPolicies();
+    }
+  }, [isOpen, fetchDomains, fetchPolicies]);
+
+  const toggleDomain = (domain: string) => {
+    setSelectedDomains((prev) => {
+      const next = new Set(prev);
+      if (next.has(domain)) {
+        next.delete(domain);
+      } else {
+        next.add(domain);
+      }
+      return next;
+    });
+  };
+
+  const handleAddToPolicy = async () => {
+    if (!selectedPolicyId || selectedDomains.size === 0) return;
+    setIsAdding(true);
+    setAddSuccess(null);
+    setError(null);
+    try {
+      const policy = policies.find((p) => p.id === selectedPolicyId);
+      if (!policy) throw new Error('ポリシーが見つかりません');
+
+      const domainsToAdd = Array.from(selectedDomains);
+      const isAllowlist = (policy.allowed_domains?.length ?? 0) > 0 || (policy.denied_domains?.length ?? 0) === 0;
+      const update: UpdateSandboxPolicyRequest = isAllowlist
+        ? { allowed_domains: [...(policy.allowed_domains ?? []), ...domainsToAdd.filter((d) => !policy.allowed_domains?.includes(d))] }
+        : { denied_domains: (policy.denied_domains ?? []).filter((d) => !domainsToAdd.includes(d)) };
+
+      await agentAPI.updateSandboxPolicy(selectedPolicyId, update);
+      setAddSuccess(`${domainsToAdd.length} 件のドメインをポリシー「${policy.name}」に追加しました`);
+      setSelectedDomains(new Set());
+    } catch (err) {
+      setError(err instanceof AgentAPIProxyError ? err.message : 'ポリシーの更新に失敗しました');
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const currentDomains = activeTab === 'denied' ? denied : allowed;
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+        title="サンドボックス アクセスドメイン"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          onClick={(e) => { if (e.target === e.currentTarget) setIsOpen(false); }}
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-lg max-h-[80vh] flex flex-col">
+            {/* Header */}
+            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between shrink-0">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                サンドボックス アクセスドメイン
+              </h2>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+              {isLoading && (
+                <div className="flex items-center justify-center py-8">
+                  <svg className="animate-spin w-6 h-6 text-blue-500" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                  </svg>
+                </div>
+              )}
+
+              {error && !isLoading && (
+                <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md text-red-700 dark:text-red-400 text-sm">
+                  {error}
+                </div>
+              )}
+
+              {addSuccess && (
+                <div className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-md text-green-700 dark:text-green-400 text-sm">
+                  {addSuccess}
+                </div>
+              )}
+
+              {!isLoading && !error && (
+                <>
+                  {/* Tab switcher */}
+                  <div className="flex border-b border-gray-200 dark:border-gray-700">
+                    <button
+                      onClick={() => setActiveTab('denied')}
+                      className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                        activeTab === 'denied'
+                          ? 'border-red-500 text-red-600 dark:text-red-400'
+                          : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'
+                      }`}
+                    >
+                      ブロック済み ({denied.length})
+                    </button>
+                    <button
+                      onClick={() => setActiveTab('allowed')}
+                      className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                        activeTab === 'allowed'
+                          ? 'border-green-500 text-green-600 dark:text-green-400'
+                          : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'
+                      }`}
+                    >
+                      許可済み ({allowed.length})
+                    </button>
+                  </div>
+
+                  {/* Domain list */}
+                  {currentDomains.length === 0 ? (
+                    <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
+                      {activeTab === 'denied' ? 'ブロックされたドメインはありません' : '許可されたドメインはありません'}
+                    </p>
+                  ) : (
+                    <div className="space-y-1 max-h-48 overflow-y-auto">
+                      {currentDomains.map((domain) => (
+                        <label
+                          key={domain}
+                          className="flex items-center space-x-3 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedDomains.has(domain)}
+                            onChange={() => toggleDomain(domain)}
+                            className="rounded border-gray-300 dark:border-gray-600 text-blue-600"
+                          />
+                          <span className={`text-sm font-mono flex-1 truncate ${
+                            activeTab === 'denied' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'
+                          }`}>
+                            {domain}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Add to policy section */}
+                  {selectedDomains.size > 0 && policies.length > 0 && (
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-3">
+                      <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {selectedDomains.size} 件のドメインをポリシーに追加
+                      </p>
+                      <select
+                        value={selectedPolicyId}
+                        onChange={(e) => setSelectedPolicyId(e.target.value)}
+                        className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                      >
+                        {policies.map((p) => (
+                          <option key={p.id} value={p.id}>{p.name}</option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={handleAddToPolicy}
+                        disabled={isAdding}
+                        className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white rounded-md transition-colors disabled:cursor-not-allowed text-sm"
+                      >
+                        {isAdding ? '追加中...' : 'ポリシーに追加（許可リスト更新）'}
+                      </button>
+                    </div>
+                  )}
+
+                  {selectedDomains.size > 0 && policies.length === 0 && (
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        ドメインを追加するには、まず<a href="/sandbox-policies" className="text-blue-600 hover:underline ml-1">サンドボックスポリシー</a>を作成してください。
+                      </p>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div className="px-6 py-3 border-t border-gray-200 dark:border-gray-700 shrink-0 flex justify-between items-center">
+              <button
+                onClick={fetchDomains}
+                disabled={isLoading}
+                className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 disabled:opacity-50"
+              >
+                再読み込み
+              </button>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="px-4 py-2 text-sm bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-md transition-colors"
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/sandbox-policies/page.tsx
+++ b/src/app/sandbox-policies/page.tsx
@@ -17,57 +17,56 @@ interface SessionDomainImportModalProps {
 }
 
 function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: SessionDomainImportModalProps) {
-  const [sessions, setSessions] = useState<Session[]>([])
-  const [selectedSessionId, setSelectedSessionId] = useState('')
   const [domains, setDomains] = useState<{ allowed: string[]; denied: string[] } | null>(null)
-  const [loadingSessions, setLoadingSessions] = useState(false)
-  const [loadingDomains, setLoadingDomains] = useState(false)
+  const [matchCount, setMatchCount] = useState(0)
+  const [loading, setLoading] = useState(false)
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set())
   const [activeTab, setActiveTab] = useState<'denied' | 'allowed'>('denied')
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
 
-  useEffect(() => {
-    if (!isOpen) return
-    setDomains(null)
-    setSelectedDomains(new Set())
-    setSelectedSessionId('')
-    setError(null)
-    setSuccess(null)
-    setActiveTab('denied')
-
-    setLoadingSessions(true)
-    const client = createAgentAPIProxyClientFromStorage()
-    client.search({ status: 'running' })
-      .then((res) => setSessions(res.sessions ?? []))
-      .catch(() => setSessions([]))
-      .finally(() => setLoadingSessions(false))
-  }, [isOpen])
-
-  const fetchDomains = async () => {
-    if (!selectedSessionId) return
-    setLoadingDomains(true)
+  // Fetch and aggregate domains from all sessions using this policy
+  const fetchDomains = useCallback(async () => {
+    setLoading(true)
     setDomains(null)
     setSelectedDomains(new Set())
     setError(null)
     setSuccess(null)
     try {
       const client = createAgentAPIProxyClientFromStorage()
-      const result = await client.getSessionSandboxDomains(selectedSessionId)
-      setDomains(result)
-    } catch (err) {
-      if (err instanceof AgentAPIProxyError && err.status === 503) {
-        setError('このセッションにはネットワークフィルター（サンドボックス）が設定されていません')
-      } else if (err instanceof AgentAPIProxyError && err.status === 501) {
-        setError('このセッションタイプではサンドボックスドメインの取得はサポートされていません')
-      } else {
-        setError('ドメインリストの取得に失敗しました')
+      const res = await client.search()
+      const matching = (res.sessions ?? []).filter((s) => s.sandbox_policy_id === policy.id)
+      setMatchCount(matching.length)
+      if (matching.length === 0) {
+        setDomains({ allowed: [], denied: [] })
+        return
       }
+      // Fetch domains from all matching sessions in parallel, ignore failures
+      const results = await Promise.allSettled(
+        matching.map((s) => client.getSessionSandboxDomains(s.session_id))
+      )
+      const allowedSet = new Set<string>()
+      const deniedSet = new Set<string>()
+      for (const r of results) {
+        if (r.status === 'fulfilled') {
+          r.value.allowed?.forEach((d) => allowedSet.add(d))
+          r.value.denied?.forEach((d) => deniedSet.add(d))
+        }
+      }
+      setDomains({ allowed: Array.from(allowedSet), denied: Array.from(deniedSet) })
+    } catch {
+      setError('セッション情報の取得に失敗しました')
     } finally {
-      setLoadingDomains(false)
+      setLoading(false)
     }
-  }
+  }, [policy.id])
+
+  useEffect(() => {
+    if (!isOpen) return
+    setActiveTab('denied')
+    fetchDomains()
+  }, [isOpen, fetchDomains])
 
   const toggleDomain = (domain: string) => {
     setSelectedDomains((prev) => {
@@ -104,8 +103,6 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
   if (!isOpen) return null
 
   const currentDomains = activeTab === 'denied' ? (domains?.denied ?? []) : (domains?.allowed ?? [])
-  const sessionLabel = (s: Session) =>
-    s.tags?.description || s.tags?.repo || s.session_id.slice(0, 8)
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -116,7 +113,10 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
           <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white">セッションからドメインを取り込む</h2>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">ポリシー: {policy.name}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                ポリシー: {policy.name}
+                {!loading && domains && ` — 対象セッション ${matchCount} 件`}
+              </p>
             </div>
             <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -126,7 +126,6 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
           </div>
 
           <div className="px-6 py-5 space-y-4 max-h-[70vh] overflow-y-auto">
-            {/* Error / success */}
             {error && (
               <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
                 <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
@@ -138,42 +137,23 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
               </div>
             )}
 
-            {/* Session picker */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                セッションを選択
-              </label>
-              {loadingSessions ? (
-                <p className="text-sm text-gray-400">セッションを取得中...</p>
-              ) : sessions.length === 0 ? (
-                <p className="text-sm text-gray-400">実行中のセッションがありません</p>
-              ) : (
-                <div className="flex gap-2">
-                  <select
-                    value={selectedSessionId}
-                    onChange={(e) => { setSelectedSessionId(e.target.value); setDomains(null); setError(null); setSuccess(null) }}
-                    className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  >
-                    <option value="">-- セッションを選択 --</option>
-                    {sessions.map((s) => (
-                      <option key={s.session_id} value={s.session_id}>
-                        {sessionLabel(s)} ({s.status})
-                      </option>
-                    ))}
-                  </select>
-                  <button
-                    onClick={fetchDomains}
-                    disabled={!selectedSessionId || loadingDomains}
-                    className="px-3 py-2 text-sm bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white rounded-lg transition-colors disabled:cursor-not-allowed"
-                  >
-                    {loadingDomains ? '取得中...' : '取得'}
-                  </button>
-                </div>
-              )}
-            </div>
+            {loading && (
+              <div className="flex items-center justify-center py-8 gap-2 text-gray-400">
+                <svg className="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                </svg>
+                <span className="text-sm">セッションのアクセスログを収集中...</span>
+              </div>
+            )}
 
-            {/* Domain tabs */}
-            {domains && (
+            {!loading && domains && matchCount === 0 && (
+              <p className="text-sm text-gray-400 text-center py-6">
+                このポリシーを使用しているセッションが見つかりませんでした
+              </p>
+            )}
+
+            {!loading && domains && matchCount > 0 && (
               <>
                 <div className="flex border-b border-gray-200 dark:border-gray-700">
                   <button
@@ -240,7 +220,14 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
             )}
           </div>
 
-          <div className="flex justify-end px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+            <button
+              onClick={fetchDomains}
+              disabled={loading}
+              className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 disabled:opacity-50"
+            >
+              再取得
+            </button>
             <button onClick={onClose} className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors">
               閉じる
             </button>

--- a/src/app/sandbox-policies/page.tsx
+++ b/src/app/sandbox-policies/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { SandboxPolicy, CreateSandboxPolicyRequest, UpdateSandboxPolicyRequest } from '../../types/sandbox_policy'
-import { Session } from '../../types/agentapi'
 import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 import TopBar from '../components/TopBar'
@@ -17,8 +16,7 @@ interface SessionDomainImportModalProps {
 }
 
 function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: SessionDomainImportModalProps) {
-  const [domains, setDomains] = useState<{ allowed: string[]; denied: string[] } | null>(null)
-  const [matchCount, setMatchCount] = useState(0)
+  const [domains, setDomains] = useState<{ allowed: string[]; denied: string[]; updated_at?: string } | null>(null)
   const [loading, setLoading] = useState(false)
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set())
   const [activeTab, setActiveTab] = useState<'denied' | 'allowed'>('denied')
@@ -26,7 +24,6 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
 
-  // Fetch and aggregate domains from all sessions using this policy
   const fetchDomains = useCallback(async () => {
     setLoading(true)
     setDomains(null)
@@ -35,28 +32,14 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
     setSuccess(null)
     try {
       const client = createAgentAPIProxyClientFromStorage()
-      const res = await client.search()
-      const matching = (res.sessions ?? []).filter((s) => s.sandbox_policy_id === policy.id)
-      setMatchCount(matching.length)
-      if (matching.length === 0) {
-        setDomains({ allowed: [], denied: [] })
-        return
+      const result = await client.getSandboxPolicyDomains(policy.id)
+      setDomains(result)
+    } catch (err) {
+      if (err instanceof AgentAPIProxyError && err.status === 501) {
+        setError('ドメイン収集機能が利用できません')
+      } else {
+        setError('ドメインデータの取得に失敗しました')
       }
-      // Fetch domains from all matching sessions in parallel, ignore failures
-      const results = await Promise.allSettled(
-        matching.map((s) => client.getSessionSandboxDomains(s.session_id))
-      )
-      const allowedSet = new Set<string>()
-      const deniedSet = new Set<string>()
-      for (const r of results) {
-        if (r.status === 'fulfilled') {
-          r.value.allowed?.forEach((d) => allowedSet.add(d))
-          r.value.denied?.forEach((d) => deniedSet.add(d))
-        }
-      }
-      setDomains({ allowed: Array.from(allowedSet), denied: Array.from(deniedSet) })
-    } catch {
-      setError('セッション情報の取得に失敗しました')
     } finally {
       setLoading(false)
     }
@@ -115,7 +98,7 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white">セッションからドメインを取り込む</h2>
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                 ポリシー: {policy.name}
-                {!loading && domains && ` — 対象セッション ${matchCount} 件`}
+                {!loading && domains?.updated_at && ` — 最終更新: ${new Date(domains.updated_at).toLocaleString('ja-JP')}`}
               </p>
             </div>
             <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
@@ -147,13 +130,13 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
               </div>
             )}
 
-            {!loading && domains && matchCount === 0 && (
+            {!loading && domains && domains.allowed.length === 0 && domains.denied.length === 0 && (
               <p className="text-sm text-gray-400 text-center py-6">
-                このポリシーを使用しているセッションが見つかりませんでした
+                まだドメインが収集されていません。このポリシーを使用したセッションが起動されると自動的に収集されます。
               </p>
             )}
 
-            {!loading && domains && matchCount > 0 && (
+            {!loading && domains && (domains.allowed.length > 0 || domains.denied.length > 0) && (
               <>
                 <div className="flex border-b border-gray-200 dark:border-gray-700">
                   <button

--- a/src/app/sandbox-policies/page.tsx
+++ b/src/app/sandbox-policies/page.tsx
@@ -2,10 +2,254 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { SandboxPolicy, CreateSandboxPolicyRequest, UpdateSandboxPolicyRequest } from '../../types/sandbox_policy'
-import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
+import { Session } from '../../types/agentapi'
+import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 import TopBar from '../components/TopBar'
 import NavigationTabs from '../components/NavigationTabs'
+
+// ---- Session Domain Import Modal ----
+interface SessionDomainImportModalProps {
+  isOpen: boolean
+  onClose: () => void
+  policy: SandboxPolicy
+  onImported: () => void
+}
+
+function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: SessionDomainImportModalProps) {
+  const [sessions, setSessions] = useState<Session[]>([])
+  const [selectedSessionId, setSelectedSessionId] = useState('')
+  const [domains, setDomains] = useState<{ allowed: string[]; denied: string[] } | null>(null)
+  const [loadingSessions, setLoadingSessions] = useState(false)
+  const [loadingDomains, setLoadingDomains] = useState(false)
+  const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set())
+  const [activeTab, setActiveTab] = useState<'denied' | 'allowed'>('denied')
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    setDomains(null)
+    setSelectedDomains(new Set())
+    setSelectedSessionId('')
+    setError(null)
+    setSuccess(null)
+    setActiveTab('denied')
+
+    setLoadingSessions(true)
+    const client = createAgentAPIProxyClientFromStorage()
+    client.search({ status: 'running' })
+      .then((res) => setSessions(res.sessions ?? []))
+      .catch(() => setSessions([]))
+      .finally(() => setLoadingSessions(false))
+  }, [isOpen])
+
+  const fetchDomains = async () => {
+    if (!selectedSessionId) return
+    setLoadingDomains(true)
+    setDomains(null)
+    setSelectedDomains(new Set())
+    setError(null)
+    setSuccess(null)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      const result = await client.getSessionSandboxDomains(selectedSessionId)
+      setDomains(result)
+    } catch (err) {
+      if (err instanceof AgentAPIProxyError && err.status === 503) {
+        setError('このセッションにはネットワークフィルター（サンドボックス）が設定されていません')
+      } else if (err instanceof AgentAPIProxyError && err.status === 501) {
+        setError('このセッションタイプではサンドボックスドメインの取得はサポートされていません')
+      } else {
+        setError('ドメインリストの取得に失敗しました')
+      }
+    } finally {
+      setLoadingDomains(false)
+    }
+  }
+
+  const toggleDomain = (domain: string) => {
+    setSelectedDomains((prev) => {
+      const next = new Set(prev)
+      if (next.has(domain)) next.delete(domain)
+      else next.add(domain)
+      return next
+    })
+  }
+
+  const handleAddToPolicy = async () => {
+    if (selectedDomains.size === 0) return
+    setIsSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      const toAdd = Array.from(selectedDomains)
+      const isAllowlist = (policy.allowed_domains?.length ?? 0) > 0 || (policy.denied_domains?.length ?? 0) === 0
+      const update: UpdateSandboxPolicyRequest = isAllowlist
+        ? { allowed_domains: [...new Set([...(policy.allowed_domains ?? []), ...toAdd])] }
+        : { denied_domains: (policy.denied_domains ?? []).filter((d) => !toAdd.includes(d)) }
+      await client.updateSandboxPolicy(policy.id, update)
+      setSuccess(`${toAdd.length} 件のドメインをポリシーに追加しました`)
+      setSelectedDomains(new Set())
+      onImported()
+    } catch (err) {
+      setError(err instanceof AgentAPIProxyError ? err.message : 'ポリシーの更新に失敗しました')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  const currentDomains = activeTab === 'denied' ? (domains?.denied ?? []) : (domains?.allowed ?? [])
+  const sessionLabel = (s: Session) =>
+    s.tags?.description || s.tags?.repo || s.session_id.slice(0, 8)
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="fixed inset-0 bg-black bg-opacity-50" onClick={onClose} />
+      <div className="relative min-h-full flex items-center justify-center p-4">
+        <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
+          {/* Header */}
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">セッションからドメインを取り込む</h2>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">ポリシー: {policy.name}</p>
+            </div>
+            <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="px-6 py-5 space-y-4 max-h-[70vh] overflow-y-auto">
+            {/* Error / success */}
+            {error && (
+              <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
+              </div>
+            )}
+            {success && (
+              <div className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+                <p className="text-sm text-green-700 dark:text-green-400">{success}</p>
+              </div>
+            )}
+
+            {/* Session picker */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                セッションを選択
+              </label>
+              {loadingSessions ? (
+                <p className="text-sm text-gray-400">セッションを取得中...</p>
+              ) : sessions.length === 0 ? (
+                <p className="text-sm text-gray-400">実行中のセッションがありません</p>
+              ) : (
+                <div className="flex gap-2">
+                  <select
+                    value={selectedSessionId}
+                    onChange={(e) => { setSelectedSessionId(e.target.value); setDomains(null); setError(null); setSuccess(null) }}
+                    className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="">-- セッションを選択 --</option>
+                    {sessions.map((s) => (
+                      <option key={s.session_id} value={s.session_id}>
+                        {sessionLabel(s)} ({s.status})
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={fetchDomains}
+                    disabled={!selectedSessionId || loadingDomains}
+                    className="px-3 py-2 text-sm bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white rounded-lg transition-colors disabled:cursor-not-allowed"
+                  >
+                    {loadingDomains ? '取得中...' : '取得'}
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Domain tabs */}
+            {domains && (
+              <>
+                <div className="flex border-b border-gray-200 dark:border-gray-700">
+                  <button
+                    onClick={() => setActiveTab('denied')}
+                    className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                      activeTab === 'denied'
+                        ? 'border-red-500 text-red-600 dark:text-red-400'
+                        : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'
+                    }`}
+                  >
+                    ブロック済み ({domains.denied.length})
+                  </button>
+                  <button
+                    onClick={() => setActiveTab('allowed')}
+                    className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                      activeTab === 'allowed'
+                        ? 'border-green-500 text-green-600 dark:text-green-400'
+                        : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'
+                    }`}
+                  >
+                    許可済み ({domains.allowed.length})
+                  </button>
+                </div>
+
+                {currentDomains.length === 0 ? (
+                  <p className="text-sm text-gray-400 text-center py-3">
+                    {activeTab === 'denied' ? 'ブロックされたドメインはありません' : '許可されたドメインはありません'}
+                  </p>
+                ) : (
+                  <div className="space-y-1 max-h-48 overflow-y-auto">
+                    {currentDomains.map((domain) => (
+                      <label key={domain} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={selectedDomains.has(domain)}
+                          onChange={() => toggleDomain(domain)}
+                          className="rounded border-gray-300 dark:border-gray-600 text-blue-600 shrink-0"
+                        />
+                        <span className={`text-sm font-mono flex-1 truncate ${
+                          activeTab === 'denied' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'
+                        }`}>
+                          {domain}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+
+                {selectedDomains.size > 0 && (
+                  <div className="pt-2">
+                    <button
+                      onClick={handleAddToPolicy}
+                      disabled={isSaving}
+                      className="w-full px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white rounded-lg transition-colors disabled:cursor-not-allowed"
+                    >
+                      {isSaving ? '追加中...' : `選択した ${selectedDomains.size} 件をポリシーに追加`}
+                    </button>
+                    <p className="text-xs text-gray-400 mt-1 text-center">
+                      {(policy.allowed_domains?.length ?? 0) > 0 ? '許可リストに追加されます' : '拒否リストから除外されます'}
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          <div className="flex justify-end px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+            <button onClick={onClose} className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors">
+              閉じる
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 // ---- Form Modal ----
 interface SandboxPolicyFormModalProps {
@@ -168,7 +412,17 @@ function SandboxPolicyFormModal({ isOpen, onClose, onSuccess, editing }: Sandbox
 }
 
 // ---- Policy Card ----
-function PolicyCard({ policy, onEdit, onDelete }: { policy: SandboxPolicy; onEdit: () => void; onDelete: () => void }) {
+function PolicyCard({
+  policy,
+  onEdit,
+  onDelete,
+  onImportDomains,
+}: {
+  policy: SandboxPolicy
+  onEdit: () => void
+  onDelete: () => void
+  onImportDomains: () => void
+}) {
   const domains = policy.allowed_domains?.length
     ? { mode: '許可リスト', list: policy.allowed_domains }
     : policy.denied_domains?.length
@@ -183,6 +437,9 @@ function PolicyCard({ policy, onEdit, onDelete }: { policy: SandboxPolicy; onEdi
           {policy.description && <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{policy.description}</p>}
         </div>
         <div className="flex gap-2 shrink-0">
+          <button onClick={onImportDomains} title="セッションからドメインを取り込む" className="text-xs px-2 py-1 rounded border border-blue-200 dark:border-blue-800 text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20">
+            取り込む
+          </button>
           <button onClick={onEdit} className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700">編集</button>
           <button onClick={onDelete} className="text-xs px-2 py-1 rounded border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">削除</button>
         </div>
@@ -209,6 +466,7 @@ export default function SandboxPoliciesPage() {
   const [loading, setLoading] = useState(true)
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [editing, setEditing] = useState<SandboxPolicy | null>(null)
+  const [importTarget, setImportTarget] = useState<SandboxPolicy | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -291,6 +549,7 @@ export default function SandboxPoliciesPage() {
                 policy={policy}
                 onEdit={() => { setEditing(policy); setIsFormOpen(true) }}
                 onDelete={() => handleDelete(policy)}
+                onImportDomains={() => setImportTarget(policy)}
               />
             ))}
           </div>
@@ -314,6 +573,15 @@ export default function SandboxPoliciesPage() {
         onSuccess={() => { setIsFormOpen(false); setEditing(null); load() }}
         editing={editing}
       />
+
+      {importTarget && (
+        <SessionDomainImportModal
+          isOpen={!!importTarget}
+          onClose={() => setImportTarget(null)}
+          policy={importTarget}
+          onImported={load}
+        />
+      )}
     </main>
   )
 }

--- a/src/app/sandbox-policies/page.tsx
+++ b/src/app/sandbox-policies/page.tsx
@@ -19,6 +19,8 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
   const [domains, setDomains] = useState<{ allowed: string[]; denied: string[]; updated_at?: string } | null>(null)
   const [loading, setLoading] = useState(false)
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set())
+  // Track domains already registered in the policy (pre-existing + just added this session)
+  const [registeredDomains, setRegisteredDomains] = useState<Set<string>>(new Set())
   const [activeTab, setActiveTab] = useState<'denied' | 'allowed'>('denied')
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -48,8 +50,11 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
   useEffect(() => {
     if (!isOpen) return
     setActiveTab('denied')
+    // Seed registered set from the policy's current domain list
+    const isAllowlist = (policy.allowed_domains?.length ?? 0) > 0 || (policy.denied_domains?.length ?? 0) === 0
+    setRegisteredDomains(new Set(isAllowlist ? (policy.allowed_domains ?? []) : (policy.denied_domains ?? [])))
     fetchDomains()
-  }, [isOpen, fetchDomains])
+  }, [isOpen, fetchDomains, policy.allowed_domains, policy.denied_domains])
 
   const toggleDomain = (domain: string) => {
     setSelectedDomains((prev) => {
@@ -75,6 +80,7 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
       await client.updateSandboxPolicy(policy.id, update)
       setSuccess(`${toAdd.length} 件のドメインをポリシーに追加しました`)
       setSelectedDomains(new Set())
+      setRegisteredDomains((prev) => new Set([...prev, ...toAdd]))
       onImported()
     } catch (err) {
       setError(err instanceof AgentAPIProxyError ? err.message : 'ポリシーの更新に失敗しました')
@@ -85,7 +91,8 @@ function SessionDomainImportModal({ isOpen, onClose, policy, onImported }: Sessi
 
   if (!isOpen) return null
 
-  const currentDomains = activeTab === 'denied' ? (domains?.denied ?? []) : (domains?.allowed ?? [])
+  const currentDomains = (activeTab === 'denied' ? (domains?.denied ?? []) : (domains?.allowed ?? []))
+    .filter((d) => !registeredDomains.has(d))
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -1456,6 +1456,10 @@ export class AgentAPIProxyClient {
    * Revoke share for a session
    * DELETE /sessions/{sessionId}/share
    */
+  async getSandboxPolicyDomains(policyId: string): Promise<{ allowed: string[]; denied: string[]; updated_at?: string }> {
+    return this.makeRequest<{ allowed: string[]; denied: string[]; updated_at?: string }>(`/sandbox-policies/${policyId}/domains`);
+  }
+
   async getSessionSandboxDomains(sessionId: string): Promise<{ allowed: string[]; denied: string[] }> {
     if (this.debug) {
       console.log(`[AgentAPIProxy] Fetching sandbox domains for session: ${sessionId}`);

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -1456,6 +1456,13 @@ export class AgentAPIProxyClient {
    * Revoke share for a session
    * DELETE /sessions/{sessionId}/share
    */
+  async getSessionSandboxDomains(sessionId: string): Promise<{ allowed: string[]; denied: string[] }> {
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Fetching sandbox domains for session: ${sessionId}`);
+    }
+    return this.makeRequest<{ allowed: string[]; denied: string[] }>(`/sessions/${sessionId}/sandbox-domains`);
+  }
+
   async revokeShare(sessionId: string): Promise<RevokeShareResponse> {
     if (this.debug) {
       console.log(`[AgentAPIProxy] Revoking share for session: ${sessionId}`);

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -176,6 +176,7 @@ export interface Session {
   tags?: Record<string, string>;
   scope?: ResourceScope;
   team_id?: string;
+  sandbox_policy_id?: string;
 }
 
 export interface SessionListParams {


### PR DESCRIPTION
## Summary

- Adds `getSessionSandboxDomains(sessionId)` to `AgentAPIProxyClient` — calls the new `GET /sessions/:sessionId/sandbox-domains` proxy endpoint
- Adds `SandboxDomainsButton` component: a toolbar button that opens a modal showing domains the session's network filter has allowed and blocked, with checkboxes to select domains and a policy picker to add them to an existing sandbox policy
- Wires the button into `AgentAPIChat` toolbar (next to the share button)

## UX flow

1. User opens a sandboxed session
2. Clicks the shield icon in the toolbar
3. Modal opens showing two tabs: **ブロック済み** (denied) and **許可済み** (allowed)
4. User selects domains they want to allow (e.g. a domain that was unexpectedly blocked)
5. Picks a sandbox policy from the dropdown
6. Clicks "ポリシーに追加（許可リスト更新）" to update the policy
7. Future sessions using that policy will have those domains allowed

## Test plan

- [ ] TypeScript compiles without errors
- [ ] Button is visible in chat toolbar for all sessions
- [ ] Shows 503 error message for sessions without sandbox sidecar
- [ ] Blocked domains appear in the "ブロック済み" tab
- [ ] Allowed domains appear in the "許可済み" tab
- [ ] Selecting domains and clicking "追加" updates the sandbox policy
- [ ] "再読み込み" button refreshes the domain list

Requires: takutakahashi/agentapi-proxy#788

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)