### PR TITLE
Render scia integrations dynamically

### DIFF
--- a/src/app/api/oauth/[provider]/callback/route.ts
+++ b/src/app/api/oauth/[provider]/callback/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 const DEFAULT_SCIA_INTERNAL_URL = 'http://scia-oauth.agentapi-ui-dev.svc.cluster.local:8081'
-const DEFAULT_COMPLETE_PATH = '/integrations?google_oauth=connected'
 
-export async function GET(request: NextRequest) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ provider: string }> }
+) {
+  const { provider: rawProvider } = await params
+  const provider = encodeURIComponent(rawProvider)
   const sciaBaseUrl = (process.env.SCIA_OAUTH_INTERNAL_URL || DEFAULT_SCIA_INTERNAL_URL).replace(/\/$/, '')
-  const completePath = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_COMPLETE_PATH || DEFAULT_COMPLETE_PATH
   const publicBaseUrl = getPublicBaseUrl(request)
-  const callbackUrl = `${sciaBaseUrl}/oauth/google/callback${request.nextUrl.search}`
+  const completePath = process.env.NEXT_PUBLIC_OAUTH_COMPLETE_PATH || `/integrations?integration_connected=${provider}`
+  const callbackUrl = `${sciaBaseUrl}/oauth/${provider}/callback${request.nextUrl.search}`
 
   const response = await fetch(callbackUrl, {
     method: 'GET',
@@ -16,7 +20,7 @@ export async function GET(request: NextRequest) {
 
   if (!response.ok) {
     const text = await response.text()
-    return new NextResponse(text || 'Google OAuth callback failed', {
+    return new NextResponse(text || `${rawProvider} OAuth callback failed`, {
       status: response.status,
       headers: {
         'content-type': response.headers.get('content-type') || 'text/plain; charset=utf-8',

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -12,6 +12,7 @@ export default function IntegrationsPage() {
   const [integrations, setIntegrations] = useState<SciaIntegrationsResponse | null>(null)
   const [selectedScopes, setSelectedScopes] = useState<Record<string, string[]>>({})
   const [loading, setLoading] = useState(true)
+  const [connectingIntegrationID, setConnectingIntegrationID] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const { showToast } = useToast()
 
@@ -75,17 +76,21 @@ export default function IntegrationsPage() {
     })
   }
 
-  const startOAuth = (integration: SciaIntegration) => {
-    if (!integration.start_url) return
-    const startUrl = new URL(integration.start_url, window.location.origin)
-    startUrl.searchParams.set('redirect_uri', `${window.location.origin}/api/oauth/${integration.provider}/callback`)
-
-    const scopes = selectedScopes[integration.id] || []
-    if (scopes.length > 0) {
-      startUrl.searchParams.set('scope', scopes.join(scopeSeparator(integration.provider)))
+  const startOAuth = async (integration: SciaIntegration) => {
+    if (!integration.authorization_url_endpoint) return
+    setConnectingIntegrationID(integration.id)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      const response = await client.createIntegrationAuthorizationURL(integration.id, {
+        redirect_uri: `${window.location.origin}/api/oauth/${integration.provider}/callback`,
+        scope_ids: selectedScopes[integration.id] || [],
+      })
+      window.location.href = response.authorization_url
+    } catch (err) {
+      console.error('Failed to create authorization URL:', err)
+      showToast('OAuth URL を作成できませんでした', 'error')
+      setConnectingIntegrationID(null)
     }
-
-    window.location.href = startUrl.toString()
   }
 
   return (
@@ -237,11 +242,11 @@ export default function IntegrationsPage() {
                   <button
                     type="button"
                     onClick={() => startOAuth(integration)}
-                    disabled={!integration.start_url}
+                    disabled={!integration.authorization_url_endpoint || connectingIntegrationID === integration.id}
                     className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   >
                     <ExternalLink className="h-4 w-4" />
-                    {integration.connected ? `Reconnect ${integration.name}` : `Connect ${integration.name}`}
+                    {connectingIntegrationID === integration.id ? 'Connecting...' : integration.connected ? `Reconnect ${integration.name}` : `Connect ${integration.name}`}
                   </button>
                 </section>
               ))}
@@ -285,8 +290,4 @@ function scopeGroups(integration: SciaIntegration): Array<{ id: string; name: st
 
 function ungroupedScopes(integration: SciaIntegration): IntegrationScope[] {
   return integration.scopes.filter((scope) => !scope.group)
-}
-
-function scopeSeparator(provider: string): string {
-  return provider === 'todoist' ? ',' : ' '
 }

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -1,53 +1,81 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { CheckCircle, ExternalLink } from 'lucide-react'
+import { CheckCircle, ExternalLink, RefreshCw } from 'lucide-react'
 import TopBar from '../components/TopBar'
 import NavigationTabs from '../components/NavigationTabs'
 import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
 import { useToast } from '@/contexts/ToastContext'
-import { GoogleOAuthStatus } from '@/types/settings'
+import { SciaIntegration, SciaIntegrationsResponse } from '@/types/settings'
 
 export default function IntegrationsPage() {
-  const [googleStatus, setGoogleStatus] = useState<GoogleOAuthStatus | null>(null)
+  const [integrations, setIntegrations] = useState<SciaIntegrationsResponse | null>(null)
+  const [selectedScopes, setSelectedScopes] = useState<Record<string, string[]>>({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { showToast } = useToast()
 
+  const loadIntegrations = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      const response = await client.getIntegrations()
+      setIntegrations(response)
+      setSelectedScopes((current) => {
+        const next = { ...current }
+        for (const integration of response.integrations || []) {
+          if (!next[integration.id]) {
+            next[integration.id] = defaultScopes(integration)
+          }
+        }
+        return next
+      })
+    } catch (err) {
+      console.error('Failed to load integrations:', err)
+      setError('Integrations を読み込めませんでした')
+    } finally {
+      setLoading(false)
+    }
+  }
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
-    if (params.get('google_oauth') === 'connected') {
-      showToast('Google OAuth 連携が完了しました', 'success')
+    const connectedProvider = params.get('integration_connected')
+    if (connectedProvider) {
+      showToast(`${connectedProvider} 連携が完了しました`, 'success')
       window.history.replaceState(null, '', '/integrations')
     }
   }, [showToast])
 
   useEffect(() => {
-    const loadIntegrations = async () => {
-      setLoading(true)
-      setError(null)
-      try {
-        const client = createAgentAPIProxyClientFromStorage()
-        setGoogleStatus(await client.getGoogleOAuthStatus())
-      } catch (err) {
-        console.error('Failed to load integrations:', err)
-        setError('Integrations を読み込めませんでした')
-      } finally {
-        setLoading(false)
-      }
-    }
-
     loadIntegrations()
   }, [])
 
-  const googleAvailable = useMemo(() => {
-    return Boolean(googleStatus?.enabled && googleStatus.oauth_start_url)
-  }, [googleStatus])
+  const visibleIntegrations = useMemo(() => {
+    return (integrations?.integrations || []).filter((integration) => integration.released)
+  }, [integrations])
 
-  const startGoogleOAuth = () => {
-    if (!googleStatus?.oauth_start_url) return
-    const startUrl = new URL(googleStatus.oauth_start_url, window.location.origin)
-    startUrl.searchParams.set('redirect_uri', `${window.location.origin}/api/oauth/google/callback`)
+  const setScopeSelected = (integration: SciaIntegration, value: string, checked: boolean) => {
+    setSelectedScopes((current) => {
+      const currentValues = current[integration.id] || []
+      const nextValues = checked
+        ? Array.from(new Set([...currentValues, value]))
+        : currentValues.filter((scope) => scope !== value)
+      return { ...current, [integration.id]: nextValues }
+    })
+  }
+
+  const startOAuth = (integration: SciaIntegration) => {
+    if (!integration.start_url) return
+    const startUrl = new URL(integration.start_url, window.location.origin)
+    startUrl.searchParams.set('redirect_uri', `${window.location.origin}/api/oauth/${integration.provider}/callback`)
+
+    const scopes = selectedScopes[integration.id] || []
+    if (scopes.length > 0) {
+      startUrl.searchParams.set('scope', scopes.join(scopeSeparator(integration.provider)))
+    }
+
     window.location.href = startUrl.toString()
   }
 
@@ -63,49 +91,118 @@ export default function IntegrationsPage() {
       </TopBar>
 
       <div className="px-4 md:px-6 lg:px-8 pt-6 md:pt-8 pb-6 md:pb-8">
-        <div className="mx-auto max-w-3xl">
+        <div className="mx-auto max-w-4xl">
+          <div className="mb-4 flex items-center justify-end">
+            <button
+              type="button"
+              onClick={loadIntegrations}
+              disabled={loading}
+              aria-label="Refresh integrations"
+              title="Refresh integrations"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
+
           {loading ? (
             <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
             </div>
           ) : error ? (
             <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
               {error}
             </div>
-          ) : googleAvailable ? (
-            <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h2 className="text-base font-semibold text-gray-900 dark:text-white">Google</h2>
-                    {googleStatus?.connected && (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300">
+          ) : !integrations?.enabled || visibleIntegrations.length === 0 ? (
+            <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+              No SaaS integrations are available.
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {visibleIntegrations.map((integration) => (
+                <section
+                  key={integration.id}
+                  className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        {integration.icon_url && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={integration.icon_url} alt="" className="h-5 w-5 shrink-0" />
+                        )}
+                        <h2 className="truncate text-base font-semibold text-gray-900 dark:text-white">
+                          {integration.name}
+                        </h2>
+                      </div>
+                      {integration.description && (
+                        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                          {integration.description}
+                        </p>
+                      )}
+                    </div>
+                    {integration.connected && (
+                      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300">
                         <CheckCircle className="h-3.5 w-3.5" />
                         Connected
                       </span>
                     )}
                   </div>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    Allow sessions to use Google OAuth through scia.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={startGoogleOAuth}
-                  className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  {googleStatus?.connected ? 'Reconnect Google' : 'Connect Google'}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-              No SaaS integrations are available.
+
+                  {integration.scopes.length > 0 && (
+                    <div className="mt-4 space-y-2">
+                      {integration.scopes.map((scope) => {
+                        const checked = (selectedScopes[integration.id] || []).includes(scope.value)
+                        return (
+                          <label
+                            key={scope.value}
+                            className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 p-3 text-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/60"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={(event) => setScopeSelected(integration, scope.value, event.target.checked)}
+                              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                            />
+                            <span className="min-w-0">
+                              <span className="block font-medium text-gray-800 dark:text-gray-100">
+                                {scope.label || scope.value}
+                              </span>
+                              {scope.description && (
+                                <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+                                  {scope.description}
+                                </span>
+                              )}
+                            </span>
+                          </label>
+                        )
+                      })}
+                    </div>
+                  )}
+
+                  <button
+                    type="button"
+                    onClick={() => startOAuth(integration)}
+                    disabled={!integration.start_url}
+                    className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    {integration.connected ? `Reconnect ${integration.name}` : `Connect ${integration.name}`}
+                  </button>
+                </section>
+              ))}
             </div>
           )}
         </div>
       </div>
     </main>
   )
+}
+
+function defaultScopes(integration: SciaIntegration): string[] {
+  return integration.scopes.filter((scope) => scope.enabled).map((scope) => scope.value)
+}
+
+function scopeSeparator(provider: string): string {
+  return provider === 'todoist' ? ',' : ' '
 }

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -152,25 +152,25 @@ export default function IntegrationsPage() {
                   {integration.scopes.length > 0 && (
                     <div className="mt-4 space-y-2">
                       {integration.scopes.map((scope) => {
-                        const checked = (selectedScopes[integration.id] || []).includes(scope.value)
+                        const checked = (selectedScopes[integration.id] || []).includes(scope.id)
                         return (
                           <label
-                            key={scope.value}
+                            key={scope.id}
                             className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 p-3 text-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/60"
                           >
                             <input
                               type="checkbox"
                               checked={checked}
-                              onChange={(event) => setScopeSelected(integration, scope.value, event.target.checked)}
+                              onChange={(event) => setScopeSelected(integration, scope.id, event.target.checked)}
                               className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                             />
                             <span className="min-w-0">
                               <span className="block font-medium text-gray-800 dark:text-gray-100">
-                                {scope.label || scope.value}
+                                {scope.name}
                               </span>
-                              {scope.description && (
+                              {scope.desc && (
                                 <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
-                                  {scope.description}
+                                  {scope.desc}
                                 </span>
                               )}
                             </span>
@@ -200,7 +200,7 @@ export default function IntegrationsPage() {
 }
 
 function defaultScopes(integration: SciaIntegration): string[] {
-  return integration.scopes.filter((scope) => scope.enabled).map((scope) => scope.value)
+  return integration.scopes.filter((scope) => scope.enabled).map((scope) => scope.id)
 }
 
 function scopeSeparator(provider: string): string {

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -6,7 +6,7 @@ import TopBar from '../components/TopBar'
 import NavigationTabs from '../components/NavigationTabs'
 import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
 import { useToast } from '@/contexts/ToastContext'
-import { SciaIntegration, SciaIntegrationsResponse } from '@/types/settings'
+import { IntegrationScope, SciaIntegration, SciaIntegrationsResponse } from '@/types/settings'
 
 export default function IntegrationsPage() {
   const [integrations, setIntegrations] = useState<SciaIntegrationsResponse | null>(null)
@@ -63,6 +63,15 @@ export default function IntegrationsPage() {
         ? Array.from(new Set([...currentValues, value]))
         : currentValues.filter((scope) => scope !== value)
       return { ...current, [integration.id]: nextValues }
+    })
+  }
+
+  const setScopeGroupSelected = (integration: SciaIntegration, group: string, value: string) => {
+    setSelectedScopes((current) => {
+      const currentValues = current[integration.id] || []
+      const groupScopeIDs = new Set(integration.scopes.filter((scope) => scope.group === group).map((scope) => scope.id))
+      const nextValues = [...currentValues.filter((scope) => !groupScopeIDs.has(scope)), value]
+      return { ...current, [integration.id]: Array.from(new Set(nextValues)) }
     })
   }
 
@@ -151,7 +160,52 @@ export default function IntegrationsPage() {
 
                   {integration.scopes.length > 0 && (
                     <div className="mt-4 space-y-2">
-                      {integration.scopes.map((scope) => {
+                      {scopeGroups(integration).map((group) => (
+                        <fieldset
+                          key={group.id}
+                          className="rounded-md border border-gray-200 p-3 dark:border-gray-700"
+                        >
+                          <legend className="px-1 text-sm font-medium text-gray-800 dark:text-gray-100">
+                            {group.name}
+                          </legend>
+                          {group.desc && (
+                            <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                              {group.desc}
+                            </p>
+                          )}
+                          <div className="space-y-2">
+                            {group.scopes.map((scope) => {
+                              const checked = (selectedScopes[integration.id] || []).includes(scope.id)
+                              return (
+                                <label
+                                  key={scope.id}
+                                  className="flex cursor-pointer items-start gap-3 rounded-md p-2 text-sm transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/60"
+                                >
+                                  <input
+                                    type="radio"
+                                    name={`${integration.id}-${group.id}`}
+                                    checked={checked}
+                                    onChange={() => setScopeGroupSelected(integration, group.id, scope.id)}
+                                    className="mt-0.5 h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+                                  />
+                                  <span className="min-w-0">
+                                    <span className="block font-medium text-gray-800 dark:text-gray-100">
+                                      {scope.name}
+                                    </span>
+                                    {scope.desc && (
+                                      <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+                                        {scope.desc}
+                                      </span>
+                                    )}
+                                  </span>
+                                </label>
+                              )
+                            })}
+                          </div>
+                        </fieldset>
+                      ))}
+
+                      {ungroupedScopes(integration).map((scope) => {
                         const checked = (selectedScopes[integration.id] || []).includes(scope.id)
                         return (
                           <label
@@ -200,7 +254,37 @@ export default function IntegrationsPage() {
 }
 
 function defaultScopes(integration: SciaIntegration): string[] {
-  return integration.scopes.filter((scope) => scope.enabled).map((scope) => scope.id)
+  const selected: string[] = []
+  const selectedGroups = new Set<string>()
+  for (const scope of integration.scopes) {
+    if (!scope.enabled) continue
+    if (scope.group) {
+      if (selectedGroups.has(scope.group)) continue
+      selectedGroups.add(scope.group)
+    }
+    selected.push(scope.id)
+  }
+  return selected
+}
+
+function scopeGroups(integration: SciaIntegration): Array<{ id: string; name: string; desc?: string; scopes: IntegrationScope[] }> {
+  const groups = new Map<string, { id: string; name: string; desc?: string; scopes: IntegrationScope[] }>()
+  for (const scope of integration.scopes) {
+    if (!scope.group) continue
+    const group = groups.get(scope.group) || {
+      id: scope.group,
+      name: scope.group_name || scope.group,
+      desc: scope.group_desc,
+      scopes: [],
+    }
+    group.scopes.push(scope)
+    groups.set(scope.group, group)
+  }
+  return Array.from(groups.values())
+}
+
+function ungroupedScopes(integration: SciaIntegration): IntegrationScope[] {
+  return integration.scopes.filter((scope) => !scope.group)
 }
 
 function scopeSeparator(provider: string): string {

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -74,7 +74,7 @@ import {
   TaskListResponse,
   TaskListParams
 } from '../types/task';
-import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, SciaIntegrationsResponse, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
+import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, SciaAuthorizationURLResponse, SciaIntegrationsResponse, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
 import { ProxyUserInfo } from '../types/user';
 import { handleAuthenticationRequired, isAuthenticationRequiredError } from './auth-error-handler';
 
@@ -1465,6 +1465,16 @@ export class AgentAPIProxyClient {
    */
   async getIntegrations(): Promise<SciaIntegrationsResponse> {
     return await this.makeRequest<SciaIntegrationsResponse>('/integrations');
+  }
+
+  /**
+   * Ask scia, through the proxy, to build an OAuth authorization URL.
+   */
+  async createIntegrationAuthorizationURL(integrationId: string, request: { scope_ids: string[]; redirect_uri: string }): Promise<SciaAuthorizationURLResponse> {
+    return await this.makeRequest<SciaAuthorizationURLResponse>(`/integrations/${encodeURIComponent(integrationId)}/authorization-url`, {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
   }
 
   /**

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -74,7 +74,7 @@ import {
   TaskListResponse,
   TaskListParams
 } from '../types/task';
-import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
+import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, SciaIntegrationsResponse, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
 import { ProxyUserInfo } from '../types/user';
 import { handleAuthenticationRequired, isAuthenticationRequiredError } from './auth-error-handler';
 
@@ -1458,6 +1458,13 @@ export class AgentAPIProxyClient {
    */
   async getGoogleOAuthStatus(): Promise<GoogleOAuthStatus> {
     return await this.makeRequest<GoogleOAuthStatus>('/integrations/google-oauth/status');
+  }
+
+  /**
+   * Get scia OAuth integrations configured for the current user.
+   */
+  async getIntegrations(): Promise<SciaIntegrationsResponse> {
+    return await this.makeRequest<SciaIntegrationsResponse>('/integrations');
   }
 
   /**

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -73,9 +73,9 @@ export interface GoogleOAuthStatus {
 }
 
 export interface IntegrationScope {
-  value: string;
-  label?: string;
-  description?: string;
+  id: string;
+  name: string;
+  desc?: string;
   enabled: boolean;
 }
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -106,6 +106,14 @@ export interface SciaIntegrationsResponse {
   integrations: SciaIntegration[];
 }
 
+export interface SciaAuthorizationURLResponse {
+  credential_id: string;
+  authorization_url: string;
+  auth_url?: string;
+  redirect_uri?: string;
+  scope?: string;
+}
+
 // 設定データ（API で保存）
 export interface SettingsData {
   bedrock?: BedrockConfig;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -72,6 +72,37 @@ export interface GoogleOAuthStatus {
   proxy_configured: boolean;
 }
 
+export interface IntegrationScope {
+  value: string;
+  label?: string;
+  description?: string;
+  enabled: boolean;
+}
+
+export interface SciaIntegration {
+  id: string;
+  provider: string;
+  namespace?: string;
+  credential_id: string;
+  name: string;
+  icon_url?: string;
+  description?: string;
+  released: boolean;
+  source?: string;
+  start_url: string;
+  authorization_url_endpoint?: string;
+  setup?: Record<string, string>;
+  scopes: IntegrationScope[];
+  connected: boolean;
+}
+
+export interface SciaIntegrationsResponse {
+  enabled: boolean;
+  health_ok: boolean;
+  health_status?: string;
+  integrations: SciaIntegration[];
+}
+
 // 設定データ（API で保存）
 export interface SettingsData {
   bedrock?: BedrockConfig;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -76,6 +76,9 @@ export interface IntegrationScope {
   id: string;
   name: string;
   desc?: string;
+  group?: string;
+  group_name?: string;
+  group_desc?: string;
   enabled: boolean;
 }
 


### PR DESCRIPTION
## Summary
- load integrations from the proxy /integrations endpoint
- render released scia integrations dynamically with selectable scopes
- replace Google-only callback handling with provider-based OAuth callback routing

## Verification
- npm run type-check
- npm run lint