### PR TITLE
Update integrations access selection UI

### DIFF
--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -73,6 +73,10 @@ export default function IntegrationsPage() {
     })
   }
 
+  const setScopeGroupAllowed = (integration: SciaIntegration, group: ScopeGroup, allowed: boolean) => {
+    setScopeGroup(integration, group.id, allowed ? fallbackScopeForGroup(group) : denyScopeValue)
+  }
+
   const startOAuth = async (integration: SciaIntegration) => {
     if (!integration.authorization_url_endpoint) return
     setConnectingIntegrationID(integration.id)
@@ -170,48 +174,63 @@ export default function IntegrationsPage() {
                       <div className="space-y-3">
                         {scopeGroups(integration).map((group) => {
                           const selectedScopeID = selectedScopeGroups[integration.id]?.[group.id] ?? defaultScopeForGroup(group)
+                          const allowed = selectedScopeID !== denyScopeValue
                           return (
                             <fieldset
                               key={group.id}
-                              className="rounded-md border border-gray-200 p-3 dark:border-gray-700"
+                              className={`rounded-md border p-3 transition-colors ${
+                                allowed
+                                  ? 'border-blue-200 bg-blue-50/50 dark:border-blue-900/70 dark:bg-blue-900/10'
+                                  : 'border-gray-200 bg-gray-50/60 dark:border-gray-700 dark:bg-gray-800/70'
+                              }`}
                             >
-                              <legend className="px-1 text-sm font-medium text-gray-900 dark:text-white">
-                                {group.name}
-                              </legend>
-                              {group.desc && (
-                                <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-                                  {group.desc}
-                                </p>
-                              )}
-                              <div className="grid gap-2">
-                                {group.scopes.map((scope) => (
-                                  <ScopeRadio
-                                    key={scope.id}
-                                    integrationID={integration.id}
-                                    groupID={group.id}
-                                    scope={scope}
-                                    checked={selectedScopeID === scope.id}
-                                    onChange={() => setScopeGroup(integration, group.id, scope.id)}
-                                  />
-                                ))}
-                                <label
-                                  className={`flex cursor-pointer items-start gap-3 rounded-md border p-3 text-sm transition-colors ${
-                                    selectedScopeID === denyScopeValue
-                                      ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-100'
-                                      : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/60'
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="min-w-0">
+                                  <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
+                                    {group.name}
+                                  </h4>
+                                  {group.desc && (
+                                    <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                                      {group.desc}
+                                    </p>
+                                  )}
+                                </div>
+                                <button
+                                  type="button"
+                                  role="switch"
+                                  aria-checked={allowed}
+                                  onClick={() => setScopeGroupAllowed(integration, group, !allowed)}
+                                  className={`relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
+                                    allowed ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
                                   }`}
                                 >
-                                  <input
-                                    type="radio"
-                                    name={`${integration.id}-${group.id}`}
-                                    value={denyScopeValue}
-                                    checked={selectedScopeID === denyScopeValue}
-                                    onChange={() => setScopeGroup(integration, group.id, denyScopeValue)}
-                                    className="mt-0.5 h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+                                  <span
+                                    className={`inline-block h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                                      allowed ? 'translate-x-5' : 'translate-x-0.5'
+                                    }`}
                                   />
-                                  <span className="font-medium">許可しない</span>
-                                </label>
+                                </button>
                               </div>
+
+                              {allowed && (
+                                <div className="mt-3 border-t border-blue-100 pt-3 dark:border-blue-900/50">
+                                  <div className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+                                    詳しいアクセス
+                                  </div>
+                                  <div className="space-y-1.5">
+                                    {group.scopes.map((scope) => (
+                                      <ScopeRadio
+                                        key={scope.id}
+                                        integrationID={integration.id}
+                                        groupID={group.id}
+                                        scope={scope}
+                                        checked={selectedScopeID === scope.id}
+                                        onChange={() => setScopeGroup(integration, group.id, scope.id)}
+                                      />
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
                             </fieldset>
                           )
                         })}
@@ -253,11 +272,11 @@ function ScopeRadio({
 }) {
   return (
     <label
-      className={`flex items-start gap-3 rounded-md border p-3 text-sm transition-colors ${
+      className={`flex cursor-pointer items-start gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${
         checked
-          ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-100'
-          : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/60'
-      } cursor-pointer`}
+          ? 'bg-white text-gray-900 shadow-sm ring-1 ring-blue-100 dark:bg-gray-800 dark:text-white dark:ring-blue-900/60'
+          : 'text-gray-600 hover:bg-white/70 dark:text-gray-300 dark:hover:bg-gray-800/70'
+      }`}
     >
       <input
         type="radio"
@@ -265,10 +284,10 @@ function ScopeRadio({
         value={scope.id}
         checked={checked}
         onChange={onChange}
-        className="mt-0.5 h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+        className="mt-0.5 h-3.5 w-3.5 border-gray-300 text-blue-600 focus:ring-blue-500"
       />
       <span className="min-w-0">
-        <span className="block font-medium text-gray-900 dark:text-white">
+        <span className="block font-medium">
           {scope.name}
         </span>
         {scope.desc && (
@@ -291,6 +310,10 @@ function defaultScopeGroups(integration: SciaIntegration): Record<string, string
 
 function defaultScopeForGroup(group: ScopeGroup): string {
   return group.scopes.find((scope) => scope.enabled)?.id || denyScopeValue
+}
+
+function fallbackScopeForGroup(group: ScopeGroup): string {
+  return group.scopes.find((scope) => scope.enabled)?.id || group.scopes[0]?.id || denyScopeValue
 }
 
 function scopeIDsForSelectedGroups(integration: SciaIntegration, selectedGroups: Record<string, string>): string[] {

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -8,9 +8,17 @@ import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-clien
 import { useToast } from '@/contexts/ToastContext'
 import { IntegrationScope, SciaIntegration, SciaIntegrationsResponse } from '@/types/settings'
 
+type AccessLevel = 'read' | 'read_write' | 'none'
+
+const accessOptions: Array<{ value: AccessLevel; label: string }> = [
+  { value: 'read', label: '読み込みのみ' },
+  { value: 'read_write', label: '読み込みと書き込み' },
+  { value: 'none', label: '許可しない' },
+]
+
 export default function IntegrationsPage() {
   const [integrations, setIntegrations] = useState<SciaIntegrationsResponse | null>(null)
-  const [selectedScopes, setSelectedScopes] = useState<Record<string, string[]>>({})
+  const [selectedAccessLevels, setSelectedAccessLevels] = useState<Record<string, AccessLevel>>({})
   const [loading, setLoading] = useState(true)
   const [connectingIntegrationID, setConnectingIntegrationID] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -23,11 +31,11 @@ export default function IntegrationsPage() {
       const client = createAgentAPIProxyClientFromStorage()
       const response = await client.getIntegrations()
       setIntegrations(response)
-      setSelectedScopes((current) => {
+      setSelectedAccessLevels((current) => {
         const next = { ...current }
         for (const integration of response.integrations || []) {
           if (!next[integration.id]) {
-            next[integration.id] = defaultScopes(integration)
+            next[integration.id] = defaultAccessLevel(integration)
           }
         }
         return next
@@ -57,22 +65,9 @@ export default function IntegrationsPage() {
     return (integrations?.integrations || []).filter((integration) => integration.released)
   }, [integrations])
 
-  const setScopeSelected = (integration: SciaIntegration, value: string, checked: boolean) => {
-    setSelectedScopes((current) => {
-      const currentValues = current[integration.id] || []
-      const nextValues = checked
-        ? Array.from(new Set([...currentValues, value]))
-        : currentValues.filter((scope) => scope !== value)
-      return { ...current, [integration.id]: nextValues }
-    })
-  }
-
-  const setScopeGroupSelected = (integration: SciaIntegration, group: string, value: string) => {
-    setSelectedScopes((current) => {
-      const currentValues = current[integration.id] || []
-      const groupScopeIDs = new Set(integration.scopes.filter((scope) => scope.group === group).map((scope) => scope.id))
-      const nextValues = [...currentValues.filter((scope) => !groupScopeIDs.has(scope)), value]
-      return { ...current, [integration.id]: Array.from(new Set(nextValues)) }
+  const setAccessLevel = (integration: SciaIntegration, value: AccessLevel) => {
+    setSelectedAccessLevels((current) => {
+      return { ...current, [integration.id]: value }
     })
   }
 
@@ -83,7 +78,7 @@ export default function IntegrationsPage() {
       const client = createAgentAPIProxyClientFromStorage()
       const response = await client.createIntegrationAuthorizationURL(integration.id, {
         redirect_uri: `${window.location.origin}/api/oauth/${integration.provider}/callback`,
-        scope_ids: selectedScopes[integration.id] || [],
+        scope_ids: scopeIDsForAccessLevel(integration, selectedAccessLevels[integration.id] || defaultAccessLevel(integration)),
       })
       window.location.href = response.authorization_url
     } catch (err) {
@@ -105,7 +100,7 @@ export default function IntegrationsPage() {
       </TopBar>
 
       <div className="px-4 md:px-6 lg:px-8 pt-6 md:pt-8 pb-6 md:pb-8">
-        <div className="mx-auto max-w-4xl">
+        <div className="mx-auto max-w-5xl">
           <div className="mb-4 flex items-center justify-end">
             <button
               type="button"
@@ -132,11 +127,11 @@ export default function IntegrationsPage() {
               No SaaS integrations are available.
             </div>
           ) : (
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
               {visibleIntegrations.map((integration) => (
                 <section
                   key={integration.id}
-                  className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+                  className="flex min-h-[320px] flex-col rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0">
@@ -164,86 +159,45 @@ export default function IntegrationsPage() {
                   </div>
 
                   {integration.scopes.length > 0 && (
-                    <div className="mt-4 space-y-2">
-                      {scopeGroups(integration).map((group) => (
-                        <fieldset
-                          key={group.id}
-                          className="rounded-md border border-gray-200 p-3 dark:border-gray-700"
-                        >
-                          <legend className="px-1 text-sm font-medium text-gray-800 dark:text-gray-100">
-                            {group.name}
-                          </legend>
-                          {group.desc && (
-                            <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-                              {group.desc}
-                            </p>
-                          )}
-                          <div className="space-y-2">
-                            {group.scopes.map((scope) => {
-                              const checked = (selectedScopes[integration.id] || []).includes(scope.id)
-                              return (
-                                <label
-                                  key={scope.id}
-                                  className="flex cursor-pointer items-start gap-3 rounded-md p-2 text-sm transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/60"
-                                >
-                                  <input
-                                    type="radio"
-                                    name={`${integration.id}-${group.id}`}
-                                    checked={checked}
-                                    onChange={() => setScopeGroupSelected(integration, group.id, scope.id)}
-                                    className="mt-0.5 h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
-                                  />
-                                  <span className="min-w-0">
-                                    <span className="block font-medium text-gray-800 dark:text-gray-100">
-                                      {scope.name}
-                                    </span>
-                                    {scope.desc && (
-                                      <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
-                                        {scope.desc}
-                                      </span>
-                                    )}
-                                  </span>
-                                </label>
-                              )
-                            })}
-                          </div>
-                        </fieldset>
-                      ))}
-
-                      {ungroupedScopes(integration).map((scope) => {
-                        const checked = (selectedScopes[integration.id] || []).includes(scope.id)
-                        return (
-                          <label
-                            key={scope.id}
-                            className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 p-3 text-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/60"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={checked}
-                              onChange={(event) => setScopeSelected(integration, scope.id, event.target.checked)}
-                              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                            />
-                            <span className="min-w-0">
-                              <span className="block font-medium text-gray-800 dark:text-gray-100">
-                                {scope.name}
-                              </span>
-                              {scope.desc && (
-                                <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
-                                  {scope.desc}
-                                </span>
-                              )}
-                            </span>
-                          </label>
-                        )
-                      })}
-                    </div>
+                    <fieldset className="mt-5">
+                      <legend className="text-sm font-semibold text-gray-900 dark:text-white">
+                        詳しいアクセス
+                      </legend>
+                      <div className="mt-3 grid gap-2">
+                        {accessOptions.map((option) => {
+                          const checked = (selectedAccessLevels[integration.id] || defaultAccessLevel(integration)) === option.value
+                          const disabled = option.value !== 'none' && scopeIDsForAccessLevel(integration, option.value).length === 0
+                          return (
+                            <label
+                              key={option.value}
+                              className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 text-sm transition-colors ${
+                                checked
+                                  ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-100'
+                                  : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/60'
+                              } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                            >
+                              <input
+                                type="radio"
+                                name={`${integration.id}-access`}
+                                value={option.value}
+                                checked={checked}
+                                disabled={disabled}
+                                onChange={() => setAccessLevel(integration, option.value)}
+                                className="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+                              />
+                              <span className="font-medium">{option.label}</span>
+                            </label>
+                          )
+                        })}
+                      </div>
+                    </fieldset>
                   )}
 
                   <button
                     type="button"
                     onClick={() => startOAuth(integration)}
                     disabled={!integration.authorization_url_endpoint || connectingIntegrationID === integration.id}
-                    className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                    className="mt-auto inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   >
                     <ExternalLink className="h-4 w-4" />
                     {connectingIntegrationID === integration.id ? 'Connecting...' : integration.connected ? `Reconnect ${integration.name}` : `Connect ${integration.name}`}
@@ -258,36 +212,64 @@ export default function IntegrationsPage() {
   )
 }
 
-function defaultScopes(integration: SciaIntegration): string[] {
-  const selected: string[] = []
-  const selectedGroups = new Set<string>()
-  for (const scope of integration.scopes) {
-    if (!scope.enabled) continue
-    if (scope.group) {
-      if (selectedGroups.has(scope.group)) continue
-      selectedGroups.add(scope.group)
-    }
-    selected.push(scope.id)
-  }
-  return selected
+function defaultAccessLevel(integration: SciaIntegration): AccessLevel {
+  if (scopeIDsForAccessLevel(integration, 'read').length > 0) return 'read'
+  if (scopeIDsForAccessLevel(integration, 'read_write').length > 0) return 'read_write'
+  return 'none'
 }
 
-function scopeGroups(integration: SciaIntegration): Array<{ id: string; name: string; desc?: string; scopes: IntegrationScope[] }> {
-  const groups = new Map<string, { id: string; name: string; desc?: string; scopes: IntegrationScope[] }>()
-  for (const scope of integration.scopes) {
-    if (!scope.group) continue
-    const group = groups.get(scope.group) || {
-      id: scope.group,
-      name: scope.group_name || scope.group,
-      desc: scope.group_desc,
-      scopes: [],
-    }
-    group.scopes.push(scope)
-    groups.set(scope.group, group)
+function scopeIDsForAccessLevel(integration: SciaIntegration, level: AccessLevel): string[] {
+  if (level === 'none') return []
+
+  const scopes = integration.scopes.filter((scope) => scope.enabled)
+  if (level === 'read_write') {
+    return preferredScopesByGroup(scopes, 'write').map((scope) => scope.id)
   }
-  return Array.from(groups.values())
+
+  return preferredScopesByGroup(scopes, 'read').map((scope) => scope.id)
 }
 
-function ungroupedScopes(integration: SciaIntegration): IntegrationScope[] {
-  return integration.scopes.filter((scope) => !scope.group)
+function preferredScopesByGroup(scopes: IntegrationScope[], preference: 'read' | 'write'): IntegrationScope[] {
+  const grouped = new Map<string, IntegrationScope[]>()
+  const standalone: IntegrationScope[] = []
+
+  for (const scope of scopes) {
+    if (!scope.group) {
+      standalone.push(scope)
+      continue
+    }
+    const groupScopes = grouped.get(scope.group) || []
+    groupScopes.push(scope)
+    grouped.set(scope.group, groupScopes)
+  }
+
+  const selected = Array.from(grouped.values())
+    .map((groupScopes) => selectScope(groupScopes, preference))
+    .filter((scope): scope is IntegrationScope => Boolean(scope))
+
+  const standaloneScopes = standalone.filter((scope) => {
+    const type = scopeAccessType(scope)
+    return preference === 'write' ? type !== 'read' : type === 'read'
+  })
+
+  return [...selected, ...standaloneScopes]
+}
+
+function selectScope(scopes: IntegrationScope[], preference: 'read' | 'write'): IntegrationScope | undefined {
+  const readScopes = scopes.filter((scope) => scopeAccessType(scope) === 'read')
+  const writeScopes = scopes.filter((scope) => scopeAccessType(scope) === 'write')
+
+  if (preference === 'write') {
+    return writeScopes[0] || scopes[0]
+  }
+
+  return readScopes[0]
+}
+
+function scopeAccessType(scope: IntegrationScope): 'read' | 'write' {
+  const text = `${scope.id} ${scope.name} ${scope.desc || ''}`.toLowerCase()
+  if (/(write|read_write|read-write|read\/write|edit|create|delete|manage|admin|modify|full|post|send)/.test(text)) {
+    return 'write'
+  }
+  return 'read'
 }

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -8,17 +8,13 @@ import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-clien
 import { useToast } from '@/contexts/ToastContext'
 import { IntegrationScope, SciaIntegration, SciaIntegrationsResponse } from '@/types/settings'
 
-type AccessLevel = 'read' | 'read_write' | 'none'
+type SelectedScopeGroups = Record<string, Record<string, string>>
 
-const accessOptions: Array<{ value: AccessLevel; label: string }> = [
-  { value: 'read', label: '読み込みのみ' },
-  { value: 'read_write', label: '読み込みと書き込み' },
-  { value: 'none', label: '許可しない' },
-]
+const denyScopeValue = '__none__'
 
 export default function IntegrationsPage() {
   const [integrations, setIntegrations] = useState<SciaIntegrationsResponse | null>(null)
-  const [selectedAccessLevels, setSelectedAccessLevels] = useState<Record<string, AccessLevel>>({})
+  const [selectedScopeGroups, setSelectedScopeGroups] = useState<SelectedScopeGroups>({})
   const [loading, setLoading] = useState(true)
   const [connectingIntegrationID, setConnectingIntegrationID] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -31,11 +27,11 @@ export default function IntegrationsPage() {
       const client = createAgentAPIProxyClientFromStorage()
       const response = await client.getIntegrations()
       setIntegrations(response)
-      setSelectedAccessLevels((current) => {
+      setSelectedScopeGroups((current) => {
         const next = { ...current }
         for (const integration of response.integrations || []) {
           if (!next[integration.id]) {
-            next[integration.id] = defaultAccessLevel(integration)
+            next[integration.id] = defaultScopeGroups(integration)
           }
         }
         return next
@@ -65,9 +61,15 @@ export default function IntegrationsPage() {
     return (integrations?.integrations || []).filter((integration) => integration.released)
   }, [integrations])
 
-  const setAccessLevel = (integration: SciaIntegration, value: AccessLevel) => {
-    setSelectedAccessLevels((current) => {
-      return { ...current, [integration.id]: value }
+  const setScopeGroup = (integration: SciaIntegration, groupID: string, scopeID: string) => {
+    setSelectedScopeGroups((current) => {
+      return {
+        ...current,
+        [integration.id]: {
+          ...(current[integration.id] || {}),
+          [groupID]: scopeID,
+        },
+      }
     })
   }
 
@@ -78,7 +80,7 @@ export default function IntegrationsPage() {
       const client = createAgentAPIProxyClientFromStorage()
       const response = await client.createIntegrationAuthorizationURL(integration.id, {
         redirect_uri: `${window.location.origin}/api/oauth/${integration.provider}/callback`,
-        scope_ids: scopeIDsForAccessLevel(integration, selectedAccessLevels[integration.id] || defaultAccessLevel(integration)),
+        scope_ids: scopeIDsForSelectedGroups(integration, selectedScopeGroups[integration.id] || defaultScopeGroups(integration)),
       })
       window.location.href = response.authorization_url
     } catch (err) {
@@ -159,38 +161,62 @@ export default function IntegrationsPage() {
                   </div>
 
                   {integration.scopes.length > 0 && (
-                    <fieldset className="mt-5">
-                      <legend className="text-sm font-semibold text-gray-900 dark:text-white">
-                        詳しいアクセス
-                      </legend>
-                      <div className="mt-3 grid gap-2">
-                        {accessOptions.map((option) => {
-                          const checked = (selectedAccessLevels[integration.id] || defaultAccessLevel(integration)) === option.value
-                          const disabled = option.value !== 'none' && scopeIDsForAccessLevel(integration, option.value).length === 0
+                    <div className="mt-5 space-y-3">
+                      <div>
+                        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+                          アクセスを許可する
+                        </h3>
+                      </div>
+                      <div className="space-y-3">
+                        {scopeGroups(integration).map((group) => {
+                          const selectedScopeID = selectedScopeGroups[integration.id]?.[group.id] ?? defaultScopeForGroup(group)
                           return (
-                            <label
-                              key={option.value}
-                              className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 text-sm transition-colors ${
-                                checked
-                                  ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-100'
-                                  : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/60'
-                              } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                            <fieldset
+                              key={group.id}
+                              className="rounded-md border border-gray-200 p-3 dark:border-gray-700"
                             >
-                              <input
-                                type="radio"
-                                name={`${integration.id}-access`}
-                                value={option.value}
-                                checked={checked}
-                                disabled={disabled}
-                                onChange={() => setAccessLevel(integration, option.value)}
-                                className="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
-                              />
-                              <span className="font-medium">{option.label}</span>
-                            </label>
+                              <legend className="px-1 text-sm font-medium text-gray-900 dark:text-white">
+                                {group.name}
+                              </legend>
+                              {group.desc && (
+                                <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                                  {group.desc}
+                                </p>
+                              )}
+                              <div className="grid gap-2">
+                                {group.scopes.map((scope) => (
+                                  <ScopeRadio
+                                    key={scope.id}
+                                    integrationID={integration.id}
+                                    groupID={group.id}
+                                    scope={scope}
+                                    checked={selectedScopeID === scope.id}
+                                    onChange={() => setScopeGroup(integration, group.id, scope.id)}
+                                  />
+                                ))}
+                                <label
+                                  className={`flex cursor-pointer items-start gap-3 rounded-md border p-3 text-sm transition-colors ${
+                                    selectedScopeID === denyScopeValue
+                                      ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-100'
+                                      : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/60'
+                                  }`}
+                                >
+                                  <input
+                                    type="radio"
+                                    name={`${integration.id}-${group.id}`}
+                                    value={denyScopeValue}
+                                    checked={selectedScopeID === denyScopeValue}
+                                    onChange={() => setScopeGroup(integration, group.id, denyScopeValue)}
+                                    className="mt-0.5 h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+                                  />
+                                  <span className="font-medium">許可しない</span>
+                                </label>
+                              </div>
+                            </fieldset>
                           )
                         })}
                       </div>
-                    </fieldset>
+                    </div>
                   )}
 
                   <button
@@ -212,64 +238,81 @@ export default function IntegrationsPage() {
   )
 }
 
-function defaultAccessLevel(integration: SciaIntegration): AccessLevel {
-  if (scopeIDsForAccessLevel(integration, 'read').length > 0) return 'read'
-  if (scopeIDsForAccessLevel(integration, 'read_write').length > 0) return 'read_write'
-  return 'none'
+function ScopeRadio({
+  integrationID,
+  groupID,
+  scope,
+  checked,
+  onChange,
+}: {
+  integrationID: string
+  groupID: string
+  scope: IntegrationScope
+  checked: boolean
+  onChange: () => void
+}) {
+  return (
+    <label
+      className={`flex items-start gap-3 rounded-md border p-3 text-sm transition-colors ${
+        checked
+          ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-100'
+          : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/60'
+      } ${scope.enabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
+    >
+      <input
+        type="radio"
+        name={`${integrationID}-${groupID}`}
+        value={scope.id}
+        checked={checked}
+        disabled={!scope.enabled}
+        onChange={onChange}
+        className="mt-0.5 h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+      />
+      <span className="min-w-0">
+        <span className="block font-medium text-gray-900 dark:text-white">
+          {scope.name}
+        </span>
+        {scope.desc && (
+          <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+            {scope.desc}
+          </span>
+        )}
+      </span>
+    </label>
+  )
 }
 
-function scopeIDsForAccessLevel(integration: SciaIntegration, level: AccessLevel): string[] {
-  if (level === 'none') return []
-
-  const scopes = integration.scopes.filter((scope) => scope.enabled)
-  if (level === 'read_write') {
-    return preferredScopesByGroup(scopes, 'write').map((scope) => scope.id)
+function defaultScopeGroups(integration: SciaIntegration): Record<string, string> {
+  const selected: Record<string, string> = {}
+  for (const group of scopeGroups(integration)) {
+    selected[group.id] = defaultScopeForGroup(group)
   }
-
-  return preferredScopesByGroup(scopes, 'read').map((scope) => scope.id)
+  return selected
 }
 
-function preferredScopesByGroup(scopes: IntegrationScope[], preference: 'read' | 'write'): IntegrationScope[] {
-  const grouped = new Map<string, IntegrationScope[]>()
-  const standalone: IntegrationScope[] = []
+function defaultScopeForGroup(group: ScopeGroup): string {
+  return group.scopes.find((scope) => scope.enabled)?.id || denyScopeValue
+}
 
-  for (const scope of scopes) {
-    if (!scope.group) {
-      standalone.push(scope)
-      continue
+function scopeIDsForSelectedGroups(integration: SciaIntegration, selectedGroups: Record<string, string>): string[] {
+  const enabledScopeIDs = new Set(integration.scopes.filter((scope) => scope.enabled).map((scope) => scope.id))
+  return Object.values(selectedGroups).filter((scopeID) => scopeID !== denyScopeValue && enabledScopeIDs.has(scopeID))
+}
+
+type ScopeGroup = { id: string; name: string; desc?: string; scopes: IntegrationScope[] }
+
+function scopeGroups(integration: SciaIntegration): ScopeGroup[] {
+  const groups = new Map<string, ScopeGroup>()
+  for (const scope of integration.scopes) {
+    const groupID = scope.group || scope.id
+    const group = groups.get(groupID) || {
+      id: groupID,
+      name: scope.group_name || scope.name,
+      desc: scope.group_desc,
+      scopes: [],
     }
-    const groupScopes = grouped.get(scope.group) || []
-    groupScopes.push(scope)
-    grouped.set(scope.group, groupScopes)
+    group.scopes.push(scope)
+    groups.set(groupID, group)
   }
-
-  const selected = Array.from(grouped.values())
-    .map((groupScopes) => selectScope(groupScopes, preference))
-    .filter((scope): scope is IntegrationScope => Boolean(scope))
-
-  const standaloneScopes = standalone.filter((scope) => {
-    const type = scopeAccessType(scope)
-    return preference === 'write' ? type !== 'read' : type === 'read'
-  })
-
-  return [...selected, ...standaloneScopes]
-}
-
-function selectScope(scopes: IntegrationScope[], preference: 'read' | 'write'): IntegrationScope | undefined {
-  const readScopes = scopes.filter((scope) => scopeAccessType(scope) === 'read')
-  const writeScopes = scopes.filter((scope) => scopeAccessType(scope) === 'write')
-
-  if (preference === 'write') {
-    return writeScopes[0] || scopes[0]
-  }
-
-  return readScopes[0]
-}
-
-function scopeAccessType(scope: IntegrationScope): 'read' | 'write' {
-  const text = `${scope.id} ${scope.name} ${scope.desc || ''}`.toLowerCase()
-  if (/(write|read_write|read-write|read\/write|edit|create|delete|manage|admin|modify|full|post|send)/.test(text)) {
-    return 'write'
-  }
-  return 'read'
+  return Array.from(groups.values())
 }

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -257,14 +257,13 @@ function ScopeRadio({
         checked
           ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-100'
           : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/60'
-      } ${scope.enabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
+      } cursor-pointer`}
     >
       <input
         type="radio"
         name={`${integrationID}-${groupID}`}
         value={scope.id}
         checked={checked}
-        disabled={!scope.enabled}
         onChange={onChange}
         className="mt-0.5 h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
       />
@@ -295,8 +294,8 @@ function defaultScopeForGroup(group: ScopeGroup): string {
 }
 
 function scopeIDsForSelectedGroups(integration: SciaIntegration, selectedGroups: Record<string, string>): string[] {
-  const enabledScopeIDs = new Set(integration.scopes.filter((scope) => scope.enabled).map((scope) => scope.id))
-  return Object.values(selectedGroups).filter((scopeID) => scopeID !== denyScopeValue && enabledScopeIDs.has(scopeID))
+  const scopeIDs = new Set(integration.scopes.map((scope) => scope.id))
+  return Object.values(selectedGroups).filter((scopeID) => scopeID !== denyScopeValue && scopeIDs.has(scopeID))
 }
 
 type ScopeGroup = { id: string; name: string; desc?: string; scopes: IntegrationScope[] }


### PR DESCRIPTION
## Summary
- Show integrations in a denser card grid
- Replace per-scope controls with a three-option access radio group
- Convert selected access level into OAuth scope_ids when connecting

## Verification
- npm run type-check
- npm run lint (existing warnings only)
- npm run build (existing warnings only)