### PR TITLE
feat(docker): add insecure checkbox to registry config UI

### DIFF
--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -47,11 +47,11 @@ export default function SessionProfileFormModal({
 
   // Docker / DinD fields
   const [dockerEnabled, setDockerEnabled] = useState(false)
-  const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string }>>([])
+  const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string; insecure: boolean }>>([])
 
-  const addDockerRegistry = () => setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '' }])
+  const addDockerRegistry = () => setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '', insecure: false }])
   const removeDockerRegistry = (index: number) => setDockerRegistries(prev => prev.filter((_, i) => i !== index))
-  const updateDockerRegistry = (index: number, field: string, value: string) =>
+  const updateDockerRegistry = (index: number, field: string, value: string | boolean) =>
     setDockerRegistries(prev => prev.map((r, i) => i === index ? { ...r, [field]: value } : r))
 
   // UI state
@@ -134,6 +134,7 @@ export default function SessionProfileFormModal({
           username: r.username ?? '',
           password: r.password ?? '',
           secretName: r.secret_name ?? '',
+          insecure: r.insecure ?? false,
         })))
         if (docker.enabled) setShowAdvanced(true)
       } else {
@@ -241,7 +242,7 @@ export default function SessionProfileFormModal({
       }
 
       // Build docker config if enabled
-      let dockerConfig: { enabled: boolean; registries?: { server?: string; username?: string; password?: string; secret_name?: string }[] } | undefined
+      let dockerConfig: { enabled: boolean; registries?: { server?: string; username?: string; password?: string; secret_name?: string; insecure?: boolean }[] } | undefined
       if (dockerEnabled) {
         const regs = dockerRegistries
           .filter(r => r.server || r.username || r.secretName)
@@ -249,6 +250,7 @@ export default function SessionProfileFormModal({
             ...(r.server ? { server: r.server } : {}),
             ...(r.secretName ? { secret_name: r.secretName } : {}),
             ...(r.username && !r.secretName ? { username: r.username, password: r.password } : {}),
+            ...(r.insecure ? { insecure: true } : {}),
           }))
         dockerConfig = { enabled: true, ...(regs.length > 0 ? { registries: regs } : {}) }
       }
@@ -707,6 +709,16 @@ export default function SessionProfileFormModal({
                                 placeholder="ghcr.io"
                                 className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                               />
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                id={`insecure-${index}`}
+                                checked={registry.insecure}
+                                onChange={e => updateDockerRegistry(index, 'insecure', e.target.checked)}
+                                className="w-3 h-3 rounded"
+                              />
+                              <label htmlFor={`insecure-${index}`} className="text-xs text-gray-500 dark:text-gray-400">HTTP（insecure）レジストリ</label>
                             </div>
                             <div>
                               <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">K8s Secret 名（docker config JSON）</label>

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -47,15 +47,15 @@ export default function NewSessionPage() {
   const [sandboxMode, setSandboxMode] = useState<'allowlist' | 'denylist'>('allowlist')
   const [sandboxDomains, setSandboxDomains] = useState('')
   const [dockerEnabled, setDockerEnabled] = useState(false)
-  const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string }>>([])
+  const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string; insecure: boolean }>>([])
 
   const addDockerRegistry = () => {
-    setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '' }])
+    setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '', insecure: false }])
   }
   const removeDockerRegistry = (index: number) => {
     setDockerRegistries(prev => prev.filter((_, i) => i !== index))
   }
-  const updateDockerRegistry = (index: number, field: string, value: string) => {
+  const updateDockerRegistry = (index: number, field: string, value: string | boolean) => {
     setDockerRegistries(prev => prev.map((r, i) => i === index ? { ...r, [field]: value } : r))
   }
 
@@ -199,6 +199,7 @@ export default function NewSessionPage() {
             ...(r.server ? { server: r.server } : {}),
             ...(r.secretName ? { secret_name: r.secretName } : {}),
             ...(r.username && !r.secretName ? { username: r.username, password: r.password } : {}),
+            ...(r.insecure ? { insecure: true } : {}),
           }))
         params.docker = {
           enabled: true,
@@ -842,6 +843,17 @@ export default function NewSessionPage() {
                                 disabled={isCreating}
                                 className="w-full px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                               />
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                id={`insecure-${index}`}
+                                checked={registry.insecure}
+                                onChange={e => updateDockerRegistry(index, 'insecure', e.target.checked)}
+                                disabled={isCreating}
+                                className="w-3 h-3 rounded"
+                              />
+                              <label htmlFor={`insecure-${index}`} className="text-xs text-gray-500 dark:text-gray-400">HTTP（insecure）レジストリ</label>
                             </div>
                             <div>
                               <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">K8s Secret 名（docker config JSON）</label>

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -208,6 +208,7 @@ export interface DockerRegistry {
   username?: string;
   password?: string;
   secret_name?: string;
+  insecure?: boolean;
 }
 
 export interface DockerConfig {


### PR DESCRIPTION
## Summary

- セッション作成画面とセッションプロファイルモーダルの Docker レジストリ設定に「HTTP（insecure）レジストリ」チェックボックスを追加
- agentapi-proxy PR #794 と対になる UI 側の対応

## 変更内容

- `src/types/agentapi.ts`: `DockerRegistry` に `insecure?: boolean` を追加
- `src/app/sessions/new/page.tsx`:
  - state の型に `insecure: boolean` を追加
  - サーバー入力の下に insecure チェックボックスを追加
  - API 送信時に `insecure: true` を含めるよう修正
- `src/app/components/SessionProfileFormModal.tsx`:
  - 同上（既存プロファイル読み込み時の `insecure` 復元も対応）

## UI イメージ

レジストリ設定フォームのサーバー入力の下に以下が追加されます：
```
☐ HTTP（insecure）レジストリ
```
チェックすると API に `insecure: true` が送信され、DinD が `--insecure-registry=<server>` 付きで起動します。

## Test plan

- [ ] セッション作成画面で insecure チェックボックスが表示される
- [ ] チェックした状態でセッション作成 → DinD が `--insecure-registry` 付きで起動する
- [ ] セッションプロファイルで設定した insecure が保存・復元される

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)