### PR TITLE
Remove legacy AgentAPI agent type options

### DIFF
--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -420,7 +420,7 @@ function MessageItem({
     }
   }
 
-  // スタンドアロンの tool_result（parentToolUseId なし、codex-agentapi など）
+  // スタンドアロンの tool_result（parentToolUseId なし）
   if (message.role === 'tool_result') {
     const isSuccess = message.status === 'success';
     const contentPreview =

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -18,6 +18,11 @@ interface SessionProfileFormModalProps {
 }
 
 type KeyValuePair = { key: string; value: string }
+const SUPPORTED_AGENT_TYPES = new Set(['claude-acp', 'codex-acp', 'cursor'])
+
+const normalizeAgentType = (value?: string): string => {
+  return value && SUPPORTED_AGENT_TYPES.has(value) ? value : ''
+}
 
 export default function SessionProfileFormModal({
   isOpen,
@@ -83,7 +88,7 @@ export default function SessionProfileFormModal({
       setIsDefault(editingProfile.is_default ?? false)
 
       const cfg = editingProfile.config
-      setAgentType(cfg?.params?.agent_type ?? '')
+      setAgentType(normalizeAgentType(cfg?.params?.agent_type))
 
       if (cfg?.environment && Object.keys(cfg.environment).length > 0) {
         setEnvPairs(Object.entries(cfg.environment).map(([key, value]) => ({ key, value })))
@@ -529,8 +534,6 @@ export default function SessionProfileFormModal({
                     <div className="space-y-2">
                       {([
                         { value: '', label: 'デフォルト', description: 'agent_type を送信しない' },
-                        { value: 'claude-agentapi', label: 'Claude AgentAPI', description: 'agent_type=claude-agentapi を送信' },
-                        { value: 'codex-agentapi', label: 'Codex AgentAPI', description: 'agent_type=codex-agentapi を送信' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
                         { value: 'cursor', label: 'Cursor ACP', description: 'agent_type=cursor を送信' },

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -547,9 +547,7 @@ export default function NewSessionPage() {
                 その他の設定
                 {selectedAgentType !== 'default' && (
                   <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 text-xs rounded-full">
-                    {selectedAgentType === 'claude-agentapi' ? 'Claude AgentAPI'
-                      : selectedAgentType === 'codex-agentapi' ? 'Codex AgentAPI'
-                      : selectedAgentType === 'claude-acp' ? 'Claude ACP'
+                    {selectedAgentType === 'claude-acp' ? 'Claude ACP'
                       : selectedAgentType === 'codex-acp' ? 'Codex ACP'
                       : selectedAgentType === 'cursor' ? 'Cursor ACP'
                       : selectedAgentType}
@@ -937,8 +935,6 @@ export default function NewSessionPage() {
                       <div className="space-y-2">
                       {([
                         { value: 'default', label: 'デフォルト', description: 'agent_type を送信しない' },
-                        { value: 'claude-agentapi', label: 'Claude AgentAPI', description: 'agent_type=claude-agentapi を送信' },
-                        { value: 'codex-agentapi', label: 'Codex AgentAPI', description: 'agent_type=codex-agentapi を送信' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
                         { value: 'cursor', label: 'Cursor ACP', description: 'agent_type=cursor を送信' },

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -145,12 +145,10 @@ export interface FontSettings {
 
 // セッション作成時に使用するエージェント種別
 // 'default': agent_type を送信しない（バックエンドのデフォルト動作）
-// 'claude-agentapi': claude-agentapi を使用
-// 'codex-agentapi': codex-agentapi を使用
 // 'claude-acp': claude-acp を使用
 // 'codex-acp': codex-acp を使用
 // 'cursor': Cursor ACP を使用
-export type AgentApiType = 'default' | 'claude-agentapi' | 'codex-agentapi' | 'claude-acp' | 'codex-acp' | 'cursor'
+export type AgentApiType = 'default' | 'claude-acp' | 'codex-acp' | 'cursor'
 
 export interface GlobalSettings {
   agentApiProxy: AgentApiProxySettings
@@ -159,7 +157,6 @@ export interface GlobalSettings {
   messageTemplates: MessageTemplate[]
   githubAuth?: GitHubOAuthSettings
   sendGithubTokenOnSessionStart?: boolean  // デフォルト true
-  useClaudeAgentAPI?: boolean  // 後方互換性のために残す（非推奨: agentApiType を使用）
   agentApiType?: AgentApiType  // デフォルト 'default'
   enterKeyBehavior?: EnterKeyBehavior  // デフォルト 'send' (Enter で送信、Shift+Enter で改行)
   fontSettings?: FontSettings  // デフォルト { fontSize: 14, fontFamily: 'sans-serif' }
@@ -753,27 +750,21 @@ export const setFontSettings = (fontSettings: FontSettings): void => {
 // AgentAPI Type utilities
 export const getAgentApiType = (): AgentApiType => {
   const settings = loadFullGlobalSettings()
-  // 新しい agentApiType が設定されていればそれを返す
-  if (settings.agentApiType) return settings.agentApiType
-  // 後方互換性: 旧 useClaudeAgentAPI が true なら claude-agentapi
-  if (settings.useClaudeAgentAPI) return 'claude-agentapi'
+  if (
+    settings.agentApiType === 'claude-acp' ||
+    settings.agentApiType === 'codex-acp' ||
+    settings.agentApiType === 'cursor'
+  ) {
+    return settings.agentApiType
+  }
   return 'default'
 }
 
 export const setAgentApiType = (type: AgentApiType): void => {
   const settings = loadFullGlobalSettings()
   settings.agentApiType = type
-  // 後方互換性のため useClaudeAgentAPI も同期
-  settings.useClaudeAgentAPI = type === 'claude-agentapi'
+  delete (settings as { useClaudeAgentAPI?: boolean }).useClaudeAgentAPI
   saveFullGlobalSettings(settings)
-}
-
-// @deprecated: getAgentApiType を使用してください
-export const getUseClaudeAgentAPI = (): boolean => getAgentApiType() === 'claude-agentapi'
-
-// @deprecated: setAgentApiType を使用してください
-export const setUseClaudeAgentAPI = (enabled: boolean): void => {
-  setAgentApiType(enabled ? 'claude-agentapi' : 'default')
 }
 
 // Memory Settings utilities


### PR DESCRIPTION
## Summary
- remove claude-agentapi and codex-agentapi from session creation agent type choices
- remove the same options from session profile editing and normalize legacy saved profile values to default
- drop the old AgentApiType variants and legacy useClaudeAgentAPI helpers

## Verification
- bun run type-check
- bun run lint