### PR TITLE
Normalize ACP tool display

### DIFF
--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -60,6 +60,30 @@ function isGenericToolTitle(title: string | undefined, toolName: string): boolea
   );
 }
 
+function truncateBrief(text: string, maxLength: number): string {
+  return text.length > maxLength ? text.substring(0, maxLength) + '...' : text;
+}
+
+function firstMeaningfulLine(text: string): string | null {
+  const line = text
+    .split('\n')
+    .map(part => part.trim())
+    .find(part => part.length > 0);
+  return line || null;
+}
+
+function getToolResultBrief(result: ToolResultContent | null, fallbackContent: string | undefined, maxLength: number): string | null {
+  const content = result?.error || result?.result || fallbackContent;
+  if (!content) return null;
+
+  if (typeof content === 'string') {
+    const line = firstMeaningfulLine(content);
+    return line ? truncateBrief(line, maxLength) : null;
+  }
+
+  return null;
+}
+
 // Markdown の特徴的な記法をチェックする関数
 function hasMarkdownSyntax(text: string): boolean {
   if (!text || typeof text !== 'string') return false;
@@ -306,41 +330,31 @@ function MessageItem({
 
         // description があれば優先
         if (input.description && typeof input.description === 'string') {
-          return input.description.length > maxLength
-            ? input.description.substring(0, maxLength) + '...'
-            : input.description;
+          return truncateBrief(input.description, maxLength);
         }
 
         // ファイル系のツール
         if (input.file_path && typeof input.file_path === 'string') {
           const path = input.file_path;
-          return path.length > maxLength
-            ? '...' + path.substring(path.length - maxLength)
-            : path;
+          return path.length > maxLength ? '...' + path.substring(path.length - maxLength) : path;
         }
 
         // パターン検索系
         if (input.pattern && typeof input.pattern === 'string') {
-          return input.pattern.length > maxLength
-            ? input.pattern.substring(0, maxLength) + '...'
-            : input.pattern;
+          return truncateBrief(input.pattern, maxLength);
         }
 
         // コマンド系
         if (input.command && typeof input.command === 'string') {
-          return input.command.length > maxLength
-            ? input.command.substring(0, maxLength) + '...'
-            : input.command;
+          return truncateBrief(input.command, maxLength);
         }
 
         // ACP title は補助情報として使うが、"Read File" のような汎用 title は抑制する
         if (toolUse.title && typeof toolUse.title === 'string' && !isGenericToolTitle(toolUse.title, toolUse.name)) {
-          return toolUse.title.length > maxLength
-            ? toolUse.title.substring(0, maxLength) + '...'
-            : toolUse.title;
+          return truncateBrief(toolUse.title, maxLength);
         }
 
-        return null;
+        return getToolResultBrief(result, toolResult?.content, maxLength);
       };
 
       const briefInfo = getBriefInfo();

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -40,6 +40,26 @@ function parseToolResultContent(content: string): ToolResultContent | null {
   return null;
 }
 
+function hasObjectEntries(value: Record<string, unknown> | undefined): boolean {
+  return !!value && Object.keys(value).length > 0;
+}
+
+function visibleToolInput(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).filter(([key]) => key !== '_toolName'));
+}
+
+function isGenericToolTitle(title: string | undefined, toolName: string): boolean {
+  if (!title) return true;
+  const normalizedTitle = title.trim().toLowerCase();
+  const normalizedName = toolName.trim().toLowerCase();
+  if (!normalizedTitle) return true;
+  return (
+    normalizedTitle === normalizedName ||
+    normalizedTitle === `${normalizedName} file` ||
+    normalizedTitle === `${normalizedName} tool`
+  );
+}
+
 // Markdown の特徴的な記法をチェックする関数
 function hasMarkdownSyntax(text: string): boolean {
   if (!text || typeof text !== 'string') return false;
@@ -279,17 +299,10 @@ function MessageItem({
     const hasResult = !!toolResult;
 
     if (toolUse) {
-      // ツールの簡易情報を抽出（ACP title > description, file_path, pattern など）
+      // ツールの簡易情報を抽出（具体的な input を優先し、汎用 title は表示しない）
       const getBriefInfo = (): string | null => {
         const input = toolUse.input;
         const maxLength = 40;
-
-        // ACP title (コマンド全文やファイルパスのサマリーなど) を最優先で表示
-        if (toolUse.title && typeof toolUse.title === 'string') {
-          return toolUse.title.length > maxLength
-            ? toolUse.title.substring(0, maxLength) + '...'
-            : toolUse.title;
-        }
 
         // description があれば優先
         if (input.description && typeof input.description === 'string') {
@@ -320,10 +333,19 @@ function MessageItem({
             : input.command;
         }
 
+        // ACP title は補助情報として使うが、"Read File" のような汎用 title は抑制する
+        if (toolUse.title && typeof toolUse.title === 'string' && !isGenericToolTitle(toolUse.title, toolUse.name)) {
+          return toolUse.title.length > maxLength
+            ? toolUse.title.substring(0, maxLength) + '...'
+            : toolUse.title;
+        }
+
         return null;
       };
 
       const briefInfo = getBriefInfo();
+      const inputForDisplay = visibleToolInput(toolUse.input);
+      const hasInput = hasObjectEntries(inputForDisplay);
 
       return (
         <div className="px-4 sm:px-6 py-0.5">
@@ -387,12 +409,14 @@ function MessageItem({
           {isExpanded && (
             <div className="ml-3 mt-1 mb-2 text-xs">
               {/* ツール入力 */}
-              <div className="mb-2">
-                <div className="font-semibold text-gray-700 dark:text-gray-300 mb-1">Input:</div>
-                <pre className="bg-gray-50 dark:bg-gray-800 p-2 rounded text-gray-600 dark:text-gray-400 overflow-x-auto">
-                  {JSON.stringify(toolUse.input, null, 2)}
-                </pre>
-              </div>
+              {hasInput && (
+                <div className="mb-2">
+                  <div className="font-semibold text-gray-700 dark:text-gray-300 mb-1">Input:</div>
+                  <pre className="bg-gray-50 dark:bg-gray-800 p-2 rounded text-gray-600 dark:text-gray-400 overflow-x-auto">
+                    {JSON.stringify(inputForDisplay, null, 2)}
+                  </pre>
+                </div>
+              )}
 
               {/* ツール結果 */}
               {hasResult && (

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -136,15 +136,32 @@ const ACP_KIND_TO_NAME: Record<string, string> = {
   execute: 'Bash',
   read: 'Read',
   write: 'Write',
+  edit: 'Edit',
   search: 'Search',
   glob: 'Glob',
+  other: 'Tool',
   think: 'Think',
+  task: 'Task',
   explore: 'Explore',
 };
 
+function titleToToolName(title: string | undefined): string | undefined {
+  if (!title) return undefined;
+  const match = title.match(/^[A-Za-z][A-Za-z0-9_-]*/);
+  if (!match) return undefined;
+  return match[0];
+}
+
 function acpToolDisplayName(kind?: string, title?: string): string {
   if (kind && ACP_KIND_TO_NAME[kind]) return ACP_KIND_TO_NAME[kind];
-  return title || kind || 'tool';
+  return titleToToolName(title) || kind || 'tool';
+}
+
+function acpToolNameFromRawInput(rawInput: unknown): string | undefined {
+  if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return undefined;
+  const toolName = (rawInput as Record<string, unknown>)._toolName;
+  if (typeof toolName !== 'string' || toolName.length === 0) return undefined;
+  return ACP_KIND_TO_NAME[toolName] || titleToToolName(toolName) || toolName;
 }
 
 function acpExtractText(content: unknown): string {
@@ -172,13 +189,31 @@ function extractACPToolContent(content: unknown): string {
 }
 
 function extractRawOutputText(rawOutput: unknown): string {
+  if (rawOutput == null) return '';
   if (typeof rawOutput === 'string') return rawOutput;
   if (Array.isArray(rawOutput)) {
-    return rawOutput.map(b => (typeof b === 'object' && b !== null ? (b as Record<string, unknown>).text || '' : '')).join('\n');
+    return rawOutput.map(b => {
+      if (typeof b === 'string') return b;
+      if (typeof b === 'object' && b !== null) {
+        const obj = b as Record<string, unknown>;
+        if (typeof obj.text === 'string') return obj.text;
+        if (typeof obj.content === 'string') return obj.content;
+        return JSON.stringify(obj);
+      }
+      return '';
+    }).join('\n');
   }
   if (typeof rawOutput === 'object' && rawOutput !== null) {
     const obj = rawOutput as Record<string, unknown>;
     if (typeof obj.text === 'string') return obj.text;
+    if (typeof obj.content === 'string') return obj.content;
+    const outputParts: string[] = [];
+    if (typeof obj.stdout === 'string' && obj.stdout.length > 0) outputParts.push(obj.stdout);
+    if (typeof obj.stderr === 'string' && obj.stderr.length > 0) outputParts.push(obj.stderr);
+    if (outputParts.length > 0) {
+      if (typeof obj.exitCode === 'number') outputParts.push(`exit code: ${obj.exitCode}`);
+      return outputParts.join('\n');
+    }
     return JSON.stringify(rawOutput);
   }
   return '';
@@ -408,7 +443,7 @@ export class ACPServerClient {
               streamingThoughtId = null;
               const toolObj = {
                 type: 'tool_use',
-                name: acpToolDisplayName(update.kind, update.title),
+                name: acpToolNameFromRawInput(update.rawInput) || acpToolDisplayName(update.kind, update.title),
                 id: update.toolCallId,
                 input: update.rawInput ?? {},
                 ...(update.title != null ? { title: update.title } : {}),

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -232,10 +232,21 @@ const ACP_KIND_TO_NAME: Record<string, string> = {
   execute: 'Bash',
   read: 'Read',
   write: 'Write',
+  edit: 'Edit',
   search: 'Search',
+  glob: 'Glob',
+  other: 'Tool',
   think: 'Think',
+  task: 'Task',
   browse: 'Browser',
 };
+
+function titleToToolName(title: string | undefined): string | undefined {
+  if (!title) return undefined;
+  const match = title.match(/^[A-Za-z][A-Za-z0-9_-]*/);
+  if (!match) return undefined;
+  return match[0];
+}
 
 /**
  * Returns a short human-readable tool name for display.
@@ -243,7 +254,14 @@ const ACP_KIND_TO_NAME: Record<string, string> = {
  */
 function acpToolDisplayName(kind: string | undefined, title: string | undefined): string {
   if (kind && ACP_KIND_TO_NAME[kind]) return ACP_KIND_TO_NAME[kind];
-  return title || kind || 'tool';
+  return titleToToolName(title) || kind || 'tool';
+}
+
+function acpToolNameFromRawInput(rawInput: unknown): string | undefined {
+  if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return undefined;
+  const toolName = (rawInput as Record<string, unknown>)._toolName;
+  if (typeof toolName !== 'string' || toolName.length === 0) return undefined;
+  return ACP_KIND_TO_NAME[toolName] || titleToToolName(toolName) || toolName;
 }
 
 /** A permission option offered by the ACP agent. */
@@ -376,6 +394,22 @@ function extractRawOutputText(rawOutput: unknown): string {
   const obj = rawOutput as Record<string, unknown>;
   if (typeof obj.text === 'string') {
     return obj.text;
+  }
+  if (typeof obj.content === 'string') {
+    return obj.content;
+  }
+  const outputParts: string[] = [];
+  if (typeof obj.stdout === 'string' && obj.stdout.length > 0) {
+    outputParts.push(obj.stdout);
+  }
+  if (typeof obj.stderr === 'string' && obj.stderr.length > 0) {
+    outputParts.push(obj.stderr);
+  }
+  if (outputParts.length > 0) {
+    if (typeof obj.exitCode === 'number') {
+      outputParts.push(`exit code: ${obj.exitCode}`);
+    }
+    return outputParts.join('\n');
   }
   return JSON.stringify(rawOutput);
 }
@@ -2133,7 +2167,7 @@ export class AgentAPIProxyClient {
               streamingMsgId = null;
               const toolObj = {
                 type: 'tool_use',
-                name: acpToolDisplayName(update.kind, update.title),
+                name: acpToolNameFromRawInput(update.rawInput) || acpToolDisplayName(update.kind, update.title),
                 id: update.toolCallId,
                 input: update.rawInput ?? {},
                 title: update.title,
@@ -2317,7 +2351,7 @@ export class AgentAPIProxyClient {
                 type: 'tool_use',
                 // Use kind→name mapping for a proper tool name (e.g. "Bash" for "execute").
                 // title often contains the full command/path text, not a short name.
-                name: acpToolDisplayName(update.kind, update.title),
+                name: acpToolNameFromRawInput(update.rawInput) || acpToolDisplayName(update.kind, update.title),
                 id: update.toolCallId,
                 input: update.rawInput ?? {},
                 title: update.title,


### PR DESCRIPTION
## Summary
- normalize ACP tool names using known kind mappings and optional rawInput._toolName hints
- avoid using full titles/commands as the compact tool name fallback
- render structured rawOutput objects such as content/stdout/stderr/exitCode as readable text

## Verification
- bun run type-check
- bunx next lint

Note: bun test currently also collects Playwright e2e specs under Bun's test runner and fails before this change's tests; bunx vitest run fails in this environment because node is a Bun shim and tinypool expects process.channel.unref.