### PR TITLE
Add pi-ollama agent type option

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -43,7 +43,7 @@ function normalizeAgentStatus(raw: string): 'stable' | 'running' | 'error' {
 }
 
 function isACPAgentType(agentType?: string | null): boolean {
-  return !!agentType && (agentType.includes('acp') || agentType === 'cursor');
+  return !!agentType && (agentType.includes('acp') || agentType === 'pi-ollama' || agentType === 'cursor');
 }
 
 // Type guard function to validate session message response

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -19,7 +19,7 @@ interface SessionProfileFormModalProps {
 
 type KeyValuePair = { key: string; value: string }
 type AuthProxyMode = 'default' | 'enabled' | 'disabled'
-const SUPPORTED_AGENT_TYPES = new Set(['claude-acp', 'codex-acp', 'cursor'])
+const SUPPORTED_AGENT_TYPES = new Set(['claude-acp', 'codex-acp', 'pi-ollama', 'cursor'])
 
 const normalizeAgentType = (value?: string): string => {
   return value && SUPPORTED_AGENT_TYPES.has(value) ? value : ''
@@ -565,6 +565,7 @@ export default function SessionProfileFormModal({
                         { value: '', label: 'デフォルト', description: 'agent_type を送信しない' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
+                        { value: 'pi-ollama', label: 'Pi Ollama', description: 'agent_type=pi-ollama を送信' },
                         { value: 'cursor', label: 'Cursor ACP', description: 'agent_type=cursor を送信' },
                       ]).map(({ value: v, label, description }) => (
                         <label key={v} className="flex items-start cursor-pointer group">

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -22,6 +22,21 @@ import { useTeamScope } from '../../../contexts/TeamScopeContext'
 type AuthProxyMode = 'default' | 'enabled' | 'disabled'
 type CheckoutTarget = 'branch' | 'pr' | ''
 
+const getAgentTypeLabel = (agentType: AgentApiType): string => {
+  switch (agentType) {
+    case 'claude-acp':
+      return 'Claude ACP'
+    case 'codex-acp':
+      return 'Codex ACP'
+    case 'pi-ollama':
+      return 'Pi Ollama'
+    case 'cursor':
+      return 'Cursor ACP'
+    default:
+      return 'Claude ACP'
+  }
+}
+
 function buildRepositoryTags(
   repo: string,
   checkoutTarget: CheckoutTarget,
@@ -674,10 +689,7 @@ export default function NewSessionPage() {
                 その他の設定
                 {selectedAgentType !== 'default' && (
                   <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 text-xs rounded-full">
-                    {selectedAgentType === 'claude-acp' ? 'Claude ACP'
-                      : selectedAgentType === 'codex-acp' ? 'Codex ACP'
-                      : selectedAgentType === 'cursor' ? 'Cursor ACP'
-                      : selectedAgentType}
+                    {getAgentTypeLabel(selectedAgentType)}
                   </span>
                 )}
                 {selectedManagerId !== '' && (
@@ -1083,7 +1095,7 @@ export default function NewSessionPage() {
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                         </svg>
                         <span className="text-xs text-blue-700 dark:text-blue-300">
-                          ACP サーバーモード: <strong>{selectedAgentType === 'codex-acp' ? 'Codex' : 'Claude'}</strong>（{selectedAgentType === 'codex-acp' ? 'codex-acp' : 'claude-acp'}）が使用されます
+                          ACP サーバーモード: <strong>{getAgentTypeLabel(selectedAgentType)}</strong>（{selectedAgentType !== 'default' ? selectedAgentType : 'claude-acp'}）が使用されます
                         </span>
                       </div>
                     ) : (
@@ -1092,6 +1104,7 @@ export default function NewSessionPage() {
                         { value: 'default', label: 'デフォルト', description: 'agent_type を送信しない' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
+                        { value: 'pi-ollama', label: 'Pi Ollama', description: 'agent_type=pi-ollama を送信' },
                         { value: 'cursor', label: 'Cursor ACP', description: 'agent_type=cursor を送信' },
                       ] as { value: AgentApiType; label: string; description: string }[]).map(({ value, label, description }) => (
                         <label key={value} className="flex items-start cursor-pointer group">

--- a/src/components/settings/ACPServerSettings.tsx
+++ b/src/components/settings/ACPServerSettings.tsx
@@ -53,7 +53,7 @@ export function ACPServerSettings({
           </ul>
           <p className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 p-2 rounded">
             ACP サーバーモードを使用するには、agentapi-proxy が ACP サーバー機能をサポートしている必要があります。
-            セッション作成時にエージェントタイプが自動的に <code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">claude-acp</code> または <code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">codex-acp</code> に設定されます。
+            セッション作成時にエージェントタイプが <code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">claude-acp</code>、<code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">codex-acp</code>、<code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">pi-ollama</code>、<code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">cursor</code> のいずれかに設定されます。
           </p>
         </div>
       )}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -207,8 +207,9 @@ export interface FontSettings {
 // 'default': agent_type を送信しない（バックエンドのデフォルト動作）
 // 'claude-acp': claude-acp を使用
 // 'codex-acp': codex-acp を使用
+// 'pi-ollama': Pi + pi-acp + pi-ollama-cloud を使用
 // 'cursor': Cursor ACP を使用
-export type AgentApiType = 'default' | 'claude-acp' | 'codex-acp' | 'cursor'
+export type AgentApiType = 'default' | 'claude-acp' | 'codex-acp' | 'pi-ollama' | 'cursor'
 
 export interface GlobalSettings {
   agentApiProxy: AgentApiProxySettings
@@ -813,6 +814,7 @@ export const getAgentApiType = (): AgentApiType => {
   if (
     settings.agentApiType === 'claude-acp' ||
     settings.agentApiType === 'codex-acp' ||
+    settings.agentApiType === 'pi-ollama' ||
     settings.agentApiType === 'cursor'
   ) {
     return settings.agentApiType


### PR DESCRIPTION
## Summary
- add pi-ollama to the AgentApiType union and persisted setting validation
- show Pi Ollama as an agent type option on new sessions and session profiles
- treat pi-ollama sessions as ACP-backed in chat transport selection

## Tests
- bun run type-check
- bun run lint (passes with existing warnings)
- bun run build (passes with existing warnings)