### PR TITLE
Add ACP model switcher

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { createAgentAPIProxyClientFromStorage, ACPSessionInfo } from '../../lib/agentapi-proxy-client';
+import { createAgentAPIProxyClientFromStorage, ACPSessionInfo, ACPConfigOption } from '../../lib/agentapi-proxy-client';
 import { AgentAPIProxyError } from '../../lib/agentapi-proxy-client';
 import { createACPServerClientFromStorage, ACPServerClient } from '../../lib/acp-server-client';
 import { getACPServerEnabled } from '../../types/settings';
@@ -117,6 +117,76 @@ function formatACPModelValue(value: unknown): string | null {
   return direct;
 }
 
+interface ACPModelOption {
+  value: string;
+  label: string;
+  description?: string;
+  group?: string;
+}
+
+function getACPConfigOptionId(option: ACPConfigOption | undefined): string | null {
+  if (!option) return null;
+  return formatACPModelValue(option.id) || formatACPModelValue(option.key);
+}
+
+function getACPConfigOptionCurrentValue(option: ACPConfigOption | undefined): string | null {
+  if (!option) return null;
+  return (
+    formatACPModelValue(option.currentValue) ||
+    formatACPModelValue(option.value) ||
+    formatACPModelValue(option.default)
+  );
+}
+
+function getACPModelConfigOption(info: ACPSessionInfo | null): ACPConfigOption | null {
+  if (!info?.configOptions?.length) return null;
+
+  const byCategory = info.configOptions.find(option => option.category === 'model');
+  if (byCategory) return byCategory;
+
+  return info.configOptions.find(option => {
+    const haystack = [option.id, option.key, option.name, option.description]
+      .filter((value): value is string => typeof value === 'string')
+      .join(' ')
+      .toLowerCase();
+    return /\bmodel\b/.test(haystack) || haystack.includes('modelid');
+  }) ?? null;
+}
+
+function flattenACPModelOptions(options: unknown): ACPModelOption[] {
+  if (!Array.isArray(options)) return [];
+
+  const flattened: ACPModelOption[] = [];
+  for (const item of options) {
+    if (typeof item === 'string') {
+      flattened.push({ value: item, label: item });
+      continue;
+    }
+
+    if (!item || typeof item !== 'object') continue;
+    const record = item as Record<string, unknown>;
+
+    if (Array.isArray(record.options)) {
+      const groupName = formatACPModelValue(record.name) || formatACPModelValue(record.group) || undefined;
+      flattened.push(...flattenACPModelOptions(record.options).map(option => ({
+        ...option,
+        group: option.group ?? groupName,
+      })));
+      continue;
+    }
+
+    const value = formatACPModelValue(record.value);
+    if (!value) continue;
+    flattened.push({
+      value,
+      label: formatACPModelValue(record.name) || value,
+      description: formatACPModelValue(record.description) || undefined,
+    });
+  }
+
+  return flattened;
+}
+
 export function getACPModelDisplay(info: ACPSessionInfo | null): string | null {
   if (!info) return null;
 
@@ -140,20 +210,12 @@ export function getACPModelDisplay(info: ACPSessionInfo | null): string | null {
     );
   if (metaModel) return metaModel;
 
-  const modelOption = info.configOptions?.find(option => {
-    const haystack = [option.key, option.name, option.description]
-      .filter((value): value is string => typeof value === 'string')
-      .join(' ')
-      .toLowerCase();
-    return /\bmodel\b/.test(haystack) || haystack.includes('modelid');
-  });
+  const modelOption = getACPModelConfigOption(info);
 
   if (!modelOption) return null;
-  return (
-    formatACPModelValue(modelOption.value) ||
-    formatACPModelValue(modelOption.currentValue) ||
-    formatACPModelValue(modelOption.default)
-  );
+  const currentValue = getACPConfigOptionCurrentValue(modelOption);
+  const selected = flattenACPModelOptions(modelOption.options).find(option => option.value === currentValue);
+  return selected ? `${selected.label} (${selected.value})` : currentValue;
 }
 
 interface SessionTokenUsage {
@@ -352,6 +414,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   },
                   onModeUpdate: (modeId: string) => {
                     console.log('[ACP] current_mode_update:', modeId);
+                  },
+                  onConfigOptionsUpdate: (configOptions: ACPConfigOption[]) => {
+                    applyACPConfigOptions(configOptions);
                   },
                   onStatus: (status: { status: 'stable' | 'running' | 'error'; agent_type?: string }) => {
                     setAgentStatus(status);
@@ -615,7 +680,14 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
 
   // ACP session state
   const [acpInfo, setACPInfo] = useState<ACPSessionInfo | null>(null);
+  const acpModelConfigOption = useMemo(() => getACPModelConfigOption(acpInfo), [acpInfo]);
+  const acpModelConfigId = useMemo(() => getACPConfigOptionId(acpModelConfigOption ?? undefined), [acpModelConfigOption]);
+  const acpModelOptions = useMemo(() => flattenACPModelOptions(acpModelConfigOption?.options), [acpModelConfigOption]);
+  const acpCurrentModelValue = useMemo(() => getACPConfigOptionCurrentValue(acpModelConfigOption ?? undefined), [acpModelConfigOption]);
   const acpModelDisplay = useMemo(() => getACPModelDisplay(acpInfo), [acpInfo]);
+  const [selectedACPModel, setSelectedACPModel] = useState('');
+  const [isSettingACPModel, setIsSettingACPModel] = useState(false);
+  const [acpModelMessage, setACPModelMessage] = useState<string | null>(null);
   const isACPSession = !!acpInfo || (!!agentType && agentType.includes('acp')) || acpServerEnabled;
   const tokenUsage = useMemo(() => getSessionTokenUsage(acpInfo, messages), [acpInfo, messages]);
   const [acpPendingPermission, setACPPendingPermission] = useState<{ action: PendingAction; rpcId: number } | null>(null);
@@ -636,6 +708,66 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       setShowSessionInfo(false);
     }
   }, [isACPSession]);
