### PR TITLE
Add integration revoke action

### DIFF
--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { CheckCircle, ExternalLink, RefreshCw, Trash2 } from 'lucide-react'
+import { CheckCircle, ExternalLink, RefreshCw, Unlink } from 'lucide-react'
 import TopBar from '../components/TopBar'
 import NavigationTabs from '../components/NavigationTabs'
 import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
@@ -261,11 +261,13 @@ export default function IntegrationsPage() {
                       type="button"
                       onClick={() => startOAuth(integration)}
                       disabled={!integration.authorization_url_endpoint || connectingIntegrationID === integration.id || revokingIntegrationID === integration.id}
-                      className="inline-flex min-w-0 flex-1 items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                      className={`inline-flex min-w-0 items-center justify-center gap-1.5 rounded-md bg-blue-600 font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
+                        integration.connected ? 'px-2.5 py-1.5 text-xs' : 'flex-1 px-3 py-2 text-sm'
+                      }`}
                     >
-                      <ExternalLink className="h-4 w-4 shrink-0" />
+                      <ExternalLink className={`${integration.connected ? 'h-3.5 w-3.5' : 'h-4 w-4'} shrink-0`} />
                       <span className="truncate">
-                        {connectingIntegrationID === integration.id ? 'Connecting...' : integration.connected ? `Reconnect ${integration.name}` : `Connect ${integration.name}`}
+                        {connectingIntegrationID === integration.id ? 'Connecting...' : integration.connected ? 'Reconnect' : `Connect ${integration.name}`}
                       </span>
                     </button>
                     {integration.connected && (
@@ -275,9 +277,10 @@ export default function IntegrationsPage() {
                         disabled={revokingIntegrationID === integration.id || connectingIntegrationID === integration.id}
                         aria-label={`Revoke ${integration.name}`}
                         title={`Revoke ${integration.name}`}
-                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-red-200 bg-white text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:border-red-900/70 dark:bg-gray-800 dark:text-red-300 dark:hover:bg-red-900/20 dark:focus:ring-offset-gray-800"
+                        className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-red-200 bg-white px-2.5 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:border-red-900/70 dark:bg-gray-800 dark:text-red-300 dark:hover:bg-red-900/20 dark:focus:ring-offset-gray-800"
                       >
-                        <Trash2 className={`h-4 w-4 ${revokingIntegrationID === integration.id ? 'animate-pulse' : ''}`} />
+                        <Unlink className={`h-3.5 w-3.5 ${revokingIntegrationID === integration.id ? 'animate-pulse' : ''}`} />
+                        <span>{revokingIntegrationID === integration.id ? 'Revoking...' : 'Revoke'}</span>
                       </button>
                     )}
                   </div>

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { CheckCircle, ExternalLink, RefreshCw } from 'lucide-react'
+import { CheckCircle, ExternalLink, RefreshCw, Trash2 } from 'lucide-react'
 import TopBar from '../components/TopBar'
 import NavigationTabs from '../components/NavigationTabs'
 import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
@@ -17,6 +17,7 @@ export default function IntegrationsPage() {
   const [selectedScopeGroups, setSelectedScopeGroups] = useState<SelectedScopeGroups>({})
   const [loading, setLoading] = useState(true)
   const [connectingIntegrationID, setConnectingIntegrationID] = useState<string | null>(null)
+  const [revokingIntegrationID, setRevokingIntegrationID] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const { showToast } = useToast()
 
@@ -91,6 +92,23 @@ export default function IntegrationsPage() {
       console.error('Failed to create authorization URL:', err)
       showToast('OAuth URL を作成できませんでした', 'error')
       setConnectingIntegrationID(null)
+    }
+  }
+
+  const revokeIntegration = async (integration: SciaIntegration) => {
+    if (!integration.connected) return
+    if (!window.confirm(`${integration.name} の連携を解除しますか？`)) return
+    setRevokingIntegrationID(integration.id)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      await client.revokeIntegration(integration.id)
+      showToast(`${integration.name} 連携を解除しました`, 'success')
+      await loadIntegrations()
+    } catch (err) {
+      console.error('Failed to revoke integration:', err)
+      showToast('連携を解除できませんでした', 'error')
+    } finally {
+      setRevokingIntegrationID(null)
     }
   }
 
@@ -238,15 +256,31 @@ export default function IntegrationsPage() {
                     </div>
                   )}
 
-                  <button
-                    type="button"
-                    onClick={() => startOAuth(integration)}
-                    disabled={!integration.authorization_url_endpoint || connectingIntegrationID === integration.id}
-                    className="mt-auto inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-                  >
-                    <ExternalLink className="h-4 w-4" />
-                    {connectingIntegrationID === integration.id ? 'Connecting...' : integration.connected ? `Reconnect ${integration.name}` : `Connect ${integration.name}`}
-                  </button>
+                  <div className="mt-auto flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => startOAuth(integration)}
+                      disabled={!integration.authorization_url_endpoint || connectingIntegrationID === integration.id || revokingIntegrationID === integration.id}
+                      className="inline-flex min-w-0 flex-1 items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                    >
+                      <ExternalLink className="h-4 w-4 shrink-0" />
+                      <span className="truncate">
+                        {connectingIntegrationID === integration.id ? 'Connecting...' : integration.connected ? `Reconnect ${integration.name}` : `Connect ${integration.name}`}
+                      </span>
+                    </button>
+                    {integration.connected && (
+                      <button
+                        type="button"
+                        onClick={() => revokeIntegration(integration)}
+                        disabled={revokingIntegrationID === integration.id || connectingIntegrationID === integration.id}
+                        aria-label={`Revoke ${integration.name}`}
+                        title={`Revoke ${integration.name}`}
+                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-red-200 bg-white text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:border-red-900/70 dark:bg-gray-800 dark:text-red-300 dark:hover:bg-red-900/20 dark:focus:ring-offset-gray-800"
+                      >
+                        <Trash2 className={`h-4 w-4 ${revokingIntegrationID === integration.id ? 'animate-pulse' : ''}`} />
+                      </button>
+                    )}
+                  </div>
                 </section>
               ))}
             </div>

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -74,7 +74,7 @@ import {
   TaskListResponse,
   TaskListParams
 } from '../types/task';
-import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, SciaAuthorizationURLResponse, SciaIntegrationsResponse, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
+import { loadFullGlobalSettings, getDefaultProxySettings, addRepositoryToHistory, SettingsData, GitSyncConfig, GoogleOAuthStatus, SciaAuthorizationURLResponse, SciaIntegrationsResponse, SciaRevokeResponse, getSendGithubTokenOnSessionStart, getMemoryEnabled, getMemorySummarizeDrafts, AvailableManager } from '../types/settings';
 import { ProxyUserInfo } from '../types/user';
 import { handleAuthenticationRequired, isAuthenticationRequiredError } from './auth-error-handler';
 
@@ -1474,6 +1474,16 @@ export class AgentAPIProxyClient {
     return await this.makeRequest<SciaAuthorizationURLResponse>(`/integrations/${encodeURIComponent(integrationId)}/authorization-url`, {
       method: 'POST',
       body: JSON.stringify(request),
+    });
+  }
+
+  /**
+   * Revoke/disconnect a scia OAuth integration for the current user.
+   */
+  async revokeIntegration(integrationId: string): Promise<SciaRevokeResponse> {
+    return await this.makeRequest<SciaRevokeResponse>(`/integrations/${encodeURIComponent(integrationId)}/revoke`, {
+      method: 'POST',
+      body: JSON.stringify({}),
     });
   }
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -114,6 +114,11 @@ export interface SciaAuthorizationURLResponse {
   scope?: string;
 }
 
+export interface SciaRevokeResponse {
+  revoked: boolean;
+  credential_id?: string;
+}
+
 // 設定データ（API で保存）
 export interface SettingsData {
   bedrock?: BedrockConfig;


### PR DESCRIPTION
## Summary
- add a Revoke action for connected integrations
- call the new proxy revoke endpoint and refresh integration status after success
- add typed client support for integration revoke responses

## Tests
- npm run type-check
- npm run lint (passes with existing warnings)