### PR TITLE
feat: show session annotations

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -708,6 +708,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [recentMessages, setRecentMessages] = useState<string[]>([]);
   const [showTemplateModal, setShowTemplateModal] = useState(false);
   const [showPRLinks, setShowPRLinks] = useState(false);
+  const [showSessionActionsMenu, setShowSessionActionsMenu] = useState(false);
   const [sessionAnnotations, setSessionAnnotations] = useState<SessionAnnotations | undefined>();
   const [showFontSettings, setShowFontSettings] = useState(false);
   const [showSessionInfo, setShowSessionInfo] = useState(false);
@@ -1034,20 +1035,22 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           setShowTemplateModal(false)
         } else if (showPRLinks) {
           setShowPRLinks(false)
+        } else if (showSessionActionsMenu) {
+          setShowSessionActionsMenu(false)
         } else if (showFontSettings) {
           setShowFontSettings(false)
         }
       }
     }
 
-    if (showQuestionModal || showTemplateModal || showPRLinks || showFontSettings) {
+    if (showQuestionModal || showTemplateModal || showPRLinks || showSessionActionsMenu || showFontSettings) {
       document.addEventListener('keydown', handleKeyDown)
     }
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [showQuestionModal, showTemplateModal, showPRLinks, showFontSettings])
+  }, [showQuestionModal, showTemplateModal, showPRLinks, showSessionActionsMenu, showFontSettings])
 
   // Listen for font settings changes
   useEffect(() => {
@@ -1831,41 +1834,53 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               </span>
             </div>
 
-            {/* Delete Session Button */}
+            {/* Session actions */}
             {sessionId && (
-              <button
-                onClick={deleteSession}
-                disabled={isDeleting}
-                className="p-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-200 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                title={isDeleting ? 'セッションを削除中...' : 'セッションを削除'}
-              >
-                {isDeleting ? (
-                  <svg className="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-                ) : (
+              <div className="relative">
+                <button
+                  onClick={() => setShowSessionActionsMenu(prev => !prev)}
+                  className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+                  title="セッション操作"
+                  aria-haspopup="menu"
+                  aria-expanded={showSessionActionsMenu}
+                >
                   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 12h.01M12 12h.01M18 12h.01" />
                   </svg>
+                </button>
+                {showSessionActionsMenu && (
+                  <div className="absolute right-0 top-full z-20 mt-2 w-48 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800">
+                    {relatedLinks.length > 0 && (
+                      <button
+                        onClick={() => {
+                          setShowSessionActionsMenu(false);
+                          setShowPRLinks(true);
+                        }}
+                        className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                      >
+                        <span>関連リンク</span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400">{relatedLinks.length}</span>
+                      </button>
+                    )}
+                    <button
+                      onClick={() => {
+                        setShowSessionActionsMenu(false);
+                        deleteSession();
+                      }}
+                      disabled={isDeleting}
+                      className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                    >
+                      <span>{isDeleting ? '削除中...' : 'セッションを削除'}</span>
+                      {isDeleting && (
+                        <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                      )}
+                    </button>
+                  </div>
                 )}
-              </button>
-            )}
-
-            {/* Related Links Button - 必要なときだけ表示 */}
-            {relatedLinks.length > 0 && (
-              <button
-                onClick={() => setShowPRLinks(!showPRLinks)}
-                className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors relative"
-                title={`関連リンク (${relatedLinks.length}件)`}
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.5 6H15a3 3 0 010 6h-1.5m-3 0H9a3 3 0 010-6h1.5m-1 6h5" />
-                </svg>
-                <span className="absolute -top-1 -right-1 bg-gray-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
-                  {relatedLinks.length}
-                </span>
-              </button>
+              </div>
             )}
 
 

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -708,7 +708,6 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [recentMessages, setRecentMessages] = useState<string[]>([]);
   const [showTemplateModal, setShowTemplateModal] = useState(false);
   const [showPRLinks, setShowPRLinks] = useState(false);
-  const [showSessionActionsMenu, setShowSessionActionsMenu] = useState(false);
   const [sessionAnnotations, setSessionAnnotations] = useState<SessionAnnotations | undefined>();
   const [showFontSettings, setShowFontSettings] = useState(false);
   const [showSessionInfo, setShowSessionInfo] = useState(false);
@@ -1035,22 +1034,20 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           setShowTemplateModal(false)
         } else if (showPRLinks) {
           setShowPRLinks(false)
-        } else if (showSessionActionsMenu) {
-          setShowSessionActionsMenu(false)
         } else if (showFontSettings) {
           setShowFontSettings(false)
         }
       }
     }
 
-    if (showQuestionModal || showTemplateModal || showPRLinks || showSessionActionsMenu || showFontSettings) {
+    if (showQuestionModal || showTemplateModal || showPRLinks || showFontSettings) {
       document.addEventListener('keydown', handleKeyDown)
     }
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [showQuestionModal, showTemplateModal, showPRLinks, showSessionActionsMenu, showFontSettings])
+  }, [showQuestionModal, showTemplateModal, showPRLinks, showFontSettings])
 
   // Listen for font settings changes
   useEffect(() => {
@@ -1834,53 +1831,41 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               </span>
             </div>
 
-            {/* Session actions */}
+            {/* Delete Session Button */}
             {sessionId && (
-              <div className="relative">
-                <button
-                  onClick={() => setShowSessionActionsMenu(prev => !prev)}
-                  className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
-                  title="セッション操作"
-                  aria-haspopup="menu"
-                  aria-expanded={showSessionActionsMenu}
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 12h.01M12 12h.01M18 12h.01" />
+              <button
+                onClick={deleteSession}
+                disabled={isDeleting}
+                className="p-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-200 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                title={isDeleting ? 'セッションを削除中...' : 'セッションを削除'}
+              >
+                {isDeleting ? (
+                  <svg className="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
-                </button>
-                {showSessionActionsMenu && (
-                  <div className="absolute right-0 top-full z-20 mt-2 w-48 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800">
-                    {relatedLinks.length > 0 && (
-                      <button
-                        onClick={() => {
-                          setShowSessionActionsMenu(false);
-                          setShowPRLinks(true);
-                        }}
-                        className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
-                      >
-                        <span>関連リンク</span>
-                        <span className="text-xs text-gray-500 dark:text-gray-400">{relatedLinks.length}</span>
-                      </button>
-                    )}
-                    <button
-                      onClick={() => {
-                        setShowSessionActionsMenu(false);
-                        deleteSession();
-                      }}
-                      disabled={isDeleting}
-                      className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
-                    >
-                      <span>{isDeleting ? '削除中...' : 'セッションを削除'}</span>
-                      {isDeleting && (
-                        <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                      )}
-                    </button>
-                  </div>
+                ) : (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
                 )}
-              </div>
+              </button>
+            )}
+
+            {/* Related Links Button - 必要なときだけ表示 */}
+            {relatedLinks.length > 0 && (
+              <button
+                onClick={() => setShowPRLinks(!showPRLinks)}
+                className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors relative"
+                title={`関連リンク (${relatedLinks.length}件)`}
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.5 6H15a3 3 0 010 6h-1.5m-3 0H9a3 3 0 010-6h1.5m-1 6h5" />
+                </svg>
+                <span className="absolute -top-1 -right-1 bg-gray-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
+                  {relatedLinks.length}
+                </span>
+              </button>
             )}
 
 

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -7,7 +7,7 @@ import { createAgentAPIProxyClientFromStorage, ACPSessionInfo, ACPConfigOption, 
 import { AgentAPIProxyError } from '../../lib/agentapi-proxy-client';
 import { createACPServerClientFromStorage, ACPServerClient } from '../../lib/acp-server-client';
 import { getACPServerEnabled } from '../../types/settings';
-import { SessionMessage, SessionMessageListResponse, PendingAction } from '../../types/agentapi';
+import { Session, SessionAnnotations, SessionMessage, SessionMessageListResponse, PendingAction } from '../../types/agentapi';
 import { useBackgroundAwareInterval, usePageVisibility } from '../hooks/usePageVisibility';
 import { messageTemplateManager } from '../../utils/messageTemplateManager';
 import { MessageTemplate } from '../../types/messageTemplate';
@@ -56,39 +56,32 @@ function isValidSessionMessageResponse(response: unknown): response is SessionMe
   );
 }
 
-// PR URLを抽出する関数
-function extractPRUrls(text: string): string[] {
-  if (!text || typeof text !== 'string') return [];
-  
-  // GitHub/GitHub Enterprise PR URLのパターン
-  // 1. GitHub.com: https://github.com/owner/repo/pull/number
-  // 2. GitHub Enterprise: https://ghe.example.com/owner/repo/pull/number
-  // GitHub Enterpriseは任意のドメインで動作するため、より汎用的なパターンを使用
-  const prUrlRegex = /https?:\/\/[^\/\s]+\/[^\/\s]+\/[^\/\s]+\/pull\/\d+/g;
-  const matches = text.match(prUrlRegex);
-  
-  // URLがGitHub形式のPR URLかを検証
-  const validPRUrls = matches ? matches.filter(url => {
-    // URLのパスが /owner/repo/pull/number の形式であることを確認
-    const urlParts = url.split('/');
-    const hasPullPath = urlParts.length >= 7 && urlParts[urlParts.length - 2] === 'pull';
-    
-    // pull以降が数値であることを確認
-    const prNumber = urlParts[urlParts.length - 1];
-    const hasValidPRNumber = /^\d+$/.test(prNumber);
-    
-    return hasPullPath && hasValidPRNumber;
-  }) : [];
-  
-  const result = Array.from(new Set(validPRUrls)); // 重複を除去
-  
-  // デバッグ用ログ
-  if (text.includes('pull')) {
-    console.log('PR URL検索対象:', text);
-    console.log('検出されたPR URL:', result);
-  }
-  
-  return result;
+type RelatedLink = {
+  type: 'pr' | 'issue';
+  url: string;
+};
+
+function getSessionFromList(sessions: Session[], sessionId: string): Session | undefined {
+  return sessions.find(session => session.session_id === sessionId);
+}
+
+function getRelatedLinks(annotations?: SessionAnnotations): RelatedLink[] {
+  return [
+    annotations?.pr_url ? { type: 'pr' as const, url: annotations.pr_url } : null,
+    annotations?.issue_url ? { type: 'issue' as const, url: annotations.issue_url } : null,
+  ].filter((link): link is RelatedLink => Boolean(link));
+}
+
+function getGitHubLinkParts(url: string, type: RelatedLink['type']) {
+  const urlParts = url.split('/');
+  const marker = type === 'pr' ? 'pull' : 'issues';
+  const markerIndex = urlParts.findIndex(part => part === marker);
+  const domain = urlParts[2] || '';
+  const number = markerIndex >= 0 ? urlParts[markerIndex + 1] || '' : '';
+  const owner = markerIndex >= 2 ? urlParts[markerIndex - 2] || '' : '';
+  const repo = markerIndex >= 1 ? urlParts[markerIndex - 1] || '' : '';
+  const repoName = owner && repo ? `${owner}/${repo}` : '';
+  return { domain, number, repoName, isGitHubCom: domain === 'github.com' };
 }
 
 function formatACPModelValue(value: unknown): string | null {
@@ -391,6 +384,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           setIsConnected(true); // Set connected immediately for better UX
 
           if (sessionId) {
+            void agentAPIRef.current.search({ limit: 100 })
+              .then(response => {
+                setSessionAnnotations(getSessionFromList(response.sessions, sessionId)?.annotations);
+                lastSessionAnnotationLoadTimeRef.current = Date.now();
+              })
+              .catch(err => console.warn('Failed to load session annotations:', err));
+
             // ── ACP session detection ───────────────────────────────────────
             // Try GET /{sessionId}/session first. If it succeeds, this is an
             // ACP-transport session – use SSE + JSON-RPC instead of polling.
@@ -708,7 +708,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [recentMessages, setRecentMessages] = useState<string[]>([]);
   const [showTemplateModal, setShowTemplateModal] = useState(false);
   const [showPRLinks, setShowPRLinks] = useState(false);
-  const [prLinks, setPRLinks] = useState<string[]>([]);
+  const [sessionAnnotations, setSessionAnnotations] = useState<SessionAnnotations | undefined>();
   const [showFontSettings, setShowFontSettings] = useState(false);
   const [showSessionInfo, setShowSessionInfo] = useState(false);
   const [showPlanModal, setShowPlanModal] = useState(false);
@@ -736,6 +736,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     : 'text-yellow-600 dark:text-yellow-400';
   const connectionStatusDotClass = isConnectionStatusConnected ? 'bg-green-500' : 'bg-yellow-500';
   const tokenUsage = useMemo(() => getSessionTokenUsage(acpInfo, messages), [acpInfo, messages]);
+  const relatedLinks = useMemo(() => getRelatedLinks(sessionAnnotations), [sessionAnnotations]);
   const [acpPendingPermission, setACPPendingPermission] = useState<{ action: PendingAction; rpcId: number } | null>(null);
   const [acpUserPrompts, setACPUserPrompts] = useState<ACPUserPromptInfo[]>([]);
   const [isLoadingACPPromptHistory, setIsLoadingACPPromptHistory] = useState(false);
@@ -754,6 +755,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const prevMessagesLengthRef = useRef(0);
   const prevAgentStatusRef = useRef<AgentStatus | null>(null);
   const lastLoadTimeRef = useRef<number>(0);
+  const lastSessionAnnotationLoadTimeRef = useRef<number>(0);
   const acpPullThreshold = 72;
 
   useEffect(() => {
@@ -1147,10 +1149,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       const latestMessage = messages[messages.length - 1];
       const latestMessageId = latestMessage && typeof latestMessage.id === 'number' ? latestMessage.id : undefined;
 
-      // Poll messages, status, and pending actions
+      // Poll messages, status, pending actions, and session annotations.
       // For claude agents: fetch only new messages using 'after' parameter
       // For other agents: always fetch all messages to ensure timeline is updated
-      const [sessionMessagesResponse, sessionStatus, pendingActions] = await Promise.all([
+      const shouldRefreshAnnotations = Date.now() - lastSessionAnnotationLoadTimeRef.current > 5000;
+      const [sessionMessagesResponse, sessionStatus, pendingActions, sessionListResponse] = await Promise.all([
         agentAPIRef.current.getSessionMessages(sessionId,
           agentType === 'claude' && latestMessageId !== undefined ? {
             after: latestMessageId, // Get messages with ID > latestMessageId (newer messages)
@@ -1161,7 +1164,8 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           }
         ),
         agentAPIRef.current.getSessionStatus(sessionId),
-        agentAPIRef.current.getPendingActions(sessionId)
+        agentAPIRef.current.getPendingActions(sessionId),
+        shouldRefreshAnnotations ? agentAPIRef.current.search({ limit: 100 }) : Promise.resolve(null)
       ]);
 
       // Validate and safely handle session messages response
@@ -1204,6 +1208,10 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
 
       const normalizedSessionStatus = { ...sessionStatus, status: normalizeAgentStatus(sessionStatus.status) };
       setAgentStatus(normalizedSessionStatus);
+      if (sessionListResponse) {
+        setSessionAnnotations(getSessionFromList(sessionListResponse.sessions, sessionId)?.annotations);
+        lastSessionAnnotationLoadTimeRef.current = Date.now();
+      }
       // When the provisioner has permanently failed, surface the error once.
       if (
         sessionStatus.status === 'error' &&
@@ -1474,16 +1482,6 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         setHasNewMessages(true);
       }
     }
-    
-    // PR URLを抽出してリストに追加
-    const allPRUrls = messages.reduce((urls: string[], message) => {
-      const prUrls = extractPRUrls(message.content);
-      return [...urls, ...prUrls];
-    }, []);
-    
-    // 重複を除去してステートを更新
-    const uniquePRUrls = Array.from(new Set(allPRUrls));
-    setPRLinks(uniquePRUrls);
     
     prevMessagesLengthRef.current = currentLength;
   }, [messages, shouldAutoScroll]);
@@ -1854,18 +1852,18 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               </button>
             )}
 
-            {/* PR Links Button - 必要なときだけ表示 */}
-            {prLinks.length > 0 && (
+            {/* Related Links Button - 必要なときだけ表示 */}
+            {relatedLinks.length > 0 && (
               <button
                 onClick={() => setShowPRLinks(!showPRLinks)}
-                className="p-2 text-purple-500 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-200 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded-md transition-colors relative"
-                title={`プルリクエスト (${prLinks.length}個)`}
+                className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors relative"
+                title={`関連リンク (${relatedLinks.length}件)`}
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.5 6H15a3 3 0 010 6h-1.5m-3 0H9a3 3 0 010-6h1.5m-1 6h5" />
                 </svg>
-                <span className="absolute -top-1 -right-1 bg-purple-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
-                  {prLinks.length}
+                <span className="absolute -top-1 -right-1 bg-gray-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
+                  {relatedLinks.length}
                 </span>
               </button>
             )}
@@ -2522,7 +2520,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         </div>
       )}
 
-      {/* PR Links Modal */}
+      {/* Related Links Modal */}
       {showPRLinks && (
         <div 
           className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
@@ -2536,7 +2534,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between">
                 <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                  プルリクエスト一覧 ({prLinks.length}個)
+                  関連リンク ({relatedLinks.length}件)
                 </h2>
                 <button
                   onClick={() => setShowPRLinks(false)}
@@ -2550,39 +2548,29 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             </div>
             
             <div className="overflow-y-auto max-h-[calc(80vh-8rem)] px-6 py-4">
-              {prLinks.length > 0 ? (
+              {relatedLinks.length > 0 ? (
                 <div className="space-y-3">
-                  {prLinks.map((url, index) => {
-                    // URLからドメイン、リポジトリ名、PR番号を抽出
-                    const urlParts = url.split('/');
-                    const domain = urlParts[2]; // ドメイン名
-                    const prNumber = urlParts[urlParts.length - 1];
-                    
-                    // リポジトリ名を取得（owner/repo形式）
-                    const ownerIndex = urlParts.findIndex(part => part === 'pull') - 2;
-                    const owner = urlParts[ownerIndex] || '';
-                    const repo = urlParts[ownerIndex + 1] || '';
-                    const repoName = owner && repo ? `${owner}/${repo}` : '';
-                    
-                    // GitHub.com以外の場合はドメイン名も表示
-                    const isGitHubCom = domain === 'github.com';
+                  {relatedLinks.map((link, index) => {
+                    const { domain, number, repoName, isGitHubCom } = getGitHubLinkParts(link.url, link.type);
+                    const label = link.type === 'pr' ? 'Pull Request' : 'Issue';
+                    const shortLabel = link.type === 'pr' ? 'PR' : 'Issue';
                     
                     return (
                       <div key={index} className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
                         <div className="flex-1 min-w-0">
                           <div className="font-medium text-sm text-gray-900 dark:text-white truncate">
-                            {repoName}
+                            {repoName || link.url}
                           </div>
                           <div className="text-xs text-gray-500 dark:text-gray-400">
                             {!isGitHubCom && (
-                              <span className="text-purple-600 dark:text-purple-400">{domain} • </span>
+                              <span>{domain} • </span>
                             )}
-                            プルリクエスト #{prNumber}
+                            {label}{number ? ` #${number}` : ''}
                           </div>
                         </div>
                         <div className="flex items-center space-x-2 ml-4">
                           <button
-                            onClick={() => navigator.clipboard.writeText(url)}
+                            onClick={() => navigator.clipboard.writeText(link.url)}
                             className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded"
                             title="URLをコピー"
                           >
@@ -2591,12 +2579,12 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                             </svg>
                           </button>
                           <a
-                            href={url}
+                            href={link.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center px-3 py-1 bg-purple-600 hover:bg-purple-700 text-white text-xs rounded-md transition-colors"
+                            className="inline-flex items-center px-3 py-1 bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 text-xs rounded-md transition-colors"
                           >
-                            開く
+                            {shortLabel}
                             <svg className="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                             </svg>
@@ -2611,7 +2599,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   <svg className="w-12 h-12 mx-auto mb-3 text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
                   </svg>
-                  <p className="text-sm">プルリクエストのURLが見つかりませんでした</p>
+                  <p className="text-sm">関連リンクが見つかりませんでした</p>
                 </div>
               )}
             </div>

--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -123,61 +123,16 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
             <StatusBadge status={session.status} />
           </div>
 
-          {(annotations.runningTask || annotations.prUrl || annotations.issueUrl) && (
+          {annotations.runningTask && (
             <div className="flex flex-wrap items-center gap-2 mb-2">
-              {annotations.runningTask && (
-                <span
-                  className="inline-flex max-w-full items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
-                  title={annotations.runningTask}
-                >
-                  <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-                  <span>作業中:</span>
-                  <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
-                </span>
-              )}
-              {(annotations.prUrl || annotations.issueUrl) && (
-                <div className="relative" onClick={(e) => e.stopPropagation()}>
-                  <button
-                    type="button"
-                    onClick={() => setShowAnnotationMenu(prev => !prev)}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                    aria-label="関連リンク"
-                    title="関連リンク"
-                  >
-                    <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
-                  </button>
-                  {showAnnotationMenu && (
-                    <div className="absolute left-0 top-7 z-20 min-w-32 overflow-hidden rounded-md border border-gray-200 bg-white py-1 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-900">
-                      {annotations.prUrl && (
-                        <a
-                          href={annotations.prUrl}
-                          target="_blank"
-                          rel="noreferrer"
-                          onClick={() => setShowAnnotationMenu(false)}
-                          className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
-                          title={annotations.prUrl}
-                        >
-                          <GitPullRequest className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
-                          {prNumber ? `PR #${prNumber}` : 'PR'}
-                        </a>
-                      )}
-                      {annotations.issueUrl && (
-                        <a
-                          href={annotations.issueUrl}
-                          target="_blank"
-                          rel="noreferrer"
-                          onClick={() => setShowAnnotationMenu(false)}
-                          className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
-                          title={annotations.issueUrl}
-                        >
-                          <CircleDot className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
-                          {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
-                        </a>
-                      )}
-                    </div>
-                  )}
-                </div>
-              )}
+              <span
+                className="inline-flex max-w-full items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+                title={annotations.runningTask}
+              >
+                <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                <span>作業中:</span>
+                <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
+              </span>
             </div>
           )}
 
@@ -247,6 +202,50 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
             </svg>
             <span className="hidden sm:inline">詳細</span>
           </Link>
+
+          {(annotations.prUrl || annotations.issueUrl) && (
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setShowAnnotationMenu(prev => !prev)}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-md border border-gray-300 px-3 py-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white sm:min-h-0 sm:px-3 sm:py-1.5"
+                aria-label="関連リンク"
+                title="関連リンク"
+              >
+                <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+              </button>
+              {showAnnotationMenu && (
+                <div className="absolute right-0 top-full z-20 mt-2 min-w-32 overflow-hidden rounded-md border border-gray-200 bg-white py-1 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-900">
+                  {annotations.prUrl && (
+                    <a
+                      href={annotations.prUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={() => setShowAnnotationMenu(false)}
+                      className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                      title={annotations.prUrl}
+                    >
+                      <GitPullRequest className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
+                      {prNumber ? `PR #${prNumber}` : 'PR'}
+                    </a>
+                  )}
+                  {annotations.issueUrl && (
+                    <a
+                      href={annotations.issueUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={() => setShowAnnotationMenu(false)}
+                      className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                      title={annotations.issueUrl}
+                    >
+                      <CircleDot className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
+                      {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
           
           {onDelete && (
             <button

--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { CircleDot, GitPullRequest, LoaderCircle } from 'lucide-react'
+import { CircleDot, GitPullRequest, LoaderCircle, MoreHorizontal } from 'lucide-react'
 import { Session } from '../../types/agentapi'
 import StatusBadge from './StatusBadge'
 import { formatRelativeTime } from '../../utils/timeUtils'
@@ -44,6 +44,7 @@ function getURLNumber(url: string): string | null {
 
 export default function SessionCard({ session, onDelete, isDeleting, isSelected, onToggleSelect, isSelectionMode }: SessionCardProps) {
   const [isMobile, setIsMobile] = useState(false)
+  const [showAnnotationMenu, setShowAnnotationMenu] = useState(false)
 
   useEffect(() => {
     const checkMobile = () => {
@@ -123,42 +124,59 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
           </div>
 
           {(annotations.runningTask || annotations.prUrl || annotations.issueUrl) && (
-            <div className="flex flex-wrap items-center gap-1.5 mb-2">
+            <div className="flex flex-wrap items-center gap-2 mb-2">
               {annotations.runningTask && (
                 <span
-                  className="inline-flex max-w-full items-center gap-1.5 px-2 py-0.5 text-xs bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800 rounded"
+                  className="inline-flex max-w-full items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
                   title={annotations.runningTask}
                 >
                   <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-                  <span className="font-medium">作業中</span>
+                  <span>作業中:</span>
                   <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
                 </span>
               )}
-              {annotations.prUrl && (
-                <a
-                  href={annotations.prUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-violet-50 text-violet-700 ring-1 ring-violet-200 hover:bg-violet-100 dark:bg-violet-950/40 dark:text-violet-200 dark:ring-violet-800 dark:hover:bg-violet-900/50 rounded"
-                  title={annotations.prUrl}
-                >
-                  <GitPullRequest className="h-3 w-3" aria-hidden="true" />
-                  {prNumber ? `PR #${prNumber}` : 'PR'}
-                </a>
-              )}
-              {annotations.issueUrl && (
-                <a
-                  href={annotations.issueUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-200 dark:ring-emerald-800 dark:hover:bg-emerald-900/50 rounded"
-                  title={annotations.issueUrl}
-                >
-                  <CircleDot className="h-3 w-3" aria-hidden="true" />
-                  {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
-                </a>
+              {(annotations.prUrl || annotations.issueUrl) && (
+                <div className="relative" onClick={(e) => e.stopPropagation()}>
+                  <button
+                    type="button"
+                    onClick={() => setShowAnnotationMenu(prev => !prev)}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                    aria-label="関連リンク"
+                    title="関連リンク"
+                  >
+                    <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  {showAnnotationMenu && (
+                    <div className="absolute left-0 top-7 z-20 min-w-32 overflow-hidden rounded-md border border-gray-200 bg-white py-1 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-900">
+                      {annotations.prUrl && (
+                        <a
+                          href={annotations.prUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={() => setShowAnnotationMenu(false)}
+                          className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                          title={annotations.prUrl}
+                        >
+                          <GitPullRequest className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
+                          {prNumber ? `PR #${prNumber}` : 'PR'}
+                        </a>
+                      )}
+                      {annotations.issueUrl && (
+                        <a
+                          href={annotations.issueUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={() => setShowAnnotationMenu(false)}
+                          className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                          title={annotations.issueUrl}
+                        >
+                          <CircleDot className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
+                          {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
+                        </a>
+                      )}
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           )}

--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
+import { CircleDot, GitPullRequest, LoaderCircle } from 'lucide-react'
 import { Session } from '../../types/agentapi'
 import StatusBadge from './StatusBadge'
 import { formatRelativeTime } from '../../utils/timeUtils'
@@ -16,24 +17,10 @@ interface SessionCardProps {
   isSelectionMode?: boolean
 }
 
-const SESSION_ANNOTATION_METADATA_KEYS = new Set([
-  'annotations',
-  'pr_url',
-  'issue_url',
-  'running_task',
-])
-
 function getSessionAnnotations(session: Session) {
-  const metadataAnnotations = session.metadata?.annotations
-  const annotations = metadataAnnotations && typeof metadataAnnotations === 'object' && !Array.isArray(metadataAnnotations)
-    ? metadataAnnotations as Record<string, unknown>
-    : {}
-
   const pick = (key: 'pr_url' | 'issue_url' | 'description' | 'running_task') => {
     const directValue = session.annotations?.[key]
     if (typeof directValue === 'string' && directValue.trim()) return directValue.trim()
-    const metadataValue = annotations[key] ?? session.metadata?.[key]
-    if (typeof metadataValue === 'string' && metadataValue.trim()) return metadataValue.trim()
     return ''
   }
 
@@ -48,6 +35,11 @@ function getSessionAnnotations(session: Session) {
 function getSessionTitle(session: Session, annotationDescription: string): string {
   if (annotationDescription) return annotationDescription
   return String(session.tags?.description || session.metadata?.description || `Session ${session.session_id.substring(0, 8)}`)
+}
+
+function getURLNumber(url: string): string | null {
+  const match = url.match(/\/(?:pull|issues)\/(\d+)(?:[/?#]|$)/)
+  return match?.[1] ?? null
 }
 
 export default function SessionCard({ session, onDelete, isDeleting, isSelected, onToggleSelect, isSelectionMode }: SessionCardProps) {
@@ -78,12 +70,10 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
   const isOld = isOldSession()
   const annotations = getSessionAnnotations(session)
   const title = getSessionTitle(session, annotations.description)
-  const annotationLinks = [
-    annotations.prUrl ? { label: 'PR', url: annotations.prUrl } : null,
-    annotations.issueUrl ? { label: 'Issue', url: annotations.issueUrl } : null,
-  ].filter(Boolean) as Array<{ label: string; url: string }>
+  const prNumber = annotations.prUrl ? getURLNumber(annotations.prUrl) : null
+  const issueNumber = annotations.issueUrl ? getURLNumber(annotations.issueUrl) : null
   const metadataEntries = session.metadata
-    ? Object.entries(session.metadata).filter(([key]) => key !== 'description' && !SESSION_ANNOTATION_METADATA_KEYS.has(key))
+    ? Object.entries(session.metadata).filter(([key]) => key !== 'description')
     : []
 
 
@@ -132,29 +122,44 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
             <StatusBadge status={session.status} />
           </div>
 
-          {(annotations.runningTask || annotationLinks.length > 0) && (
+          {(annotations.runningTask || annotations.prUrl || annotations.issueUrl) && (
             <div className="flex flex-wrap items-center gap-1.5 mb-2">
               {annotations.runningTask && (
                 <span
-                  className="inline-flex max-w-full items-center px-2 py-0.5 text-xs bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800 rounded"
+                  className="inline-flex max-w-full items-center gap-1.5 px-2 py-0.5 text-xs bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800 rounded"
                   title={annotations.runningTask}
                 >
-                  <span className="font-medium mr-1">Task</span>
+                  <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                  <span className="font-medium">作業中</span>
                   <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
                 </span>
               )}
-              {annotationLinks.map((link) => (
+              {annotations.prUrl && (
                 <a
-                  key={`${link.label}:${link.url}`}
-                  href={link.url}
+                  href={annotations.prUrl}
                   target="_blank"
                   rel="noreferrer"
                   onClick={(e) => e.stopPropagation()}
-                  className="inline-flex items-center px-2 py-0.5 text-xs bg-gray-100 text-gray-700 ring-1 ring-gray-200 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-gray-700 rounded"
+                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-violet-50 text-violet-700 ring-1 ring-violet-200 hover:bg-violet-100 dark:bg-violet-950/40 dark:text-violet-200 dark:ring-violet-800 dark:hover:bg-violet-900/50 rounded"
+                  title={annotations.prUrl}
                 >
-                  {link.label}
+                  <GitPullRequest className="h-3 w-3" aria-hidden="true" />
+                  {prNumber ? `PR #${prNumber}` : 'PR'}
                 </a>
-              ))}
+              )}
+              {annotations.issueUrl && (
+                <a
+                  href={annotations.issueUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-200 dark:ring-emerald-800 dark:hover:bg-emerald-900/50 rounded"
+                  title={annotations.issueUrl}
+                >
+                  <CircleDot className="h-3 w-3" aria-hidden="true" />
+                  {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
+                </a>
+              )}
             </div>
           )}
 

--- a/src/app/components/SessionCard.tsx
+++ b/src/app/components/SessionCard.tsx
@@ -16,6 +16,40 @@ interface SessionCardProps {
   isSelectionMode?: boolean
 }
 
+const SESSION_ANNOTATION_METADATA_KEYS = new Set([
+  'annotations',
+  'pr_url',
+  'issue_url',
+  'running_task',
+])
+
+function getSessionAnnotations(session: Session) {
+  const metadataAnnotations = session.metadata?.annotations
+  const annotations = metadataAnnotations && typeof metadataAnnotations === 'object' && !Array.isArray(metadataAnnotations)
+    ? metadataAnnotations as Record<string, unknown>
+    : {}
+
+  const pick = (key: 'pr_url' | 'issue_url' | 'description' | 'running_task') => {
+    const directValue = session.annotations?.[key]
+    if (typeof directValue === 'string' && directValue.trim()) return directValue.trim()
+    const metadataValue = annotations[key] ?? session.metadata?.[key]
+    if (typeof metadataValue === 'string' && metadataValue.trim()) return metadataValue.trim()
+    return ''
+  }
+
+  return {
+    prUrl: pick('pr_url'),
+    issueUrl: pick('issue_url'),
+    description: pick('description'),
+    runningTask: pick('running_task'),
+  }
+}
+
+function getSessionTitle(session: Session, annotationDescription: string): string {
+  if (annotationDescription) return annotationDescription
+  return String(session.tags?.description || session.metadata?.description || `Session ${session.session_id.substring(0, 8)}`)
+}
+
 export default function SessionCard({ session, onDelete, isDeleting, isSelected, onToggleSelect, isSelectionMode }: SessionCardProps) {
   const [isMobile, setIsMobile] = useState(false)
 
@@ -42,6 +76,15 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
   }
 
   const isOld = isOldSession()
+  const annotations = getSessionAnnotations(session)
+  const title = getSessionTitle(session, annotations.description)
+  const annotationLinks = [
+    annotations.prUrl ? { label: 'PR', url: annotations.prUrl } : null,
+    annotations.issueUrl ? { label: 'Issue', url: annotations.issueUrl } : null,
+  ].filter(Boolean) as Array<{ label: string; url: string }>
+  const metadataEntries = session.metadata
+    ? Object.entries(session.metadata).filter(([key]) => key !== 'description' && !SESSION_ANNOTATION_METADATA_KEYS.has(key))
+    : []
 
 
   return (
@@ -84,10 +127,36 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
           {/* タイトルとステータス */}
           <div className="flex items-start gap-3 mb-2">
             <h3 className="text-sm sm:text-base font-medium text-gray-900 dark:text-white leading-5 sm:leading-6">
-              {truncateText(String(session.tags?.description || session.metadata?.description || `Session ${session.session_id.substring(0, 8)}`), isMobile ? 100 : 120)}
+              {truncateText(title, isMobile ? 100 : 120)}
             </h3>
             <StatusBadge status={session.status} />
           </div>
+
+          {(annotations.runningTask || annotationLinks.length > 0) && (
+            <div className="flex flex-wrap items-center gap-1.5 mb-2">
+              {annotations.runningTask && (
+                <span
+                  className="inline-flex max-w-full items-center px-2 py-0.5 text-xs bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800 rounded"
+                  title={annotations.runningTask}
+                >
+                  <span className="font-medium mr-1">Task</span>
+                  <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
+                </span>
+              )}
+              {annotationLinks.map((link) => (
+                <a
+                  key={`${link.label}:${link.url}`}
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="inline-flex items-center px-2 py-0.5 text-xs bg-gray-100 text-gray-700 ring-1 ring-gray-200 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-gray-700 rounded"
+                >
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          )}
 
           {/* セッション情報 */}
           <div className="flex flex-col sm:flex-row sm:items-center text-xs text-gray-500 dark:text-gray-400 space-y-1 sm:space-y-0 sm:space-x-4 mb-3">
@@ -107,10 +176,9 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
           </div>
 
           {/* メタデータタグ - モバイルでは最大2個まで表示 */}
-          {session.metadata && (
+          {metadataEntries.length > 0 && (
             <div className="flex flex-wrap gap-1 sm:gap-2">
-              {Object.entries(session.metadata)
-                .filter(([key]) => key !== 'description')
+              {metadataEntries
                 .slice(0, isMobile ? 2 : 10)
                 .map(([key, value]) => (
                   <span
@@ -122,9 +190,9 @@ export default function SessionCard({ session, onDelete, isDeleting, isSelected,
                     {String(value).substring(0, isMobile ? 8 : 20)}
                   </span>
                 ))}
-              {Object.entries(session.metadata).filter(([key]) => key !== 'description').length > 2 && isMobile && (
+              {metadataEntries.length > 2 && isMobile && (
                 <span className="inline-flex items-center px-2 py-1 text-xs bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-400 rounded-full">
-                  +{Object.entries(session.metadata).filter(([key]) => key !== 'description').length - 2}
+                  +{metadataEntries.length - 2}
                 </span>
               )}
             </div>

--- a/src/app/components/SessionListSidebar.tsx
+++ b/src/app/components/SessionListSidebar.tsx
@@ -27,7 +27,29 @@ function isRunningStatus(status: SessionStatus): boolean {
   return status === 'active' || status === 'running' || status === 'starting' || status === 'creating'
 }
 
+function getSessionAnnotations(session: Session) {
+  const metadataAnnotations = session.metadata?.annotations
+  const annotations = metadataAnnotations && typeof metadataAnnotations === 'object' && !Array.isArray(metadataAnnotations)
+    ? metadataAnnotations as Record<string, unknown>
+    : {}
+
+  const pick = (key: 'description' | 'running_task') => {
+    const directValue = session.annotations?.[key]
+    if (typeof directValue === 'string' && directValue.trim()) return directValue.trim()
+    const metadataValue = annotations[key] ?? session.metadata?.[key]
+    if (typeof metadataValue === 'string' && metadataValue.trim()) return metadataValue.trim()
+    return ''
+  }
+
+  return {
+    description: pick('description'),
+    runningTask: pick('running_task'),
+  }
+}
+
 function getSessionTitle(session: Session): string {
+  const annotations = getSessionAnnotations(session)
+  if (annotations.description) return annotations.description
   if (session.tags?.description?.trim()) return session.tags.description.trim()
   const metaDesc = session.metadata?.description
   if (typeof metaDesc === 'string' && metaDesc.trim()) return metaDesc.trim()
@@ -147,6 +169,7 @@ export default function SessionListSidebar({
               const isActive = session.session_id === currentSessionId
               const running = isRunningStatus(session.status)
               const title = getSessionTitle(session)
+              const annotations = getSessionAnnotations(session)
               const timeStr = formatRelativeTime(session.updated_at || session.started_at)
               const isDeleting = deletingIds.has(session.session_id)
 
@@ -182,6 +205,14 @@ export default function SessionListSidebar({
                       >
                         {title}
                       </p>
+                      {annotations.runningTask && (
+                        <p
+                          className="text-[10px] text-amber-600 dark:text-amber-400 truncate mt-0.5 leading-none"
+                          title={annotations.runningTask}
+                        >
+                          {annotations.runningTask}
+                        </p>
+                      )}
                       <p className="text-[10px] text-gray-400 dark:text-gray-600 mt-0.5 leading-none">
                         {session.status === 'running' ? (
                           <span className="text-yellow-500 dark:text-yellow-400">実行中</span>

--- a/src/app/components/SessionListSidebar.tsx
+++ b/src/app/components/SessionListSidebar.tsx
@@ -28,16 +28,9 @@ function isRunningStatus(status: SessionStatus): boolean {
 }
 
 function getSessionAnnotations(session: Session) {
-  const metadataAnnotations = session.metadata?.annotations
-  const annotations = metadataAnnotations && typeof metadataAnnotations === 'object' && !Array.isArray(metadataAnnotations)
-    ? metadataAnnotations as Record<string, unknown>
-    : {}
-
   const pick = (key: 'description' | 'running_task') => {
     const directValue = session.annotations?.[key]
     if (typeof directValue === 'string' && directValue.trim()) return directValue.trim()
-    const metadataValue = annotations[key] ?? session.metadata?.[key]
-    if (typeof metadataValue === 'string' && metadataValue.trim()) return metadataValue.trim()
     return ''
   }
 

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { CircleDot, GitPullRequest, LoaderCircle } from 'lucide-react'
+import { CircleDot, GitPullRequest, LoaderCircle, MoreHorizontal } from 'lucide-react'
 import { Session, AgentStatus, SessionListParams } from '../../types/agentapi'
 import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
 import { createACPServerClientFromStorage, ACPServerSession } from '../../lib/acp-server-client'
@@ -117,6 +117,7 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
   const [isBulkDeleting, setIsBulkDeleting] = useState(false)
   const [isSelectionMode, setIsSelectionMode] = useState(false)
   const [showHiddenSessions, setShowHiddenSessions] = useState(false)
+  const [openAnnotationMenuId, setOpenAnnotationMenuId] = useState<string | null>(null)
 
   const [sortBy, setSortBy] = useState<'started_at' | 'updated_at'>(() => {
     if (typeof window !== 'undefined') {
@@ -897,42 +898,59 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                         </div>
 
                         {(annotations.runningTask || annotations.prUrl || annotations.issueUrl) && (
-                          <div className="flex flex-wrap items-center gap-1.5 mb-2">
+                          <div className="flex flex-wrap items-center gap-2 mb-2">
                             {annotations.runningTask && (
                               <span
-                                className="inline-flex max-w-full items-center gap-1.5 px-2 py-0.5 text-xs bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800 rounded"
+                                className="inline-flex max-w-full items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
                                 title={annotations.runningTask}
                               >
                                 <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-                                <span className="font-medium">作業中</span>
+                                <span>作業中:</span>
                                 <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
                               </span>
                             )}
-                            {annotations.prUrl && (
-                              <a
-                                href={annotations.prUrl.replace(/\s+/g, '')}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                onClick={(e) => e.stopPropagation()}
-                                className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-violet-50 text-violet-700 ring-1 ring-violet-200 hover:bg-violet-100 dark:bg-violet-950/40 dark:text-violet-200 dark:ring-violet-800 dark:hover:bg-violet-900/50 rounded"
-                                title={annotations.prUrl}
-                              >
-                                <GitPullRequest className="h-3 w-3" aria-hidden="true" />
-                                {prNumber ? `PR #${prNumber}` : 'PR'}
-                              </a>
-                            )}
-                            {annotations.issueUrl && (
-                              <a
-                                href={annotations.issueUrl.replace(/\s+/g, '')}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                onClick={(e) => e.stopPropagation()}
-                                className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-200 dark:ring-emerald-800 dark:hover:bg-emerald-900/50 rounded"
-                                title={annotations.issueUrl}
-                              >
-                                <CircleDot className="h-3 w-3" aria-hidden="true" />
-                                {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
-                              </a>
+                            {(annotations.prUrl || annotations.issueUrl) && (
+                              <div className="relative" onClick={(e) => e.stopPropagation()}>
+                                <button
+                                  type="button"
+                                  onClick={() => setOpenAnnotationMenuId(prev => prev === session.session_id ? null : session.session_id)}
+                                  className="inline-flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                                  aria-label="関連リンク"
+                                  title="関連リンク"
+                                >
+                                  <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+                                </button>
+                                {openAnnotationMenuId === session.session_id && (
+                                  <div className="absolute left-0 top-7 z-20 min-w-32 overflow-hidden rounded-md border border-gray-200 bg-white py-1 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-900">
+                                    {annotations.prUrl && (
+                                      <a
+                                        href={annotations.prUrl.replace(/\s+/g, '')}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        onClick={() => setOpenAnnotationMenuId(null)}
+                                        className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                                        title={annotations.prUrl}
+                                      >
+                                        <GitPullRequest className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
+                                        {prNumber ? `PR #${prNumber}` : 'PR'}
+                                      </a>
+                                    )}
+                                    {annotations.issueUrl && (
+                                      <a
+                                        href={annotations.issueUrl.replace(/\s+/g, '')}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        onClick={() => setOpenAnnotationMenuId(null)}
+                                        className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                                        title={annotations.issueUrl}
+                                      >
+                                        <CircleDot className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
+                                        {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
+                                      </a>
+                                    )}
+                                  </div>
+                                )}
+                              </div>
                             )}
                           </div>
                         )}

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import { CircleDot, GitPullRequest, LoaderCircle } from 'lucide-react'
 import { Session, AgentStatus, SessionListParams } from '../../types/agentapi'
 import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError, ProxySessionStatusEvent } from '../../lib/agentapi-proxy-client'
 import { createACPServerClientFromStorage, ACPServerSession } from '../../lib/acp-server-client'
@@ -55,6 +56,26 @@ function mapACPSessionToSession(acpSession: ACPServerSession): Session {
     scope: (acpSession._meta?.scope as Session['scope']) || 'user',
     team_id: acpSession._meta?.teamId,
   }
+}
+
+function getSessionAnnotations(session: Session) {
+  const pick = (key: 'pr_url' | 'issue_url' | 'description' | 'running_task') => {
+    const directValue = session.annotations?.[key]
+    if (typeof directValue === 'string' && directValue.trim()) return directValue.trim()
+    return ''
+  }
+
+  return {
+    prUrl: pick('pr_url'),
+    issueUrl: pick('issue_url'),
+    description: pick('description'),
+    runningTask: pick('running_task'),
+  }
+}
+
+function getURLNumber(url: string): string | null {
+  const match = url.match(/\/(?:pull|issues)\/(\d+)(?:[/?#]|$)/)
+  return match?.[1] ?? null
 }
 
 interface TagFilter {
@@ -371,6 +392,11 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
 
   // セッションの表示用説明を取得
   const getSessionDescription = (session: Session) => {
+    const annotations = getSessionAnnotations(session)
+    if (annotations.description) {
+      return annotations.description
+    }
+
     const description = session.metadata?.description
 
     if (description && description !== 'No description available') {
@@ -777,6 +803,9 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                   const agentStatusInfo = getAgentStatusForSession(session)
                   const description = getSessionDescription(session)
                   const isOld = isOldSession(session)
+                  const annotations = getSessionAnnotations(session)
+                  const prNumber = annotations.prUrl ? getURLNumber(annotations.prUrl) : null
+                  const issueNumber = annotations.issueUrl ? getURLNumber(annotations.issueUrl) : null
 
                   const isSelected = selectedSessions.has(session.session_id)
                   return (
@@ -867,6 +896,47 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                           )}
                         </div>
 
+                        {(annotations.runningTask || annotations.prUrl || annotations.issueUrl) && (
+                          <div className="flex flex-wrap items-center gap-1.5 mb-2">
+                            {annotations.runningTask && (
+                              <span
+                                className="inline-flex max-w-full items-center gap-1.5 px-2 py-0.5 text-xs bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800 rounded"
+                                title={annotations.runningTask}
+                              >
+                                <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                                <span className="font-medium">作業中</span>
+                                <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
+                              </span>
+                            )}
+                            {annotations.prUrl && (
+                              <a
+                                href={annotations.prUrl.replace(/\s+/g, '')}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={(e) => e.stopPropagation()}
+                                className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-violet-50 text-violet-700 ring-1 ring-violet-200 hover:bg-violet-100 dark:bg-violet-950/40 dark:text-violet-200 dark:ring-violet-800 dark:hover:bg-violet-900/50 rounded"
+                                title={annotations.prUrl}
+                              >
+                                <GitPullRequest className="h-3 w-3" aria-hidden="true" />
+                                {prNumber ? `PR #${prNumber}` : 'PR'}
+                              </a>
+                            )}
+                            {annotations.issueUrl && (
+                              <a
+                                href={annotations.issueUrl.replace(/\s+/g, '')}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={(e) => e.stopPropagation()}
+                                className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-200 dark:ring-emerald-800 dark:hover:bg-emerald-900/50 rounded"
+                                title={annotations.issueUrl}
+                              >
+                                <CircleDot className="h-3 w-3" aria-hidden="true" />
+                                {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
+                              </a>
+                            )}
+                          </div>
+                        )}
+
                         {/* セッション情報 */}
                         <div className="flex flex-col sm:flex-row sm:items-center text-xs text-gray-500 dark:text-gray-400 space-y-1 sm:space-y-0 sm:space-x-4 mb-3">
                           <span>#{session.session_id.substring(0, 8)}</span>
@@ -947,20 +1017,6 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                           </svg>
                           <span className="hidden sm:inline">チャット</span>
                         </button>
-                        
-                        {session.metadata?.pr_url ? (
-                          <a
-                            href={String(session.metadata.pr_url).replace(/\s+/g, '')}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center justify-center px-3 py-2 sm:px-3 sm:py-1.5 border border-purple-300 dark:border-purple-600 hover:bg-purple-50 dark:hover:bg-purple-700 text-purple-700 dark:text-purple-300 text-sm font-medium rounded-md transition-colors min-h-[44px] sm:min-h-0"
-                          >
-                            <svg className="w-4 h-4 sm:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                            </svg>
-                            <span className="hidden sm:inline">PR表示</span>
-                          </a>
-                        ) : null}
                         
                         {session.metadata?.claude_login_url ? (
                           <a

--- a/src/app/components/SessionListView.tsx
+++ b/src/app/components/SessionListView.tsx
@@ -897,61 +897,16 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                           )}
                         </div>
 
-                        {(annotations.runningTask || annotations.prUrl || annotations.issueUrl) && (
+                        {annotations.runningTask && (
                           <div className="flex flex-wrap items-center gap-2 mb-2">
-                            {annotations.runningTask && (
-                              <span
-                                className="inline-flex max-w-full items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
-                                title={annotations.runningTask}
-                              >
-                                <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-                                <span>作業中:</span>
-                                <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
-                              </span>
-                            )}
-                            {(annotations.prUrl || annotations.issueUrl) && (
-                              <div className="relative" onClick={(e) => e.stopPropagation()}>
-                                <button
-                                  type="button"
-                                  onClick={() => setOpenAnnotationMenuId(prev => prev === session.session_id ? null : session.session_id)}
-                                  className="inline-flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                                  aria-label="関連リンク"
-                                  title="関連リンク"
-                                >
-                                  <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
-                                </button>
-                                {openAnnotationMenuId === session.session_id && (
-                                  <div className="absolute left-0 top-7 z-20 min-w-32 overflow-hidden rounded-md border border-gray-200 bg-white py-1 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-900">
-                                    {annotations.prUrl && (
-                                      <a
-                                        href={annotations.prUrl.replace(/\s+/g, '')}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        onClick={() => setOpenAnnotationMenuId(null)}
-                                        className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
-                                        title={annotations.prUrl}
-                                      >
-                                        <GitPullRequest className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
-                                        {prNumber ? `PR #${prNumber}` : 'PR'}
-                                      </a>
-                                    )}
-                                    {annotations.issueUrl && (
-                                      <a
-                                        href={annotations.issueUrl.replace(/\s+/g, '')}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        onClick={() => setOpenAnnotationMenuId(null)}
-                                        className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
-                                        title={annotations.issueUrl}
-                                      >
-                                        <CircleDot className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
-                                        {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
-                                      </a>
-                                    )}
-                                  </div>
-                                )}
-                              </div>
-                            )}
+                            <span
+                              className="inline-flex max-w-full items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+                              title={annotations.runningTask}
+                            >
+                              <LoaderCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                              <span>作業中:</span>
+                              <span className="truncate">{truncateText(annotations.runningTask, isMobile ? 32 : 64)}</span>
+                            </span>
                           </div>
                         )}
 
@@ -1049,6 +1004,50 @@ export default function SessionListView({ tagFilters, onSessionsUpdate, creating
                             <span className="hidden sm:inline">ログイン</span>
                           </a>
                         ) : null}
+
+                        {(annotations.prUrl || annotations.issueUrl) && (
+                          <div className="relative">
+                            <button
+                              type="button"
+                              onClick={() => setOpenAnnotationMenuId(prev => prev === session.session_id ? null : session.session_id)}
+                              className="inline-flex min-h-[44px] items-center justify-center rounded-md border border-gray-300 px-3 py-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white sm:min-h-0 sm:px-3 sm:py-1.5"
+                              aria-label="関連リンク"
+                              title="関連リンク"
+                            >
+                              <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                            {openAnnotationMenuId === session.session_id && (
+                              <div className="absolute right-0 top-full z-20 mt-2 min-w-32 overflow-hidden rounded-md border border-gray-200 bg-white py-1 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-900">
+                                {annotations.prUrl && (
+                                  <a
+                                    href={annotations.prUrl.replace(/\s+/g, '')}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    onClick={() => setOpenAnnotationMenuId(null)}
+                                    className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                                    title={annotations.prUrl}
+                                  >
+                                    <GitPullRequest className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
+                                    {prNumber ? `PR #${prNumber}` : 'PR'}
+                                  </a>
+                                )}
+                                {annotations.issueUrl && (
+                                  <a
+                                    href={annotations.issueUrl.replace(/\s+/g, '')}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    onClick={() => setOpenAnnotationMenuId(null)}
+                                    className="flex items-center gap-2 px-3 py-2 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                                    title={annotations.issueUrl}
+                                  >
+                                    <CircleDot className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
+                                    {issueNumber ? `Issue #${issueNumber}` : 'Issue'}
+                                  </a>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        )}
                         
                         <button
                           onClick={() => deleteSession(session.session_id)}

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -163,6 +163,13 @@ export type SessionStatus = 'creating' | 'starting' | 'running' | 'active' | 'un
 export type ResourceScope = 'user' | 'team';
 
 // Session types for agentapi-proxy
+export interface SessionAnnotations {
+  pr_url?: string;
+  issue_url?: string;
+  description?: string;
+  running_task?: string;
+}
+
 export interface Session {
   session_id: string;
   user_id: string;
@@ -173,6 +180,7 @@ export interface Session {
   description?: string;
   environment?: Record<string, string>;
   metadata?: Record<string, unknown>;
+  annotations?: SessionAnnotations;
   tags?: Record<string, string>;
   scope?: ResourceScope;
   team_id?: string;


### PR DESCRIPTION
## Summary
- add session annotation types to the UI session model
- show annotation description, running task, PR URL, and issue URL in session cards
- show running task in the chat session sidebar

## Verification
- npm run type-check
- npm run lint (passes with existing warnings in unrelated files)