+
+  useEffect(() => {
+    setSelectedACPModel(acpCurrentModelValue ?? '');
+    setACPModelMessage(null);
+  }, [acpCurrentModelValue, acpModelConfigId]);
+
+  const applyACPConfigOptions = useCallback((configOptions: ACPConfigOption[]) => {
+    setACPInfo(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        configOptions,
+      };
+    });
+  }, []);
+
+  const handleSetACPModel = useCallback(async () => {
+    if (!sessionId || !acpModelConfigId || !selectedACPModel) return;
+    if (selectedACPModel === acpCurrentModelValue) return;
+
+    setIsSettingACPModel(true);
+    setACPModelMessage(null);
+
+    try {
+      let result: { configOptions?: ACPConfigOption[] } | undefined;
+      if (acpServerEnabled && acpServerClientRef.current) {
+        result = await acpServerClientRef.current.setSessionConfigOption(
+          sessionId,
+          acpModelConfigId,
+          selectedACPModel
+        );
+      } else {
+        if (!acpInfo || !agentAPIRef.current) return;
+        result = await agentAPIRef.current.setACPSessionConfigOption(
+          sessionId,
+          acpInfo.sessionId,
+          acpModelConfigId,
+          selectedACPModel
+        );
+      }
+
+      if (result?.configOptions) {
+        applyACPConfigOptions(result.configOptions);
+      }
+      setACPModelMessage('Model updated');
+    } catch (err) {
+      console.error('Failed to update ACP model:', err);
+      setACPModelMessage(err instanceof Error ? err.message : 'Failed to update model');
+    } finally {
+      setIsSettingACPModel(false);
+    }
+  }, [
+    sessionId,
+    acpInfo,
+    acpServerEnabled,
+    acpModelConfigId,
+    selectedACPModel,
+    acpCurrentModelValue,
+    applyACPConfigOptions,
+  ]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -1084,6 +1216,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           onModeUpdate: (modeId: string) => {
             console.log('[ACP] current_mode_update:', modeId);
           },
+          onConfigOptionsUpdate: (configOptions: ACPConfigOption[]) => {
+            applyACPConfigOptions(configOptions);
+          },
           onStatus: (status: { status: 'stable' | 'running' | 'error'; agent_type?: string }) => {
             setAgentStatus(status);
           },
@@ -1118,7 +1253,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     };
 
     reconnectACP();
