### PR TITLE
Add Integrations entry under Resources

### DIFF
--- a/src/app/api/oauth/google/callback/route.ts
+++ b/src/app/api/oauth/google/callback/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 const DEFAULT_SCIA_INTERNAL_URL = 'http://scia-oauth.agentapi-ui-dev.svc.cluster.local:8081'
-const DEFAULT_COMPLETE_PATH = '/settings/personal?google_oauth=connected'
+const DEFAULT_COMPLETE_PATH = '/integrations?google_oauth=connected'
 
 export async function GET(request: NextRequest) {
   const sciaBaseUrl = (process.env.SCIA_OAUTH_INTERNAL_URL || DEFAULT_SCIA_INTERNAL_URL).replace(/\/$/, '')

--- a/src/app/components/NavigationTabs.tsx
+++ b/src/app/components/NavigationTabs.tsx
@@ -78,6 +78,15 @@ const allTabs: Tab[] = [
       </svg>
     ),
   },
+  {
+    label: 'Integrations',
+    href: '/integrations',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-2.829 2.829a4 4 0 105.657 5.657l1.414-1.414M10.172 13.828a4 4 0 005.656 0l2.829-2.829A4 4 0 1013 5.343L11.586 6.757" />
+      </svg>
+    ),
+  },
 ]
 
 export default function NavigationTabs({ className = '' }: NavigationTabsProps) {

--- a/src/app/components/TopBar.tsx
+++ b/src/app/components/TopBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { useState, useEffect, useRef } from 'react'
 import { LogOut } from 'lucide-react'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
@@ -19,6 +20,16 @@ interface TopBarProps {
   children?: React.ReactNode
 }
 
+const resourceLinks = [
+  { label: 'Schedules', href: '/schedules' },
+  { label: 'Webhooks', href: '/webhooks' },
+  { label: 'Slackbots', href: '/slackbots' },
+  { label: 'Profiles', href: '/session-profiles' },
+  { label: 'Sandbox', href: '/sandbox-policies' },
+  { label: 'Memories', href: '/memories' },
+  { label: 'Integrations', href: '/integrations' },
+]
+
 export default function TopBar({
   title,
   subtitle,
@@ -33,8 +44,10 @@ export default function TopBar({
 }: TopBarProps) {
   const router = useRouter()
   const [showTeamDropdown, setShowTeamDropdown] = useState(false)
+  const [showResourceDropdown, setShowResourceDropdown] = useState(false)
   const [loggingOut, setLoggingOut] = useState(false)
   const teamDropdownRef = useRef<HTMLDivElement>(null)
+  const resourceDropdownRef = useRef<HTMLDivElement>(null)
 
   const { selectedTeam, availableTeams, selectTeam, setAvailableTeams, isLoading: isTeamLoading } = useTeamScope()
 
@@ -83,16 +96,19 @@ export default function TopBar({
       if (teamDropdownRef.current && !teamDropdownRef.current.contains(event.target as Node)) {
         setShowTeamDropdown(false)
       }
+      if (resourceDropdownRef.current && !resourceDropdownRef.current.contains(event.target as Node)) {
+        setShowResourceDropdown(false)
+      }
     }
 
-    if (showTeamDropdown) {
+    if (showTeamDropdown || showResourceDropdown) {
       document.addEventListener('mousedown', handleClickOutside)
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [showTeamDropdown])
+  }, [showTeamDropdown, showResourceDropdown])
 
   // Get display name for the current selection
   const getDisplayName = () => {
@@ -237,6 +253,43 @@ export default function TopBar({
                 )}
               </div>
             )}
+
+            {/* Resources ドロップダウン */}
+            <div className="relative" ref={resourceDropdownRef}>
+              <button
+                onClick={() => setShowResourceDropdown(!showResourceDropdown)}
+                className="inline-flex items-center px-3 py-2 text-sm bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md transition-colors"
+                title="Resources"
+              >
+                <svg className="w-4 h-4 sm:mr-2 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+                </svg>
+                <span className="hidden sm:inline">Resources</span>
+                <svg className="w-4 h-4 ml-1 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {showResourceDropdown && (
+                <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 overflow-hidden">
+                  <div className="py-1">
+                    <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Resources
+                    </div>
+                    {resourceLinks.map((item) => (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onClick={() => setShowResourceDropdown(false)}
+                        className="block px-3 py-2 text-sm text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700 transition-colors"
+                      >
+                        {item.label}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
 
             {/* タスクボタン */}
             <TaskButton />

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { CheckCircle, ExternalLink } from 'lucide-react'
+import TopBar from '../components/TopBar'
+import NavigationTabs from '../components/NavigationTabs'
+import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
+import { useToast } from '@/contexts/ToastContext'
+import { GoogleOAuthStatus } from '@/types/settings'
+
+export default function IntegrationsPage() {
+  const [googleStatus, setGoogleStatus] = useState<GoogleOAuthStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { showToast } = useToast()
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('google_oauth') === 'connected') {
+      showToast('Google OAuth 連携が完了しました', 'success')
+      window.history.replaceState(null, '', '/integrations')
+    }
+  }, [showToast])
+
+  useEffect(() => {
+    const loadIntegrations = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const client = createAgentAPIProxyClientFromStorage()
+        setGoogleStatus(await client.getGoogleOAuthStatus())
+      } catch (err) {
+        console.error('Failed to load integrations:', err)
+        setError('Integrations を読み込めませんでした')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadIntegrations()
+  }, [])
+
+  const googleAvailable = useMemo(() => {
+    return Boolean(googleStatus?.enabled && googleStatus.oauth_start_url)
+  }, [googleStatus])
+
+  const startGoogleOAuth = () => {
+    if (!googleStatus?.oauth_start_url) return
+    window.location.href = googleStatus.oauth_start_url
+  }
+
+  return (
+    <main className="min-h-dvh bg-gray-50 dark:bg-gray-900">
+      <TopBar
+        title="Integrations"
+        subtitle="Connect external SaaS accounts"
+        showSettingsButton={true}
+      >
+        <div className="md:hidden">
+          <NavigationTabs />
+        </div>
+      </TopBar>
+
+      <div className="px-4 md:px-6 lg:px-8 pt-6 md:pt-8 pb-6 md:pb-8">
+        <div className="mx-auto max-w-3xl">
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            </div>
+          ) : error ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+              {error}
+            </div>
+          ) : googleAvailable ? (
+            <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-base font-semibold text-gray-900 dark:text-white">Google</h2>
+                    {googleStatus?.connected && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300">
+                        <CheckCircle className="h-3.5 w-3.5" />
+                        Connected
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    Allow sessions to use Google OAuth through scia.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={startGoogleOAuth}
+                  className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  {googleStatus?.connected ? 'Reconnect Google' : 'Connect Google'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+              No SaaS integrations are available.
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -46,7 +46,9 @@ export default function IntegrationsPage() {
 
   const startGoogleOAuth = () => {
     if (!googleStatus?.oauth_start_url) return
-    window.location.href = googleStatus.oauth_start_url
+    const startUrl = new URL(googleStatus.oauth_start_url, window.location.origin)
+    startUrl.searchParams.set('redirect_uri', `${window.location.origin}/api/oauth/google/callback`)
+    window.location.href = startUrl.toString()
   }
 
   return (

--- a/src/app/settings/personal/page.tsx
+++ b/src/app/settings/personal/page.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { SettingsData, BedrockConfig, APIMCPServerConfig, MarketplaceConfig, AuthMode, ExternalSessionManagerConfig, GitSyncConfig, GoogleOAuthStatus, prepareSettingsForSave, getSendGithubTokenOnSessionStart, setSendGithubTokenOnSessionStart, EnterKeyBehavior, getEnterKeyBehavior, setEnterKeyBehavior, FontSettings as FontSettingsType, getFontSettings, setFontSettings } from '@/types/settings'
-import { BedrockSettings, SettingsAccordion, GithubTokenSettings, MCPServerSettings, MarketplaceSettings, PluginSettings, KeyBindingSettings, ClaudeOAuthSettings, GoogleOAuthSettings, FontSettings, EnvVarsSettings, SlackSettings, FileSettings, GitHubSyncSettings, CodexDeviceAuthSettings } from '@/components/settings'
+import { SettingsData, BedrockConfig, APIMCPServerConfig, MarketplaceConfig, AuthMode, ExternalSessionManagerConfig, GitSyncConfig, prepareSettingsForSave, getSendGithubTokenOnSessionStart, setSendGithubTokenOnSessionStart, EnterKeyBehavior, getEnterKeyBehavior, setEnterKeyBehavior, FontSettings as FontSettingsType, getFontSettings, setFontSettings } from '@/types/settings'
+import { BedrockSettings, SettingsAccordion, GithubTokenSettings, MCPServerSettings, MarketplaceSettings, PluginSettings, KeyBindingSettings, ClaudeOAuthSettings, FontSettings, EnvVarsSettings, SlackSettings, FileSettings, GitHubSyncSettings, CodexDeviceAuthSettings } from '@/components/settings'
 import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError, CredentialsMetadata } from '@/lib/agentapi-proxy-client'
 import { useToast } from '@/contexts/ToastContext'
 
@@ -33,8 +33,6 @@ export default function PersonalSettingsPage() {
   const [regeneratingEsmId, setRegeneratingEsmId] = useState<string | null>(null)
   // GitHub Sync state
   const [gitSyncConfig, setGitSyncConfig] = useState<GitSyncConfig | undefined>(undefined)
-  const [googleOAuthStatus, setGoogleOAuthStatus] = useState<GoogleOAuthStatus | null>(null)
-  const [googleOAuthLoading, setGoogleOAuthLoading] = useState(false)
   // Credentials state
   const [credentialsMetadata, setCredentialsMetadata] = useState<CredentialsMetadata | null>(null)
   const [credentialsJson, setCredentialsJson] = useState<string>('')
@@ -135,7 +133,6 @@ export default function PersonalSettingsPage() {
           // credentials endpoint が存在しない場合は無視
         }
 
-        await loadGoogleOAuthStatus()
       } catch (err) {
         console.error('Failed to load personal settings:', err)
         if (err instanceof AgentAPIProxyError && err.status === 401) {
@@ -151,26 +148,6 @@ export default function PersonalSettingsPage() {
 
     fetchSettings()
   }, [userName])
-
-  const loadGoogleOAuthStatus = async () => {
-    setGoogleOAuthLoading(true)
-    try {
-      const client = createAgentAPIProxyClientFromStorage()
-      const status = await client.getGoogleOAuthStatus()
-      setGoogleOAuthStatus(status)
-    } catch (err) {
-      console.error('Failed to load Google OAuth status:', err)
-      setGoogleOAuthStatus({
-        enabled: false,
-        health_ok: false,
-        client_configured: false,
-        connected: false,
-        proxy_configured: false,
-      })
-    } finally {
-      setGoogleOAuthLoading(false)
-    }
-  }
 
   const handleMarketplacesChange = (marketplaces: Record<string, MarketplaceConfig>) => {
     setSettings((prev) => ({ ...prev, marketplaces }))
@@ -613,13 +590,6 @@ export default function PersonalSettingsPage() {
                 authMode={settings.auth_mode}
                 onChange={handleClaudeOAuthChange}
               />
-              <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
-                <GoogleOAuthSettings
-                  status={googleOAuthStatus}
-                  loading={googleOAuthLoading}
-                  onRefresh={loadGoogleOAuthStatus}
-                />
-              </div>
               <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
                 <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">
                   Bedrock Settings


### PR DESCRIPTION
## Summary
- add a new /integrations page that shows available SaaS integration connect buttons
- move scia Google OAuth out of personal settings and use the proxy /integrations/google-oauth/status endpoint from the new page
- add Integrations to the Resources dropdown and mobile navigation
- redirect Google OAuth completion back to /integrations

## Verification
- bun run type-check
- bun run lint (passes with existing warnings)
- bun run build (passes with existing warnings)