### PR TITLE
feat(sandbox): nfa v0.6.0 count mode support

### DIFF
--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -42,6 +42,7 @@ export default function SessionProfileFormModal({
   const [sandboxPolicyId, setSandboxPolicyId] = useState('')
   const [sandboxMode, setSandboxMode] = useState<'allowlist' | 'denylist'>('allowlist')
   const [sandboxDomains, setSandboxDomains] = useState('')
+  const [sandboxCountMode, setSandboxCountMode] = useState(false)
   const [availablePolicies, setAvailablePolicies] = useState<SandboxPolicy[]>([])
 
   // UI state
@@ -106,11 +107,13 @@ export default function SessionProfileFormModal({
           setSandboxMode('denylist')
           setSandboxDomains(sandbox.denied_domains.join('\n'))
         }
+        setSandboxCountMode(sandbox.count_mode ?? false)
         if (sandbox.enabled) setShowAdvanced(true)
       } else {
         setSandboxEnabled(false)
         setSandboxMode('allowlist')
         setSandboxDomains('')
+        setSandboxCountMode(false)
       }
     } else {
       // Reset form
@@ -124,6 +127,7 @@ export default function SessionProfileFormModal({
       setSandboxPolicyId('')
       setSandboxMode('allowlist')
       setSandboxDomains('')
+      setSandboxCountMode(false)
       setShowAdvanced(false)
     }
     setError(null)
@@ -198,13 +202,14 @@ export default function SessionProfileFormModal({
       const tags = pairsToRecord(tagPairs)
 
       // Build sandbox config if enabled
-      let sandboxConfig: { enabled: boolean; allowed_domains?: string[]; denied_domains?: string[] } | undefined
+      let sandboxConfig: { enabled: boolean; allowed_domains?: string[]; denied_domains?: string[]; count_mode?: boolean } | undefined
       if (sandboxEnabled) {
         const domainList = sandboxDomains.split('\n').map(d => d.trim()).filter(Boolean)
         sandboxConfig = {
           enabled: true,
           ...(sandboxMode === 'allowlist' && domainList.length > 0 ? { allowed_domains: domainList } : {}),
           ...(sandboxMode === 'denylist' && domainList.length > 0 ? { denied_domains: domainList } : {}),
+          ...(sandboxCountMode ? { count_mode: true } : {}),
         }
       }
 
@@ -586,6 +591,20 @@ export default function SessionProfileFormModal({
                             rows={4}
                             className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
                           />
+                        </div>
+                        <div>
+                          <label className="flex items-start gap-1.5 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={sandboxCountMode}
+                              onChange={(e) => setSandboxCountMode(e.target.checked)}
+                              className="mt-0.5 h-3.5 w-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                            />
+                            <div>
+                              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">カウントモード</span>
+                              <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">ポリシーを評価してブロック対象ドメインを記録するが、トラフィックは実際にはブロックしない。本番適用前の監査に利用できる。</p>
+                            </div>
+                          </label>
                         </div>
                       </div>
                     )}

--- a/src/app/sandbox-policies/page.tsx
+++ b/src/app/sandbox-policies/page.tsx
@@ -242,6 +242,7 @@ function SandboxPolicyFormModal({ isOpen, onClose, onSuccess, editing }: Sandbox
   const [description, setDescription] = useState('')
   const [mode, setMode] = useState<'allowlist' | 'denylist'>('allowlist')
   const [domains, setDomains] = useState('')
+  const [countMode, setCountMode] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -259,11 +260,13 @@ function SandboxPolicyFormModal({ isOpen, onClose, onSuccess, editing }: Sandbox
         setMode('allowlist')
         setDomains('')
       }
+      setCountMode(editing.count_mode ?? false)
     } else {
       setName('')
       setDescription('')
       setMode('allowlist')
       setDomains('')
+      setCountMode(false)
     }
     setError(null)
   }, [editing, isOpen])
@@ -280,6 +283,7 @@ function SandboxPolicyFormModal({ isOpen, onClose, onSuccess, editing }: Sandbox
           name: name.trim(),
           description: description.trim() || undefined,
           ...(mode === 'allowlist' ? { allowed_domains: domainList, denied_domains: [] } : { denied_domains: domainList, allowed_domains: [] }),
+          count_mode: countMode,
         }
         await client.updateSandboxPolicy(editing.id, data)
       } else {
@@ -288,6 +292,7 @@ function SandboxPolicyFormModal({ isOpen, onClose, onSuccess, editing }: Sandbox
           name: name.trim(),
           description: description.trim() || undefined,
           ...(mode === 'allowlist' ? { allowed_domains: domainList } : { denied_domains: domainList }),
+          count_mode: countMode,
           scope: (scopeParams as { scope?: 'user' | 'team' }).scope ?? 'user',
           ...(scopeParams as { team_id?: string }).team_id ? { team_id: (scopeParams as { team_id?: string }).team_id } : {},
         }
@@ -372,6 +377,22 @@ function SandboxPolicyFormModal({ isOpen, onClose, onSuccess, editing }: Sandbox
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
               />
             </div>
+            <div>
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={countMode}
+                  onChange={(e) => setCountMode(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                />
+                <div>
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">カウントモード</span>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    ポリシーを評価してブロック対象ドメインを記録するが、トラフィックは実際にはブロックしない。本番適用前の監査に利用できる。
+                  </p>
+                </div>
+              </label>
+            </div>
           </form>
 
           <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700">
@@ -410,7 +431,14 @@ function PolicyCard({
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 flex flex-col gap-3">
       <div className="flex items-start justify-between gap-2">
         <div>
-          <h3 className="font-semibold text-gray-900 dark:text-white">{policy.name}</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-gray-900 dark:text-white">{policy.name}</h3>
+            {policy.count_mode && (
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300">
+                カウント
+              </span>
+            )}
+          </div>
           {policy.description && <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{policy.description}</p>}
         </div>
         <div className="flex gap-2 shrink-0">

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -200,6 +200,7 @@ export interface SandboxConfig {
   policy_id?: string;
   allowed_domains?: string[];
   denied_domains?: string[];
+  count_mode?: boolean;
 }
 
 export interface CreateSessionRequest {

--- a/src/types/sandbox_policy.ts
+++ b/src/types/sandbox_policy.ts
@@ -6,6 +6,7 @@ export interface SandboxPolicy {
   description?: string;
   allowed_domains?: string[];
   denied_domains?: string[];
+  count_mode?: boolean;
   scope: ResourceScope;
   owner_id: string;
   team_id?: string;
@@ -18,6 +19,7 @@ export interface CreateSandboxPolicyRequest {
   description?: string;
   allowed_domains?: string[];
   denied_domains?: string[];
+  count_mode?: boolean;
   scope: ResourceScope;
   team_id?: string;
 }
@@ -27,6 +29,7 @@ export interface UpdateSandboxPolicyRequest {
   description?: string;
   allowed_domains?: string[];
   denied_domains?: string[];
+  count_mode?: boolean;
 }
 
 export interface SandboxPolicyListParams {


### PR DESCRIPTION
## Summary

- `SandboxConfig` 型に `count_mode?: boolean` を追加（nfa v0.6.0 対応）
- `SessionProfileFormModal` にカウントモードのトグル UI を追加
- プロファイルの編集時に `count_mode` を初期化・リセット
- フォーム送信時に `count_mode: true` をサンドボックス設定に含める

## count mode とは

nfa v0.6.0 で追加された機能。ポリシールールを評価してブロック対象ドメインを記録するが、トラフィックは実際にはブロックしない。本番適用前のポリシー監査に利用できる。

UI では「サンドボックスを有効にする」チェックボックスの下に「カウントモード」チェックボックスが表示される。

## 関連

- agentapi-proxy PR: https://github.com/takutakahashi/agentapi-proxy/pull/789

## Test plan

- [ ] セッションプロファイル作成フォームでサンドボックスを有効にすると「カウントモード」チェックボックスが表示される
- [ ] カウントモードを有効にして保存すると `count_mode: true` がプロファイルに保存される
- [ ] 既存プロファイルの編集時に `count_mode` の値が正しく反映される

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)