### PR TITLE
Show session startup failure reasons

### DIFF
--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -18,6 +18,8 @@ interface SessionCardProps {
 
 export default function SessionCard({ session, onDelete, isDeleting, isSelected, onToggleSelect, isSelectionMode }: SessionCardProps) {
   const [isMobile, setIsMobile] = useState(false)
+  const statusReason = session.status_reason?.trim()
+  const showStatusReason = !!statusReason && ['error', 'timeout', 'unhealthy'].includes(session.status)
 
   useEffect(() => {
     const checkMobile = () => {
@@ -88,6 +90,12 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
             </h3>
             <StatusBadge status={session.status} />
           </div>
+
+          {showStatusReason && (
+            <p className="mb-2 text-xs text-red-700 dark:text-red-300 break-words">
+              {truncateText(statusReason, isMobile ? 120 : 220)}
+            </p>
+          )}
 
           {/* セッション情報 */}
           <div className="flex flex-col sm:flex-row sm:items-center text-xs text-gray-500 dark:text-gray-400 space-y-1 sm:space-y-0 sm:space-x-4 mb-3">

--- a/src/app/components/SessionListSidebar.tsx
+++ b/src/app/components/SessionListSidebar.tsx
@@ -19,6 +19,8 @@ function getStatusDotClass(status: SessionStatus): string {
     case 'starting': return 'bg-yellow-400 animate-pulse'
     case 'creating': return 'bg-blue-400 animate-pulse'
     case 'unhealthy':return 'bg-red-500'
+    case 'error':    return 'bg-red-500'
+    case 'timeout':  return 'bg-orange-500'
     default:         return 'bg-gray-300 dark:bg-gray-600'
   }
 }
@@ -33,6 +35,10 @@ function getSessionTitle(session: Session): string {
   if (typeof metaDesc === 'string' && metaDesc.trim()) return metaDesc.trim()
   if (session.description?.trim()) return session.description.trim()
   return `#${session.session_id.substring(0, 8)}`
+}
+
+function isFailureStatus(status: SessionStatus): boolean {
+  return status === 'error' || status === 'timeout' || status === 'unhealthy'
 }
 
 function formatRelativeTime(dateStr?: string): string {
@@ -80,10 +86,15 @@ export default function SessionListSidebar({
       const idx = prev.findIndex(s => s.session_id === event.session_id)
       if (idx === -1) return prev
       const updated = [...prev]
-      updated[idx] = { ...updated[idx], status: event.status as SessionStatus }
+      updated[idx] = {
+        ...updated[idx],
+        status: event.status as SessionStatus,
+        status_reason: event.status_reason ?? updated[idx].status_reason,
+        updated_at: event.timestamp,
+      }
       return updated
     })
-    if (event.status === 'active' || event.status === 'stopped') {
+    if (event.status === 'active' || event.status === 'stopped' || event.status === 'error' || event.status === 'timeout') {
       fetchSessions()
     }
   }, [fetchSessions])
@@ -149,6 +160,7 @@ export default function SessionListSidebar({
               const title = getSessionTitle(session)
               const timeStr = formatRelativeTime(session.updated_at || session.started_at)
               const isDeleting = deletingIds.has(session.session_id)
+              const statusReason = session.status_reason?.trim()
 
               return (
                 <li key={session.session_id} className="group/item relative">
@@ -178,12 +190,16 @@ export default function SessionListSidebar({
                             ? 'text-gray-900 dark:text-gray-100 font-medium'
                             : 'text-gray-700 dark:text-gray-300'
                         }`}
-                        title={title}
+                        title={statusReason ? `${title}\n${statusReason}` : title}
                       >
                         {title}
                       </p>
                       <p className="text-[10px] text-gray-400 dark:text-gray-600 mt-0.5 leading-none">
-                        {session.status === 'running' ? (
+                        {isFailureStatus(session.status) && statusReason ? (
+                          <span className="text-red-500 dark:text-red-400 truncate block" title={statusReason}>
+                            {statusReason}
+                          </span>
+                        ) : session.status === 'running' ? (
                           <span className="text-yellow-500 dark:text-yellow-400">実行中</span>
                         ) : running && session.status !== 'active' ? (
                           <span className="text-yellow-500 dark:text-yellow-400">

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -11,7 +11,7 @@ import { formatDate, formatRelativeTime } from '../../utils/timeUtils'
 import { truncateText } from '../../utils/textUtils'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 
-function createAgentStatusFromSession(session: Pick<Session, 'status' | 'updated_at'>): AgentStatus {
+function createAgentStatusFromSession(session: Pick<Session, 'status' | 'updated_at' | 'status_reason'>): AgentStatus {
   switch (session.status) {
     case 'running':
       return {
@@ -23,10 +23,17 @@ function createAgentStatusFromSession(session: Pick<Session, 'status' | 'updated
         status: 'stable',
         last_activity: session.updated_at,
       }
+    case 'creating':
+    case 'starting':
+      return {
+        status: 'running',
+        last_activity: session.updated_at,
+      }
     default:
       return {
         status: 'error',
         last_activity: session.updated_at,
+        message: session.status_reason,
       }
   }
 }
@@ -153,19 +160,25 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
       const idx = prev.findIndex(s => s.session_id === event.session_id)
       if (idx === -1) return prev
       const updated = [...prev]
-      updated[idx] = { ...updated[idx], status: event.status as Session['status'] }
+      updated[idx] = {
+        ...updated[idx],
+        status: event.status as Session['status'],
+        status_reason: event.status_reason ?? updated[idx].status_reason,
+        updated_at: event.timestamp,
+      }
       return updated
     })
     setSessionAgentStatus(prev => ({
       ...prev,
       [event.session_id]: createAgentStatusFromSession({
         status: event.status as Session['status'],
+        status_reason: event.status_reason,
         updated_at: event.timestamp,
       }),
     }))
 
     // セッションが active になったタイミングでフルリフレッシュ（メタデータ取得のため）
-    if (event.status === 'active') {
+    if (event.status === 'active' || event.status === 'error' || event.status === 'timeout') {
       fetchSessions()
     }
   }, [fetchSessions])
@@ -399,6 +412,15 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
     }
     if (session.status === 'running') {
       return { status: 'running' as const, colorClass: 'bg-yellow-500 animate-pulse', text: 'Running' }
+    }
+    if (session.status === 'error') {
+      return { status: 'error' as const, colorClass: 'bg-red-500', text: 'Error' }
+    }
+    if (session.status === 'timeout') {
+      return { status: 'timeout' as const, colorClass: 'bg-orange-500', text: 'Timeout' }
+    }
+    if (session.status === 'unhealthy') {
+      return { status: 'unhealthy' as const, colorClass: 'bg-red-500', text: 'Unhealthy' }
     }
 
     // ステータスが取得できていない場合
@@ -777,6 +799,8 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                   const agentStatusInfo = getAgentStatusForSession(session)
                   const description = getSessionDescription(session)
                   const isOld = isOldSession(session)
+                  const statusReason = session.status_reason?.trim()
+                  const isFailedSession = session.status === 'error' || session.status === 'timeout' || session.status === 'unhealthy'
 
                   const isSelected = selectedSessions.has(session.session_id)
                   return (
@@ -788,6 +812,8 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                     } ${
                       isSelected
                         ? 'bg-blue-50 dark:bg-blue-900/20 border-l-2 border-blue-500'
+                        : isFailedSession
+                        ? 'bg-red-50 dark:bg-red-900/10 hover:bg-red-100 dark:hover:bg-red-900/20 border-l-4 border-red-500'
                         : session.status === 'creating' || session.status === 'starting'
                         ? 'bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 hover:from-blue-100 hover:to-indigo-100 dark:hover:from-blue-900/30 dark:hover:to-indigo-900/30 border-l-4 border-blue-500'
                         : isNew
@@ -846,7 +872,7 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                             title={`Agent: ${agentStatusInfo.text}`}
                           />
                           {/* 新規セッション/作成中/起動中バッジ */}
-                          {(isNew || session.status === 'creating' || session.status === 'starting') && (
+                          {(!isFailedSession && (isNew || session.status === 'creating' || session.status === 'starting')) && (
                             <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${
                               session.status === 'creating'
                                 ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
@@ -866,6 +892,12 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                             </span>
                           )}
                         </div>
+
+                        {isFailedSession && statusReason && (
+                          <p className="mb-2 text-xs text-red-700 dark:text-red-300 break-words">
+                            {truncateText(statusReason, isMobile ? 120 : 220)}
+                          </p>
+                        )}
 
                         {/* セッション情報 */}
                         <div className="flex flex-col sm:flex-row sm:items-center text-xs text-gray-500 dark:text-gray-400 space-y-1 sm:space-y-0 sm:space-x-4 mb-3">

--- a/src/app/components/StatusBadge.tsx
+++ b/src/app/components/StatusBadge.tsx
@@ -84,6 +84,22 @@ export default function StatusBadge({ status, className = '' }: StatusBadgeProps
           icon: '🔴',
           label: 'Unhealthy'
         }
+      case 'error':
+        return {
+          bg: 'bg-red-100 dark:bg-red-900',
+          text: 'text-red-800 dark:text-red-200',
+          border: 'border-red-200 dark:border-red-700',
+          icon: '❌',
+          label: 'Error'
+        }
+      case 'timeout':
+        return {
+          bg: 'bg-orange-100 dark:bg-orange-900',
+          text: 'text-orange-800 dark:text-orange-200',
+          border: 'border-orange-200 dark:border-orange-700',
+          icon: '⏱️',
+          label: 'Timeout'
+        }
       case 'stopped':
         return {
           bg: 'bg-gray-100 dark:bg-gray-800',

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -127,6 +127,7 @@ interface AgentStatus {
 export interface ProxySessionStatusEvent {
   session_id: string;
   status: string;
+  status_reason?: string;
   timestamp: string;
 }
 

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -157,7 +157,7 @@ export interface RateLimitInfo {
 }
 
 // Session status types based on agentapi-proxy OpenAPI specification
-export type SessionStatus = 'creating' | 'starting' | 'running' | 'active' | 'unhealthy' | 'stopped' | 'unknown';
+export type SessionStatus = 'creating' | 'starting' | 'running' | 'active' | 'unhealthy' | 'error' | 'timeout' | 'stopped' | 'unknown';
 
 // Resource scope types for team support
 export type ResourceScope = 'user' | 'team';
@@ -167,6 +167,7 @@ export interface Session {
   session_id: string;
   user_id: string;
   status: SessionStatus;
+  status_reason?: string;
   started_at: string;
   updated_at?: string;
   addr?: string;


### PR DESCRIPTION
## Summary
- add status_reason to session and proxy status event types
- keep status_reason when /sessions/status/stream updates session state
- display startup failure reasons in session list cards and the chat sidebar
- add error/timeout session status badge handling

Depends on agentapi-proxy PR: https://github.com/takutakahashi/agentapi-proxy/pull/884

## Verification
- bun run type-check
- bun run lint (passes with existing warnings)
- bun run build (passes with existing warnings)
- bun run test / npx vitest run (blocked before collecting tests by tinypool: this.process.channel?.unref is not a function)