### PR TITLE
Add Cursor agent type option

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -40,6 +40,10 @@ function normalizeAgentStatus(raw: string): 'stable' | 'running' | 'error' {
   return 'stable';
 }
 
+function isACPAgentType(agentType?: string | null): boolean {
+  return !!agentType && (agentType.includes('acp') || agentType === 'cursor');
+}
+
 // Type guard function to validate session message response
 function isValidSessionMessageResponse(response: unknown): response is SessionMessageListResponse {
   return (
@@ -511,7 +515,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 // session whose bridge is still starting. Check agent_type via session status.
                 try {
                   const statusResult = await agentAPIRef.current!.getSessionStatus(sessionId);
-                  if (statusResult.agent_type === 'claude-acp' || statusResult.agent_type === 'codex-acp') {
+                  if (isACPAgentType(statusResult.agent_type)) {
                     if (statusResult.status === 'error') {
                       const detail = statusResult.message || '不明なエラー';
                       setError(`セッションの起動に失敗しました: ${detail}`);
@@ -688,7 +692,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [selectedACPModel, setSelectedACPModel] = useState('');
   const [isSettingACPModel, setIsSettingACPModel] = useState(false);
   const [acpModelMessage, setACPModelMessage] = useState<string | null>(null);
-  const isACPSession = !!acpInfo || (!!agentType && agentType.includes('acp')) || acpServerEnabled;
+  const isACPSession = !!acpInfo || isACPAgentType(agentType) || acpServerEnabled;
   const tokenUsage = useMemo(() => getSessionTokenUsage(acpInfo, messages), [acpInfo, messages]);
   const [acpPendingPermission, setACPPendingPermission] = useState<{ action: PendingAction; rpcId: number } | null>(null);
   const acpNextPromptId = useRef(1);
@@ -1825,7 +1829,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || (!!agentType && agentType.includes('acp'))}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || isACPAgentType(agentType)}
                   />
                 );
                 processedIds.add(message.id);
@@ -1846,7 +1850,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     formatTimestamp={formatTimestamp}
                     fontSettings={fontSettings}
                     onShowPlanModal={planModalCallbacks.get(message.id.toString())}
-                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || (!!agentType && agentType.includes('acp'))}
+                    isClaudeAgent={agentType === 'claude' || agentType === 'codex' || isACPAgentType(agentType)}
                   />
                 );
                 processedIds.add(message.id);

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -533,6 +533,7 @@ export default function SessionProfileFormModal({
                         { value: 'codex-agentapi', label: 'Codex AgentAPI', description: 'agent_type=codex-agentapi を送信' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
+                        { value: 'cursor', label: 'Cursor ACP', description: 'agent_type=cursor を送信' },
                       ]).map(({ value: v, label, description }) => (
                         <label key={v} className="flex items-start cursor-pointer group">
                           <input

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -551,6 +551,7 @@ export default function NewSessionPage() {
                       : selectedAgentType === 'codex-agentapi' ? 'Codex AgentAPI'
                       : selectedAgentType === 'claude-acp' ? 'Claude ACP'
                       : selectedAgentType === 'codex-acp' ? 'Codex ACP'
+                      : selectedAgentType === 'cursor' ? 'Cursor ACP'
                       : selectedAgentType}
                   </span>
                 )}
@@ -940,6 +941,7 @@ export default function NewSessionPage() {
                         { value: 'codex-agentapi', label: 'Codex AgentAPI', description: 'agent_type=codex-agentapi を送信' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
+                        { value: 'cursor', label: 'Cursor ACP', description: 'agent_type=cursor を送信' },
                       ] as { value: AgentApiType; label: string; description: string }[]).map(({ value, label, description }) => (
                         <label key={value} className="flex items-start cursor-pointer group">
                           <input

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -149,7 +149,8 @@ export interface FontSettings {
 // 'codex-agentapi': codex-agentapi を使用
 // 'claude-acp': claude-acp を使用
 // 'codex-acp': codex-acp を使用
-export type AgentApiType = 'default' | 'claude-agentapi' | 'codex-agentapi' | 'claude-acp' | 'codex-acp'
+// 'cursor': Cursor ACP を使用
+export type AgentApiType = 'default' | 'claude-agentapi' | 'codex-agentapi' | 'claude-acp' | 'codex-acp' | 'cursor'
 
 export interface GlobalSettings {
   agentApiProxy: AgentApiProxySettings


### PR DESCRIPTION
## Summary
- add Cursor ACP as a selectable agent type for new sessions
- add Cursor ACP to session profile agent type settings
- treat agent_type=cursor as an ACP-backed session in chat startup/rendering logic

## Verification
- bun run type-check
- bun run lint (passes with existing warnings)
- bun run build