### PR TITLE
feat(dind): add Docker-in-Docker UI to session creation form

### DIFF
--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -45,6 +45,15 @@ export default function SessionProfileFormModal({
   const [sandboxCountMode, setSandboxCountMode] = useState(false)
   const [availablePolicies, setAvailablePolicies] = useState<SandboxPolicy[]>([])
 
+  // Docker / DinD fields
+  const [dockerEnabled, setDockerEnabled] = useState(false)
+  const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string }>>([])
+
+  const addDockerRegistry = () => setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '' }])
+  const removeDockerRegistry = (index: number) => setDockerRegistries(prev => prev.filter((_, i) => i !== index))
+  const updateDockerRegistry = (index: number, field: string, value: string) =>
+    setDockerRegistries(prev => prev.map((r, i) => i === index ? { ...r, [field]: value } : r))
+
   // UI state
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -115,6 +124,22 @@ export default function SessionProfileFormModal({
         setSandboxDomains('')
         setSandboxCountMode(false)
       }
+
+      // Initialize docker from profile params
+      const docker = cfg?.params?.docker
+      if (docker) {
+        setDockerEnabled(docker.enabled)
+        setDockerRegistries((docker.registries ?? []).map(r => ({
+          server: r.server ?? '',
+          username: r.username ?? '',
+          password: r.password ?? '',
+          secretName: r.secret_name ?? '',
+        })))
+        if (docker.enabled) setShowAdvanced(true)
+      } else {
+        setDockerEnabled(false)
+        setDockerRegistries([])
+      }
     } else {
       // Reset form
       setName('')
@@ -128,6 +153,8 @@ export default function SessionProfileFormModal({
       setSandboxMode('allowlist')
       setSandboxDomains('')
       setSandboxCountMode(false)
+      setDockerEnabled(false)
+      setDockerRegistries([])
       setShowAdvanced(false)
     }
     setError(null)
@@ -213,11 +240,25 @@ export default function SessionProfileFormModal({
         }
       }
 
+      // Build docker config if enabled
+      let dockerConfig: { enabled: boolean; registries?: { server?: string; username?: string; password?: string; secret_name?: string }[] } | undefined
+      if (dockerEnabled) {
+        const regs = dockerRegistries
+          .filter(r => r.server || r.username || r.secretName)
+          .map(r => ({
+            ...(r.server ? { server: r.server } : {}),
+            ...(r.secretName ? { secret_name: r.secretName } : {}),
+            ...(r.username && !r.secretName ? { username: r.username, password: r.password } : {}),
+          }))
+        dockerConfig = { enabled: true, ...(regs.length > 0 ? { registries: regs } : {}) }
+      }
+
       // Build params if any param is set
-      const hasParams = agentType.trim() || sandboxConfig
+      const hasParams = agentType.trim() || sandboxConfig || dockerConfig
       const params = hasParams ? {
         ...(agentType.trim() ? { agent_type: agentType.trim() } : {}),
         ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
+        ...(dockerConfig ? { docker: dockerConfig } : {}),
       } : undefined
 
       const config = {
@@ -606,6 +647,103 @@ export default function SessionProfileFormModal({
                             </div>
                           </label>
                         </div>
+                      </div>
+                    )}
+                  </div>
+                  {/* Docker in Docker (DinD) */}
+                  <div>
+                    <label className="flex items-start gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={dockerEnabled}
+                        onChange={(e) => setDockerEnabled(e.target.checked)}
+                        className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                      />
+                      <div>
+                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Docker in Docker (DinD) を有効にする
+                        </span>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          セッション Pod に docker:dind サイドカーを追加し、<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs">DOCKER_HOST</code> を自動設定します。
+                        </p>
+                      </div>
+                    </label>
+
+                    {dockerEnabled && (
+                      <div className="mt-3 ml-6 space-y-3">
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-medium text-gray-600 dark:text-gray-400">認証済みレジストリ（任意）</span>
+                          <button
+                            type="button"
+                            onClick={addDockerRegistry}
+                            className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700"
+                          >
+                            + 追加
+                          </button>
+                        </div>
+                        {dockerRegistries.length === 0 && (
+                          <p className="text-xs text-gray-400 dark:text-gray-500">
+                            認証不要な場合は追加不要です。
+                          </p>
+                        )}
+                        {dockerRegistries.map((registry, index) => (
+                          <div key={index} className="border border-gray-200 dark:border-gray-600 rounded-lg p-3 space-y-2">
+                            <div className="flex items-center justify-between">
+                              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">レジストリ #{index + 1}</span>
+                              <button
+                                type="button"
+                                onClick={() => removeDockerRegistry(index)}
+                                className="text-xs text-red-500 hover:text-red-600"
+                              >
+                                削除
+                              </button>
+                            </div>
+                            <div>
+                              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">サーバー（空 = Docker Hub）</label>
+                              <input
+                                type="text"
+                                value={registry.server}
+                                onChange={e => updateDockerRegistry(index, 'server', e.target.value)}
+                                placeholder="ghcr.io"
+                                className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">K8s Secret 名（docker config JSON）</label>
+                              <input
+                                type="text"
+                                value={registry.secretName}
+                                onChange={e => updateDockerRegistry(index, 'secretName', e.target.value)}
+                                placeholder="my-registry-secret"
+                                className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                              />
+                            </div>
+                            {!registry.secretName && (
+                              <>
+                                <div>
+                                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">ユーザー名</label>
+                                  <input
+                                    type="text"
+                                    value={registry.username}
+                                    onChange={e => updateDockerRegistry(index, 'username', e.target.value)}
+                                    placeholder="myuser"
+                                    className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">パスワード / アクセストークン</label>
+                                  <input
+                                    type="password"
+                                    value={registry.password}
+                                    onChange={e => updateDockerRegistry(index, 'password', e.target.value)}
+                                    placeholder="••••••••"
+                                    className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                                  />
+                                </div>
+                              </>
+                            )}
+                          </div>
+                        ))}
                       </div>
                     )}
                   </div>

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -46,6 +46,18 @@ export default function NewSessionPage() {
   const [sandboxEnabled, setSandboxEnabled] = useState(false)
   const [sandboxMode, setSandboxMode] = useState<'allowlist' | 'denylist'>('allowlist')
   const [sandboxDomains, setSandboxDomains] = useState('')
+  const [dockerEnabled, setDockerEnabled] = useState(false)
+  const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string }>>([])
+
+  const addDockerRegistry = () => {
+    setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '' }])
+  }
+  const removeDockerRegistry = (index: number) => {
+    setDockerRegistries(prev => prev.filter((_, i) => i !== index))
+  }
+  const updateDockerRegistry = (index: number, field: string, value: string) => {
+    setDockerRegistries(prev => prev.map((r, i) => i === index ? { ...r, [field]: value } : r))
+  }
 
   useEffect(() => {
     loadTemplates()
@@ -176,6 +188,21 @@ export default function NewSessionPage() {
           enabled: true,
           ...(sandboxMode === 'allowlist' && domains.length > 0 ? { allowed_domains: domains } : {}),
           ...(sandboxMode === 'denylist' && domains.length > 0 ? { denied_domains: domains } : {}),
+        }
+      }
+
+      // DinDが有効な場合はdockerを送信
+      if (dockerEnabled) {
+        const registries = dockerRegistries
+          .filter(r => r.server || r.username || r.secretName)
+          .map(r => ({
+            ...(r.server ? { server: r.server } : {}),
+            ...(r.secretName ? { secret_name: r.secretName } : {}),
+            ...(r.username && !r.secretName ? { username: r.username, password: r.password } : {}),
+          }))
+        params.docker = {
+          enabled: true,
+          ...(registries.length > 0 ? { registries } : {}),
         }
       }
 
@@ -741,6 +768,120 @@ export default function NewSessionPage() {
                             {sandboxMode === 'allowlist' && '空の場合はすべてのドメインをブロック。'}
                           </p>
                         </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Docker in Docker (DinD) */}
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <p className="text-xs font-medium text-gray-600 dark:text-gray-400">Docker in Docker (DinD)</p>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                          {dockerEnabled ? '有効' : '無効'}
+                        </span>
+                        <button
+                          type="button"
+                          role="switch"
+                          aria-checked={dockerEnabled}
+                          onClick={() => setDockerEnabled(!dockerEnabled)}
+                          disabled={isCreating}
+                          className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${
+                            dockerEnabled ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'
+                          }`}
+                        >
+                          <span
+                            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                              dockerEnabled ? 'translate-x-4' : 'translate-x-0'
+                            }`}
+                          />
+                        </button>
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">
+                      セッション Pod に docker:dind サイドカーを追加し、<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">DOCKER_HOST</code> を自動設定します。
+                    </p>
+                    {dockerEnabled && (
+                      <div className="pl-1 space-y-3">
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs font-medium text-gray-600 dark:text-gray-400">認証済みレジストリ（任意）</p>
+                          <button
+                            type="button"
+                            onClick={addDockerRegistry}
+                            disabled={isCreating}
+                            className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 disabled:opacity-50"
+                          >
+                            + 追加
+                          </button>
+                        </div>
+                        {dockerRegistries.length === 0 && (
+                          <p className="text-xs text-gray-400 dark:text-gray-500">
+                            レジストリ認証が不要な場合は追加不要です。
+                          </p>
+                        )}
+                        {dockerRegistries.map((registry, index) => (
+                          <div key={index} className="border border-gray-200 dark:border-gray-600 rounded-lg p-3 space-y-2">
+                            <div className="flex items-center justify-between">
+                              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">レジストリ #{index + 1}</span>
+                              <button
+                                type="button"
+                                onClick={() => removeDockerRegistry(index)}
+                                disabled={isCreating}
+                                className="text-xs text-red-500 hover:text-red-600 disabled:opacity-50"
+                              >
+                                削除
+                              </button>
+                            </div>
+                            <div>
+                              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">サーバー（空 = Docker Hub）</label>
+                              <input
+                                type="text"
+                                value={registry.server}
+                                onChange={e => updateDockerRegistry(index, 'server', e.target.value)}
+                                placeholder="ghcr.io"
+                                disabled={isCreating}
+                                className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">K8s Secret 名（docker config JSON）</label>
+                              <input
+                                type="text"
+                                value={registry.secretName}
+                                onChange={e => updateDockerRegistry(index, 'secretName', e.target.value)}
+                                placeholder="my-registry-secret"
+                                disabled={isCreating}
+                                className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                              />
+                            </div>
+                            {!registry.secretName && (
+                              <>
+                                <div>
+                                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">ユーザー名</label>
+                                  <input
+                                    type="text"
+                                    value={registry.username}
+                                    onChange={e => updateDockerRegistry(index, 'username', e.target.value)}
+                                    placeholder="myuser"
+                                    disabled={isCreating}
+                                    className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">パスワード / アクセストークン</label>
+                                  <input
+                                    type="password"
+                                    value={registry.password}
+                                    onChange={e => updateDockerRegistry(index, 'password', e.target.value)}
+                                    placeholder="••••••••"
+                                    disabled={isCreating}
+                                    className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                                  />
+                                </div>
+                              </>
+                            )}
+                          </div>
+                        ))}
                       </div>
                     )}
                   </div>

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -203,6 +203,18 @@ export interface SandboxConfig {
   count_mode?: boolean;
 }
 
