### PR TITLE
feat: add session TTL field to session creation and profile forms

### DIFF
--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -49,6 +49,9 @@ export default function SessionProfileFormModal({
   const [dockerEnabled, setDockerEnabled] = useState(false)
   const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string; insecure: boolean }>>([])
 
+  // Session TTL
+  const [sessionTTL, setSessionTTL] = useState('')
+
   const addDockerRegistry = () => setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '', insecure: false }])
   const removeDockerRegistry = (index: number) => setDockerRegistries(prev => prev.filter((_, i) => i !== index))
   const updateDockerRegistry = (index: number, field: string, value: string | boolean) =>
@@ -141,6 +144,11 @@ export default function SessionProfileFormModal({
         setDockerEnabled(false)
         setDockerRegistries([])
       }
+
+      // Initialize session_ttl from profile config
+      const ttl = cfg?.session_ttl ?? ''
+      setSessionTTL(ttl)
+      if (ttl) setShowAdvanced(true)
     } else {
       // Reset form
       setName('')
@@ -156,6 +164,7 @@ export default function SessionProfileFormModal({
       setSandboxCountMode(false)
       setDockerEnabled(false)
       setDockerRegistries([])
+      setSessionTTL('')
       setShowAdvanced(false)
     }
     setError(null)
@@ -268,6 +277,7 @@ export default function SessionProfileFormModal({
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
         ...(params ? { params } : {}),
         ...(sandboxPolicyId ? { sandbox_policy_id: sandboxPolicyId } : {}),
+        ...(sessionTTL.trim() ? { session_ttl: sessionTTL.trim() } : {}),
       }
 
       if (isEditing && editingProfile) {
@@ -758,6 +768,23 @@ export default function SessionProfileFormModal({
                         ))}
                       </div>
                     )}
+                  </div>
+
+                  {/* セッション TTL */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      セッション自動削除 TTL
+                    </label>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                      最後のメッセージからこの時間が経過するとセッションを自動削除します。例: <code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">24h</code>、<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">168h</code>（空欄 = 自動削除なし / グローバル設定に従う）
+                    </p>
+                    <input
+                      type="text"
+                      value={sessionTTL}
+                      onChange={e => setSessionTTL(e.target.value)}
+                      placeholder="例: 24h、72h、168h"
+                      className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    />
                   </div>
                 </div>
               )}

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -48,6 +48,7 @@ export default function NewSessionPage() {
   const [sandboxDomains, setSandboxDomains] = useState('')
   const [dockerEnabled, setDockerEnabled] = useState(false)
   const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string; insecure: boolean }>>([])
+  const [sessionTTL, setSessionTTL] = useState('')
 
   const addDockerRegistry = () => {
     setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '', insecure: false }])
@@ -205,6 +206,11 @@ export default function NewSessionPage() {
           enabled: true,
           ...(registries.length > 0 ? { registries } : {}),
         }
+      }
+
+      // セッション TTL が指定されている場合は送信
+      if (sessionTTL.trim()) {
+        params.session_ttl = sessionTTL.trim()
       }
 
       console.log('[NewSessionPage] Final params:', params)
@@ -896,6 +902,20 @@ export default function NewSessionPage() {
                         ))}
                       </div>
                     )}
+                  </div>
+
+                  {/* セッション TTL */}
+                  <div>
+                    <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">セッション自動削除 TTL</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-2">最後のメッセージからこの時間が経過するとセッションを自動削除します。例: <code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">24h</code>、<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">168h</code>（空欄 = 自動削除なし）</p>
+                    <input
+                      type="text"
+                      value={sessionTTL}
+                      onChange={e => setSessionTTL(e.target.value)}
+                      placeholder="例: 24h、72h、168h"
+                      disabled={isCreating}
+                      className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    />
                   </div>
 
                   {/* エージェントタイプ */}

--- a/src/types/session_profile.ts
+++ b/src/types/session_profile.ts
@@ -7,6 +7,7 @@ export interface SessionProfileParams {
   agent_type?: string;
   sandbox?: SandboxConfig;
   docker?: DockerConfig;
+  session_ttl?: string;
 }
 
 // Session profile config
@@ -19,6 +20,7 @@ export interface SessionProfileConfig {
   memory_key?: Record<string, string>;
   params?: SessionProfileParams;
   sandbox_policy_id?: string;
+  session_ttl?: string;
 }
 
 // SessionProfile entity


### PR DESCRIPTION
## Summary

agentapi-proxy 側で実装した session TTL 機能を UI から設定できるようにします。

- `SessionProfileConfig` と `SessionProfileParams` 型に `session_ttl?: string` を追加
- セッション作成ページの「詳細設定」に TTL 入力フィールドを追加（DinD の直後）
- セッションプロファイル作成・編集モーダルの「詳細設定」に TTL 入力フィールドを追加
- プロファイル編集時は既存の TTL を読み込んで表示

## 入力形式

Go の duration 文字列形式: `24h`、`72h`、`168h` など  
空欄 = 自動削除なし（スラックボットセッションはグローバル設定に従う）

## Test plan

- [ ] セッション作成ページの詳細設定で TTL を入力してセッションを作成
- [ ] Kubernetes Service に `agentapi.proxy/session-ttl` アノテーションが付与されることを確認
- [ ] プロファイル作成で TTL を設定し、そのプロファイルからセッション作成すると TTL が引き継がれることを確認
- [ ] プロファイル編集時に既存の TTL が表示されることを確認

## Related

- agentapi-proxy PR: https://github.com/takutakahashi/agentapi-proxy/pull/800

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)