### PR TITLE
Fix default scia OAuth callback URL

### DIFF
--- a/src/app/api/oauth/[provider]/callback/route.ts
+++ b/src/app/api/oauth/[provider]/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const DEFAULT_SCIA_INTERNAL_URL = 'http://scia-oauth.agentapi-ui-dev.svc.cluster.local:8081'
+const DEFAULT_SCIA_INTERNAL_URL = 'http://scia-oauth:8081'
 
 export async function GET(
   request: NextRequest,


### PR DESCRIPTION
## Summary\n- change the OAuth callback route fallback scia URL from the dev namespace FQDN to the same-namespace service name\n- prevent production callbacks from being forwarded to the dev scia broker when SCIA_OAUTH_INTERNAL_URL is unset\n\n## Verification\n- bun run type-check\n- production hotfix applied via Helm: agentapi-ui env SCIA_OAUTH_INTERNAL_URL=http://scia-oauth:8081\n- reproduced invalid state before the hotfix and confirmed callback now progresses past state validation with a fake code