### PR TITLE
Add Notion OAuth integration UI

### DIFF
--- a/src/app/api/oauth/notion/callback/route.ts
+++ b/src/app/api/oauth/notion/callback/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const DEFAULT_SCIA_INTERNAL_URL = 'http://scia-oauth.agentapi-ui-dev.svc.cluster.local:8081'
+const DEFAULT_COMPLETE_PATH = '/integrations?notion_oauth=connected'
+
+export async function GET(request: NextRequest) {
+  const sciaBaseUrl = (process.env.SCIA_OAUTH_INTERNAL_URL || DEFAULT_SCIA_INTERNAL_URL).replace(/\/$/, '')
+  const completePath = process.env.NEXT_PUBLIC_NOTION_OAUTH_COMPLETE_PATH || DEFAULT_COMPLETE_PATH
+  const publicBaseUrl = getPublicBaseUrl(request)
+  const callbackUrl = `${sciaBaseUrl}/oauth/notion/callback${request.nextUrl.search}`
+
+  const response = await fetch(callbackUrl, {
+    method: 'GET',
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    return new NextResponse(text || 'Notion OAuth callback failed', {
+      status: response.status,
+      headers: {
+        'content-type': response.headers.get('content-type') || 'text/plain; charset=utf-8',
+      },
+    })
+  }
+
+  return NextResponse.redirect(new URL(completePath, publicBaseUrl))
+}
+
+function getPublicBaseUrl(request: NextRequest): string {
+  if (process.env.NEXT_PUBLIC_BASE_URL) {
+    return process.env.NEXT_PUBLIC_BASE_URL
+  }
+
+  const forwardedHost = request.headers.get('x-forwarded-host')
+  const host = forwardedHost || request.headers.get('host')
+  if (host && !host.startsWith('0.0.0.0')) {
+    const proto = request.headers.get('x-forwarded-proto') || 'https'
+    return `${proto}://${host}`
+  }
+
+  return 'https://cc-dev.takutakahashi.dev'
+}

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -6,10 +6,11 @@ import TopBar from '../components/TopBar'
 import NavigationTabs from '../components/NavigationTabs'
 import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
 import { useToast } from '@/contexts/ToastContext'
-import { GoogleOAuthStatus } from '@/types/settings'
+import { GoogleOAuthStatus, NotionOAuthStatus } from '@/types/settings'
 
 export default function IntegrationsPage() {
   const [googleStatus, setGoogleStatus] = useState<GoogleOAuthStatus | null>(null)
+  const [notionStatus, setNotionStatus] = useState<NotionOAuthStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { showToast } = useToast()
@@ -20,6 +21,10 @@ export default function IntegrationsPage() {
       showToast('Google OAuth 連携が完了しました', 'success')
       window.history.replaceState(null, '', '/integrations')
     }
+    if (params.get('notion_oauth') === 'connected') {
+      showToast('Notion OAuth 連携が完了しました', 'success')
+      window.history.replaceState(null, '', '/integrations')
+    }
   }, [showToast])
 
   useEffect(() => {
@@ -28,7 +33,12 @@ export default function IntegrationsPage() {
       setError(null)
       try {
         const client = createAgentAPIProxyClientFromStorage()
-        setGoogleStatus(await client.getGoogleOAuthStatus())
+        const [google, notion] = await Promise.all([
+          client.getGoogleOAuthStatus(),
+          client.getNotionOAuthStatus(),
+        ])
+        setGoogleStatus(google)
+        setNotionStatus(notion)
       } catch (err) {
         console.error('Failed to load integrations:', err)
         setError('Integrations を読み込めませんでした')
@@ -44,10 +54,21 @@ export default function IntegrationsPage() {
     return Boolean(googleStatus?.enabled && googleStatus.oauth_start_url)
   }, [googleStatus])
 
+  const notionAvailable = useMemo(() => {
+    return Boolean(notionStatus?.enabled && notionStatus.oauth_start_url)
+  }, [notionStatus])
+
   const startGoogleOAuth = () => {
     if (!googleStatus?.oauth_start_url) return
     const startUrl = new URL(googleStatus.oauth_start_url, window.location.origin)
     startUrl.searchParams.set('redirect_uri', `${window.location.origin}/api/oauth/google/callback`)
+    window.location.href = startUrl.toString()
+  }
+
+  const startNotionOAuth = () => {
+    if (!notionStatus?.oauth_start_url) return
+    const startUrl = new URL(notionStatus.oauth_start_url, window.location.origin)
+    startUrl.searchParams.set('redirect_uri', `${window.location.origin}/api/oauth/notion/callback`)
     window.location.href = startUrl.toString()
   }
 
@@ -72,32 +93,26 @@ export default function IntegrationsPage() {
             <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
               {error}
             </div>
-          ) : googleAvailable ? (
-            <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h2 className="text-base font-semibold text-gray-900 dark:text-white">Google</h2>
-                    {googleStatus?.connected && (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300">
-                        <CheckCircle className="h-3.5 w-3.5" />
-                        Connected
-                      </span>
-                    )}
-                  </div>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    Allow sessions to use Google OAuth through scia.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={startGoogleOAuth}
-                  className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  {googleStatus?.connected ? 'Reconnect Google' : 'Connect Google'}
-                </button>
-              </div>
+          ) : googleAvailable || notionAvailable ? (
+            <div className="space-y-4">
+              {googleAvailable && (
+                <IntegrationCard
+                  title="Google"
+                  description="Allow sessions to use Google OAuth through scia."
+                  connected={googleStatus?.connected ?? false}
+                  connectLabel={googleStatus?.connected ? 'Reconnect Google' : 'Connect Google'}
+                  onConnect={startGoogleOAuth}
+                />
+              )}
+              {notionAvailable && (
+                <IntegrationCard
+                  title="Notion"
+                  description="Allow sessions to use Notion OAuth through scia."
+                  connected={notionStatus?.connected ?? false}
+                  connectLabel={notionStatus?.connected ? 'Reconnect Notion' : 'Connect Notion'}
+                  onConnect={startNotionOAuth}
+                />
+              )}
             </div>
           ) : (
             <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
@@ -107,5 +122,46 @@ export default function IntegrationsPage() {
         </div>
       </div>
     </main>
+  )
+}
+
+function IntegrationCard({
+  title,
+  description,
+  connected,
+  connectLabel,
+  onConnect,
+}: {
+  title: string
+  description: string
+  connected: boolean
+  connectLabel: string
+  onConnect: () => void
+}) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h2>
+            {connected && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300">
+                <CheckCircle className="h-3.5 w-3.5" />
+                Connected
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onConnect}
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        >
+          <ExternalLink className="h-4 w-4" />
+          {connectLabel}
+        </button>
+      </div>
+    </div>
   )
 }

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -74,7 +74,7 @@ import {
   TaskListResponse,
   TaskListParams
 } from '../types/task';
-import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
+import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, NotionOAuthStatus, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
 import { ProxyUserInfo } from '../types/user';
 import { handleAuthenticationRequired, isAuthenticationRequiredError } from './auth-error-handler';
 
@@ -1458,6 +1458,13 @@ export class AgentAPIProxyClient {
    */
   async getGoogleOAuthStatus(): Promise<GoogleOAuthStatus> {
     return await this.makeRequest<GoogleOAuthStatus>('/integrations/google-oauth/status');
+  }
+
+  /**
+   * Get scia Notion OAuth integration status for the current user.
+   */
+  async getNotionOAuthStatus(): Promise<NotionOAuthStatus> {
+    return await this.makeRequest<NotionOAuthStatus>('/integrations/notion-oauth/status');
   }
 
   /**

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -59,7 +59,7 @@ export interface GitSyncConfig {
   encryption?: GitSyncEncryptionConfig;
 }
 
-export interface GoogleOAuthStatus {
+export interface SciaOAuthStatus {
   enabled: boolean;
   health_ok: boolean;
   health_status?: string;
@@ -71,6 +71,9 @@ export interface GoogleOAuthStatus {
   authorization_url_endpoint?: string;
   proxy_configured: boolean;
 }
+
+export type GoogleOAuthStatus = SciaOAuthStatus;
+export type NotionOAuthStatus = SciaOAuthStatus;
 
 // 設定データ（API で保存）
 export interface SettingsData {


### PR DESCRIPTION
## Summary
- add Notion OAuth status fetching to the integrations page
- render Notion connect/reconnect card alongside Google
- add UI callback route for Notion OAuth completion

## Validation
- bun run type-check
- bun run lint (passes with existing warnings)