-  }, [isPageVisible, acpInfo, sessionId]);
+  }, [isPageVisible, acpInfo, sessionId, acpServerEnabled, applyACPConfigOptions]);
 
   // Get agent type from /status endpoint
   useEffect(() => {
@@ -1315,7 +1450,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     } finally {
       setIsLoading(false);
     }
-  }, [sessionId, acpInfo, acpPendingPermission, acpServerEnabled]);
+  }, [sessionId, acpInfo, acpPendingPermission]);
 
   const sendStopSignal = async () => {
     if (!sessionId || !agentAPIRef.current) {
@@ -1865,6 +2000,52 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   <span className="text-gray-500 dark:text-gray-400">Model</span>
                   <span className="break-all text-gray-900 dark:text-gray-100">{acpModelDisplay || '-'}</span>
                 </div>
+                {acpModelConfigId && acpModelOptions.length > 0 && (
+                  <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
+                    <label htmlFor="acp-model-select" className="text-gray-500 dark:text-gray-400 pt-2">
+                      Switch Model
+                    </label>
+                    <div className="min-w-0">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+                        <select
+                          id="acp-model-select"
+                          value={selectedACPModel}
+                          onChange={(event) => setSelectedACPModel(event.target.value)}
+                          disabled={isSettingACPModel}
+                          className="min-w-0 flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1.5 text-xs text-gray-900 dark:text-gray-100 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-100 dark:disabled:bg-gray-700"
+                        >
+                          {acpModelOptions.map(option => (
+                            <option key={`${option.group ?? 'model'}:${option.value}`} value={option.value}>
+                              {option.group ? `${option.group} / ${option.label}` : option.label}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          type="button"
+                          onClick={handleSetACPModel}
+                          disabled={
+                            isSettingACPModel ||
+                            !selectedACPModel ||
+                            selectedACPModel === acpCurrentModelValue
+                          }
+                          className="shrink-0 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:disabled:bg-gray-600"
+                        >
+                          {isSettingACPModel ? 'Applying...' : 'Apply'}
+                        </button>
+                      </div>
+                      {acpModelOptions.find(option => option.value === selectedACPModel)?.description && (
+                        <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                          {acpModelOptions.find(option => option.value === selectedACPModel)?.description}
+                        </p>
+                      )}
+                      {acpModelMessage && (
+                        <p className={`mt-1 text-[11px] ${acpModelMessage === 'Model updated' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                          {acpModelMessage}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )}
                 <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
                   <span className="text-gray-500 dark:text-gray-400">ACP Status</span>
                   <span className="break-all text-gray-900 dark:text-gray-100">{acpInfo.status || '-'}</span>

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -86,6 +86,20 @@ interface ACPSessionUpdate {
   locations?: Array<{ path: string; line?: number }>;
   entries?: Array<{ content: string; status?: string; priority?: number }>;
   mode?: string;
+  configOptions?: ACPConfigOption[];
+}
+
+export interface ACPConfigOption {
+  id?: string;
+  key?: string;
+  name?: string;
+  description?: string;
+  category?: string;
+  type?: string;
+  value?: unknown;
+  currentValue?: unknown;
+  default?: unknown;
+  options?: unknown;
 }
 
 interface ACPPermissionOption {
@@ -112,6 +126,7 @@ export interface ACPServerEventCallbacks {
   onPermission?: (action: PendingAction, rpcId: number) => void;
   onTitleUpdate?: (title: string) => void;
   onModeUpdate?: (mode: string) => void;
+  onConfigOptionsUpdate?: (configOptions: ACPConfigOption[]) => void;
   onError?: (err: Event | Error) => void;
 }
 
@@ -303,6 +318,19 @@ export class ACPServerClient {
     await this.rpc<void>('session/cancel', { sessionId });
   }
 
+  /** Set a session configuration option, such as the active model. */
+  async setSessionConfigOption(
+    sessionId: string,
+    configId: string,
+    value: string
+  ): Promise<{ configOptions: ACPConfigOption[] }> {
+    return this.rpc<{ configOptions: ACPConfigOption[] }>('session/set_config_option', {
+      sessionId,
+      configId,
+      value,
+    });
+  }
+
   /**
    * Send a permission response back to the agent.
    * The agent sends a session/request_permission via SSE; the client
@@ -453,6 +481,13 @@ export class ACPServerClient {
 
             case 'current_mode_update': {
               if (update.mode) callbacks.onModeUpdate?.(update.mode);
+              break;
+            }
+
+            case 'config_option_update': {
+              if (update.configOptions && Array.isArray(update.configOptions)) {
+                callbacks.onConfigOptionsUpdate?.(update.configOptions);
+              }
               break;
             }
 

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -166,12 +166,16 @@ export class AgentAPIProxyError extends Error {
 
 /** Response from GET /{sessionId}/session for ACP sessions. */
 export interface ACPConfigOption {
+  id?: string;
   key?: string;
   name?: string;
   description?: string;
+  category?: string;
+  type?: string;
   value?: unknown;
   currentValue?: unknown;
   default?: unknown;
+  options?: unknown;
 }
 
 export interface ACPSessionInfo {
@@ -214,6 +218,8 @@ export interface ACPSessionUpdate {
   modeId?: string;
   // available_commands_update
   availableCommands?: Array<{ name: string; description: string; input?: { hint?: string } }>;
+  // config_option_update
+  configOptions?: ACPConfigOption[];
 }
 
 /**
@@ -298,6 +304,10 @@ export interface ACPSessionCallbacks {
    * Called when the agent advertises its slash-command list (available_commands_update).
    */
   onCommandsUpdate?: (commands: Array<{ name: string; description: string; hint?: string }>) => void;
+  /**
+   * Called when the agent reports updated session configuration options.
+   */
+  onConfigOptionsUpdate?: (configOptions: ACPConfigOption[]) => void;
   /** Called when agent status changes (e.g. prompt turn finished). */
   onStatus: (status: AgentStatus) => void;
   /** Called when a permission request arrives from the agent. */
@@ -2411,6 +2421,13 @@ export class AgentAPIProxyClient {
               }
               break;
             }
+
+            case 'config_option_update': {
+              if (update.configOptions && Array.isArray(update.configOptions)) {
+                callbacks.onConfigOptionsUpdate?.(update.configOptions);
+              }
+              break;
+            }
           }
           return;
         }
@@ -2569,6 +2586,36 @@ export class AgentAPIProxyClient {
     await this.makeRequest<unknown>(`/settings/${encodeURIComponent(name)}/sync/pull`, {
       method: 'POST',
     });
+  }
+
+  /**
+   * Set an ACP session configuration option, such as the active model.
+   * The ACP agent returns the complete configuration state after applying it.
+   */
+  async setACPSessionConfigOption(
+    sessionId: string,
+    acpSessionId: string,
+    configId: string,
+    value: string
+  ): Promise<{ configOptions: ACPConfigOption[] }> {
+    const response = await this.makeRequest<{
+      configOptions?: ACPConfigOption[];
+      result?: { configOptions?: ACPConfigOption[] };
+    }>(`/${sessionId}/rpc`, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'session/set_config_option',
+        params: {
+          sessionId: acpSessionId,
+          configId,
+          value,
+        },
+      }),
+    });
+
+    return { configOptions: response.result?.configOptions ?? response.configOptions ?? [] };
   }
 }
 


### PR DESCRIPTION
## Summary
- add ACP config option parsing for model selectors, including current ACP `id/category/options` fields and legacy `key/value` fields
- add `session/set_config_option` client methods for per-session bridge and global ACP server modes
- add a model switcher to the ACP info panel and update it from `config_option_update` SSE notifications

## Verification
- `npm run type-check`
- `npm run lint` (passes with existing warnings in unrelated files and an existing unused ACP history parameter warning)