+export interface DockerRegistry {
+  server?: string;
+  username?: string;
+  password?: string;
+  secret_name?: string;
+}
+
+export interface DockerConfig {
+  enabled: boolean;
+  registries?: DockerRegistry[];
+}
+
 export interface CreateSessionRequest {
   user_id: string;
   environment?: Record<string, string>;
@@ -213,6 +225,7 @@ export interface CreateSessionRequest {
     github_token?: string;
     oneshot?: boolean;
     sandbox?: SandboxConfig;
+    docker?: DockerConfig;
     [key: string]: unknown;
   };
   scope?: ResourceScope;

--- a/src/types/session_profile.ts
+++ b/src/types/session_profile.ts
@@ -1,4 +1,4 @@
-import { ResourceScope, SandboxConfig } from './agentapi';
+import { ResourceScope, SandboxConfig, DockerConfig } from './agentapi';
 
 // Session profile params
 export interface SessionProfileParams {
@@ -6,6 +6,7 @@ export interface SessionProfileParams {
   github_token?: string;
   agent_type?: string;
   sandbox?: SandboxConfig;
+  docker?: DockerConfig;
 }
 
 // Session profile config


### PR DESCRIPTION
## Summary

- Add DinD (Docker in Docker) opt-in toggle to the session creation advanced settings
- Add authenticated container registry configuration (K8s Secret or inline credentials)
- Add `DockerRegistry` and `DockerConfig` types to match agentapi-proxy API

## Changes

**New UI in Advanced Settings:**

```
Docker in Docker (DinD)    [toggle: 有効/無効]

セッション Pod に docker:dind サイドカーを追加し、DOCKER_HOST を自動設定します。

認証済みレジストリ（任意）  [+ 追加]

  レジストリ #1
  サーバー: ghcr.io
  K8s Secret 名: my-registry-secret
  （または ユーザー名 + パスワード）
```

**API payload when enabled:**
\`\`\`json
{
  "params": {
    "docker": {
      "enabled": true,
      "registries": [
        { "server": "ghcr.io", "secret_name": "my-secret" },
        { "server": "registry.example.com", "username": "user", "password": "token" }
      ]
    }
  }
}
\`\`\`

## Test plan

- [ ] Enable DinD toggle and verify `docker` params are sent in session creation request
- [ ] Add registry with K8s Secret name and verify payload
- [ ] Add registry with inline credentials and verify payload (password excluded from secret_name path)
- [ ] Deploy to dev and create DinD session from UI

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)