### PR TITLE
Track message SSE connection status

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -392,10 +392,14 @@ async function handleSSERequest(
   targetUrl: string,
   headers: Headers
 ): Promise<NextResponse> {
+  const encoder = new TextEncoder();
+
   try {
     // Create a ReadableStream to handle Server-Sent Events
     const stream = new ReadableStream({
       async start(controller) {
+        let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
         try {
           const response = await fetch(targetUrl, {
             method: 'GET',
@@ -414,11 +418,27 @@ async function handleSSERequest(
           const reader = response.body?.getReader();
           if (!reader) {
             controller.enqueue(
-              new TextEncoder().encode(`data: ${JSON.stringify({ error: 'No response body' })}\n\n`)
+              encoder.encode(`data: ${JSON.stringify({ error: 'No response body' })}\n\n`)
             );
             controller.close();
             return;
           }
+
+          // Flush headers to the browser immediately. Some SSE backends do not
+          // send data until the next agent event, but the UI still needs to know
+          // that the message stream itself is connected.
+          controller.enqueue(encoder.encode(': connected\n\n'));
+
+          heartbeatTimer = setInterval(() => {
+            try {
+              controller.enqueue(encoder.encode(': heartbeat\n\n'));
+            } catch {
+              if (heartbeatTimer) {
+                clearInterval(heartbeatTimer);
+                heartbeatTimer = null;
+              }
+            }
+          }, 15000);
 
           // Read the stream and forward chunks
           while (true) {
@@ -434,9 +454,13 @@ async function handleSSERequest(
         } catch (error) {
           console.error('SSE stream error:', error);
           controller.enqueue(
-            new TextEncoder().encode(`data: ${JSON.stringify({ error: 'Stream error', details: error instanceof Error ? error.message : 'Unknown error' })}\n\n`)
+            encoder.encode(`data: ${JSON.stringify({ error: 'Stream error', details: error instanceof Error ? error.message : 'Unknown error' })}\n\n`)
           );
           controller.close();
+        } finally {
+          if (heartbeatTimer) {
+            clearInterval(heartbeatTimer);
+          }
         }
       },
       cancel() {

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -32,6 +32,8 @@ interface AgentStatus {
   message?: string;
 }
 
+type MessageSSEConnectionStatus = 'connecting' | 'connected';
+
 // Normalize raw proxy statuses to the three values the UI knows.
 // The proxy can return 'cancel', 'stopped', etc. after a cancel — treat them as stable.
 function normalizeAgentStatus(raw: string): 'stable' | 'running' | 'error' {
@@ -363,6 +365,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       setIsInitialLoadComplete(false);
       setIsStarting(false);
       setACPInfo(null);
+      setMessageSSEConnectionStatus('connecting');
       // Clear any pending retry timer
       if (retryTimerRef.current) {
         clearTimeout(retryTimerRef.current);
@@ -430,6 +433,15 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     setPendingAction(action);
                     setShowQuestionModal(true);
                   },
+                  onConnectionOpen: () => {
+                    setMessageSSEConnectionStatus('connected');
+                  },
+                  onConnectionConnecting: () => {
+                    setMessageSSEConnectionStatus('connecting');
+                  },
+                  onConnectionClosed: () => {
+                    setMessageSSEConnectionStatus('connecting');
+                  },
                   onError: (err: Event | Error) => {
                     console.error('[ACP] SSE error callback (from AgentAPIChat):', err);
                   },
@@ -472,6 +484,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   console.log(`[ACP] initializeChat: closing existing SSE connection`);
                   acpEventSourceRef.current.close();
                 }
+                setMessageSSEConnectionStatus('connecting');
 
                 // Subscribe to SSE. In acpServerEnabled mode, route through the proxy's
                 // GET /acp endpoint with Acp-Session-Id header. Otherwise connect directly
@@ -506,6 +519,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 setIsStarting(false);
 
                 if (!acpEventSourceRef.current) {
+                  setMessageSSEConnectionStatus('connecting');
                   acpEventSourceRef.current = acpServerClientRef.current.subscribeToEvents(sessionId, acpCallbacks);
                 }
                 return;
@@ -647,6 +661,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [agentStatus, setAgentStatus] = useState<AgentStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [messageSSEConnectionStatus, setMessageSSEConnectionStatus] = useState<MessageSSEConnectionStatus>('connecting');
   const [isStarting, setIsStarting] = useState(false);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
@@ -693,6 +708,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [isSettingACPModel, setIsSettingACPModel] = useState(false);
   const [acpModelMessage, setACPModelMessage] = useState<string | null>(null);
   const isACPSession = !!acpInfo || isACPAgentType(agentType) || acpServerEnabled;
+  const isMessageSSEConnected = !isACPSession || messageSSEConnectionStatus === 'connected';
+  const isConnectionStatusConnected = isConnected && isMessageSSEConnected;
+  const connectionStatusLabel = isConnectionStatusConnected ? 'Connected' : 'Connecting';
+  const connectionStatusTextClass = isConnectionStatusConnected
+    ? 'text-green-600 dark:text-green-400'
+    : 'text-yellow-600 dark:text-yellow-400';
+  const connectionStatusDotClass = isConnectionStatusConnected ? 'bg-green-500' : 'bg-yellow-500';
   const tokenUsage = useMemo(() => getSessionTokenUsage(acpInfo, messages), [acpInfo, messages]);
   const [acpPendingPermission, setACPPendingPermission] = useState<{ action: PendingAction; rpcId: number } | null>(null);
   const acpNextPromptId = useRef(1);
@@ -1181,6 +1203,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       if (acpEventSourceRef.current) {
         acpEventSourceRef.current.close();
       }
+      setMessageSSEConnectionStatus('connecting');
 
       const reconnectCallbacks = {
           onMessage: (msg: SessionMessage) => {
@@ -1230,6 +1253,15 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             setACPPendingPermission({ action, rpcId });
             setPendingAction(action);
             setShowQuestionModal(true);
+          },
+          onConnectionOpen: () => {
+            setMessageSSEConnectionStatus('connected');
+          },
+          onConnectionConnecting: () => {
+            setMessageSSEConnectionStatus('connecting');
+          },
+          onConnectionClosed: () => {
+            setMessageSSEConnectionStatus('connecting');
           },
           onError: (err: Event | Error) => {
             console.error('[ACP] SSE error callback (from visibility reconnect):', err);
@@ -1647,9 +1679,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             
             {/* Connection Status */}
             <div className="flex items-center space-x-1 sm:space-x-2">
-              <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`}></div>
-              <span className={`text-xs sm:text-sm ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'} hidden sm:inline`}>
-                {isConnected ? 'Connected' : 'Disconnected'}
+              <div className={`w-2 h-2 rounded-full ${connectionStatusDotClass}`}></div>
+              <span className={`text-xs sm:text-sm ${connectionStatusTextClass} hidden sm:inline`}>
+                {connectionStatusLabel}
               </span>
             </div>
 
@@ -1982,7 +2014,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             </div>
             <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
               <span className="text-gray-500 dark:text-gray-400">Connection</span>
-              <span className="break-all text-gray-900 dark:text-gray-100">{isConnected ? 'connected' : 'disconnected'}</span>
+              <span className="break-all text-gray-900 dark:text-gray-100">{connectionStatusLabel.toLowerCase()}</span>
             </div>
             <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
               <span className="text-gray-500 dark:text-gray-400">Tokens so far</span>

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -127,6 +127,9 @@ export interface ACPServerEventCallbacks {
   onTitleUpdate?: (title: string) => void;
   onModeUpdate?: (mode: string) => void;
   onConfigOptionsUpdate?: (configOptions: ACPConfigOption[]) => void;
+  onConnectionOpen?: () => void;
+  onConnectionConnecting?: (attempt?: number, delayMs?: number) => void;
+  onConnectionClosed?: () => void;
   onError?: (err: Event | Error) => void;
 }
 
@@ -606,10 +609,13 @@ export class ACPServerClient {
         if (!response.ok || !response.body) {
           callbacks.onError?.(new Error(`[ACPServerClient] SSE connection failed: ${response.status}`));
           if (!abortController.signal.aborted) {
+            callbacks.onConnectionConnecting?.(undefined, retryDelay);
             setTimeout(() => connect(Math.min(retryDelay * 2, 30000)), retryDelay);
           }
           return;
         }
+
+        callbacks.onConnectionOpen?.();
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
@@ -633,18 +639,25 @@ export class ACPServerClient {
 
         // Stream closed normally — reconnect after a short delay
         if (!abortController.signal.aborted) {
+          callbacks.onConnectionConnecting?.(undefined, 1000);
           setTimeout(() => connect(1000), 1000);
         }
       } catch (err) {
         if (abortController.signal.aborted) return;
         console.error('[ACPServerClient] SSE fetch error:', err);
+        callbacks.onConnectionConnecting?.(undefined, retryDelay);
         setTimeout(() => connect(Math.min(retryDelay * 2, 30000)), retryDelay);
       }
     };
 
     connect();
 
-    return { close: () => abortController.abort() };
+    return {
+      close: () => {
+        abortController.abort();
+        callbacks.onConnectionClosed?.();
+      },
+    };
   }
 }
 

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -334,6 +334,12 @@ export interface ACPSessionCallbacks {
   onStatus: (status: AgentStatus) => void;
   /** Called when a permission request arrives from the agent. */
   onPermission: (action: PendingAction, rpcId: number) => void;
+  /** Called when the message SSE stream opens. */
+  onConnectionOpen?: () => void;
+  /** Called when the message SSE stream is connecting or retrying. */
+  onConnectionConnecting?: (attempt?: number, delayMs?: number) => void;
+  /** Called when the message SSE stream closes permanently. */
+  onConnectionClosed?: () => void;
   /** Called on transport errors. */
   onError: (error: Error) => void;
 }
@@ -2402,6 +2408,7 @@ export class AgentAPIProxyClient {
       {
         onOpen: () => {
           console.log(`[ACP] SSE connection opened (url=${sseUrl}, acpSessionId=${acpSessionId})`);
+          callbacks.onConnectionOpen?.();
         },
         onMessage: (event: MessageEvent) => {
           try {
@@ -2641,12 +2648,15 @@ export class AgentAPIProxyClient {
         },
         onTransientError: (event, state) => {
           console.warn(`[ACP] SSE transient error; browser is reconnecting (url=${sseUrl}, acpSessionId=${acpSessionId}, readyState=${state})`, event);
+          callbacks.onConnectionConnecting?.();
         },
         onReconnect: (attempt, delayMs) => {
           console.warn(`[ACP] SSE closed; recreating EventSource in ${delayMs}ms (url=${sseUrl}, acpSessionId=${acpSessionId}, attempt=${attempt})`);
+          callbacks.onConnectionConnecting?.(attempt, delayMs);
         },
         onClosed: (event, state) => {
           console.error(`[ACP] SSE connection permanently closed (url=${sseUrl}, acpSessionId=${acpSessionId}, readyState=${state})`, event);
+          callbacks.onConnectionClosed?.();
           callbacks.onError(new Error(`ACP SSE connection closed (readyState=${state})`));
         },
       },


### PR DESCRIPTION
## Summary
- Track ACP message SSE open/connecting state separately from the existing session connection state
- Show the chat header connection indicator as Connected only when the message SSE is open
- Return the indicator to Connecting while SSE retries for both per-session EventSource and ACP server fetch streams

## Verification
- npm run type-check
- npm run lint (passes with existing warnings)
- npm run test (fails before collecting tests due to Vitest/Tinypool environment error: process.channel?.unref is not a function)