### PR TITLE
Remove nfa and scia session options

### DIFF
--- a/src/app/components/NewConversationModal.tsx
+++ b/src/app/components/NewConversationModal.tsx
@@ -22,7 +22,6 @@ interface EnvironmentVariable {
 }
 
 type KeyValuePair = MemoryKeyPair
-type AuthProxyMode = 'default' | 'enabled' | 'disabled'
 
 export default function NewConversationModal({ isOpen, onClose, onSuccess, currentFilters, initialRepository }: NewConversationModalProps) {
   const { selectedTeam } = useTeamScope()
@@ -36,7 +35,6 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
   const [repositorySuggestions, setRepositorySuggestions] = useState<string[]>([])
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [oneshot, setOneshot] = useState(false)
-  const [authProxyMode, setAuthProxyMode] = useState<AuthProxyMode>('default')
   const [memoryKeyPairs, setMemoryKeyPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   
   // Initialize with current filter values
@@ -140,7 +138,6 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
     setError(null)
     setShowSuggestions(false)
     setOneshot(false)
-    setAuthProxyMode('default')
   }
 
   const handleClose = () => {
@@ -244,8 +241,7 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
         tags: sessionData.tags,
         params: {
           message: description.trim(),
-          ...(oneshot ? { oneshot: true } : {}),
-          ...(authProxyMode !== 'default' ? { auth_proxy: authProxyMode === 'enabled' } : {})
+          ...(oneshot ? { oneshot: true } : {})
         },
         ...(memoryKey ? { memory_key: memoryKey } : {}),
         ...scopeParams
@@ -391,36 +387,6 @@ export default function NewConversationModal({ isOpen, onClose, onSuccess, curre
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
                 セッションが停止した後、自動的にセッションを削除します。
               </p>
-            </div>
-          </div>
-
-          {/* Auth Proxy */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              認証プロキシ
-            </label>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-              {([
-                { value: 'default', label: 'デフォルト', description: 'サーバー設定に従う' },
-                { value: 'enabled', label: '有効', description: 'このセッションに追加' },
-                { value: 'disabled', label: '無効', description: 'このセッションでは使わない' },
-              ] as { value: AuthProxyMode; label: string; description: string }[]).map(({ value, label, description }) => (
-                <label key={value} className={`flex items-start gap-2 p-2 rounded-lg border cursor-pointer transition-colors ${authProxyMode === value ? 'border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20' : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'}`}>
-                  <input
-                    type="radio"
-                    name="modal-auth-proxy-mode"
-                    value={value}
-                    checked={authProxyMode === value}
-                    onChange={() => setAuthProxyMode(value)}
-                    disabled={isCreating}
-                    className="mt-0.5 w-3.5 h-3.5 text-emerald-600 border-gray-300 dark:border-gray-600 focus:ring-emerald-500 flex-shrink-0"
-                  />
-                  <span>
-                    <span className="block text-xs font-medium text-gray-700 dark:text-gray-300">{label}</span>
-                    <span className="block text-xs text-gray-400 dark:text-gray-500">{description}</span>
-                  </span>
-                </label>
-              ))}
             </div>
           </div>
 

--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -87,22 +87,6 @@ export default function SessionProfileCard({
             {profile.config.params.agent_type}
           </span>
         )}
-        {profile.config?.params?.sandbox?.enabled && (
-          <span className="inline-flex items-center gap-1 text-orange-600 dark:text-orange-400">
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-            </svg>
-            サンドボックス
-          </span>
-        )}
-        {profile.config?.params?.auth_proxy !== undefined && (
-          <span className={`inline-flex items-center gap-1 ${profile.config.params.auth_proxy ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-500 dark:text-gray-400'}`}>
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 11c1.657 0 3-1.12 3-2.5S13.657 6 12 6 9 7.12 9 8.5 10.343 11 12 11zm0 0c-3.314 0-6 1.79-6 4v1h12v-1c0-2.21-2.686-4-6-4z" />
-            </svg>
-            認証プロキシ{profile.config.params.auth_proxy ? '' : 'OFF'}
-          </span>
-        )}
         {profile.config?.environment && Object.keys(profile.config.environment).length > 0 && (
           <span>環境変数: <strong className="text-gray-700 dark:text-gray-300">{Object.keys(profile.config.environment).length}</strong></span>
         )}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -6,7 +6,6 @@ import {
   CreateSessionProfileRequest,
   UpdateSessionProfileRequest,
 } from '../../types/session_profile'
-import { SandboxPolicy } from '../../types/sandbox_policy'
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 
@@ -18,7 +17,6 @@ interface SessionProfileFormModalProps {
 }
 
 type KeyValuePair = { key: string; value: string }
-type AuthProxyMode = 'default' | 'enabled' | 'disabled'
 const SUPPORTED_AGENT_TYPES = new Set(['claude-acp', 'codex-acp', 'pi-ollama', 'cursor'])
 
 const normalizeAgentType = (value?: string): string => {
@@ -43,20 +41,9 @@ export default function SessionProfileFormModal({
   const [tagPairs, setTagPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [agentType, setAgentType] = useState('')
 
-  // Sandbox fields
-  const [sandboxEnabled, setSandboxEnabled] = useState(false)
-  const [sandboxPolicyId, setSandboxPolicyId] = useState('')
-  const [sandboxMode, setSandboxMode] = useState<'allowlist' | 'denylist'>('allowlist')
-  const [sandboxDomains, setSandboxDomains] = useState('')
-  const [sandboxCountMode, setSandboxCountMode] = useState(false)
-  const [availablePolicies, setAvailablePolicies] = useState<SandboxPolicy[]>([])
-
   // Docker / DinD fields
   const [dockerEnabled, setDockerEnabled] = useState(false)
   const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string; insecure: boolean }>>([])
-
-  // Auth proxy
-  const [authProxyMode, setAuthProxyMode] = useState<AuthProxyMode>('default')
 
   // Session TTL
   const [sessionTTL, setSessionTTL] = useState('')
@@ -73,17 +60,6 @@ export default function SessionProfileFormModal({
   const [showAdvanced, setShowAdvanced] = useState(false)
 
   const isEditing = !!editingProfile
-
-  // Load available sandbox policies when modal opens
-  useEffect(() => {
-    if (!isOpen) return
-    const client = createAgentAPIProxyClientFromStorage()
-    client.getSandboxPolicies().then((res) => {
-      setAvailablePolicies(res.sandbox_policies || [])
-    }).catch(() => {
-      setAvailablePolicies([])
-    })
-  }, [isOpen])
 
   // Initialize form when editing
   useEffect(() => {
@@ -111,42 +87,6 @@ export default function SessionProfileFormModal({
 
       if (cfg?.params?.agent_type) {
         setShowAdvanced(true)
-      }
-
-      const authProxy = cfg?.params?.auth_proxy
-      if (authProxy === true) {
-        setAuthProxyMode('enabled')
-        setShowAdvanced(true)
-      } else if (authProxy === false) {
-        setAuthProxyMode('disabled')
-        setShowAdvanced(true)
-      } else {
-        setAuthProxyMode('default')
-      }
-
-      // Initialize sandbox_policy_id from profile config
-      const policyId = cfg?.sandbox_policy_id ?? ''
-      setSandboxPolicyId(policyId)
-      if (policyId) setShowAdvanced(true)
-
-      // Initialize sandbox from profile params
-      const sandbox = cfg?.params?.sandbox
-      if (sandbox) {
-        setSandboxEnabled(sandbox.enabled)
-        if (sandbox.allowed_domains && sandbox.allowed_domains.length > 0) {
-          setSandboxMode('allowlist')
-          setSandboxDomains(sandbox.allowed_domains.join('\n'))
-        } else if (sandbox.denied_domains && sandbox.denied_domains.length > 0) {
-          setSandboxMode('denylist')
-          setSandboxDomains(sandbox.denied_domains.join('\n'))
-        }
-        setSandboxCountMode(sandbox.count_mode ?? false)
-        if (sandbox.enabled) setShowAdvanced(true)
-      } else {
-        setSandboxEnabled(false)
-        setSandboxMode('allowlist')
-        setSandboxDomains('')
-        setSandboxCountMode(false)
       }
 
       // Initialize docker from profile params
@@ -182,14 +122,8 @@ export default function SessionProfileFormModal({
       setEnvPairs([{ key: '', value: '' }])
       setTagPairs([{ key: '', value: '' }])
       setAgentType('')
-      setSandboxEnabled(false)
-      setSandboxPolicyId('')
-      setSandboxMode('allowlist')
-      setSandboxDomains('')
-      setSandboxCountMode(false)
       setDockerEnabled(false)
       setDockerRegistries([])
-      setAuthProxyMode('default')
       setSessionTTL('')
       setUnsyncedFilePaths('')
       setShowAdvanced(false)
@@ -269,18 +203,6 @@ export default function SessionProfileFormModal({
         .map(path => path.trim())
         .filter(Boolean)
 
-      // Build sandbox config if enabled
-      let sandboxConfig: { enabled: boolean; allowed_domains?: string[]; denied_domains?: string[]; count_mode?: boolean } | undefined
-      if (sandboxEnabled) {
-        const domainList = sandboxDomains.split('\n').map(d => d.trim()).filter(Boolean)
-        sandboxConfig = {
-          enabled: true,
-          ...(sandboxMode === 'allowlist' && domainList.length > 0 ? { allowed_domains: domainList } : {}),
-          ...(sandboxMode === 'denylist' && domainList.length > 0 ? { denied_domains: domainList } : {}),
-          ...(sandboxCountMode ? { count_mode: true } : {}),
-        }
-      }
-
       // Build docker config if enabled
       let dockerConfig: { enabled: boolean; registries?: { server?: string; username?: string; password?: string; secret_name?: string; insecure?: boolean }[] } | undefined
       if (dockerEnabled) {
@@ -296,20 +218,16 @@ export default function SessionProfileFormModal({
       }
 
       // Build params if any param is set
-      const authProxyValue = authProxyMode === 'default' ? undefined : authProxyMode === 'enabled'
-      const hasParams = agentType.trim() || sandboxConfig || dockerConfig || authProxyValue !== undefined
+      const hasParams = agentType.trim() || dockerConfig
       const params = hasParams ? {
         ...(agentType.trim() ? { agent_type: agentType.trim() } : {}),
-        ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
         ...(dockerConfig ? { docker: dockerConfig } : {}),
-        ...(authProxyValue !== undefined ? { auth_proxy: authProxyValue } : {}),
       } : undefined
 
       const config = {
         ...(Object.keys(environment).length > 0 ? { environment } : {}),
         ...(Object.keys(tags).length > 0 ? { tags } : {}),
         ...(params ? { params } : {}),
-        ...(sandboxPolicyId ? { sandbox_policy_id: sandboxPolicyId } : {}),
         ...(sessionTTL.trim() ? { session_ttl: sessionTTL.trim() } : {}),
         ...(parsedUnsyncedFilePaths.length > 0 ? { unsynced_file_paths: parsedUnsyncedFilePaths } : {}),
       }
@@ -590,148 +508,6 @@ export default function SessionProfileFormModal({
                     </div>
                   </div>
 
-                  {/* Auth Proxy */}
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      認証プロキシ
-                    </label>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                      {([
-                        { value: 'default', label: 'デフォルト', description: 'サーバー設定に従う' },
-                        { value: 'enabled', label: '有効', description: 'セッションに追加' },
-                        { value: 'disabled', label: '無効', description: 'セッションでは使わない' },
-                      ] as { value: AuthProxyMode; label: string; description: string }[]).map(({ value, label, description }) => (
-                        <label
-                          key={value}
-                          className={`flex items-start gap-2 p-2 rounded-lg border cursor-pointer transition-colors ${
-                            authProxyMode === value
-                              ? 'border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20'
-                              : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
-                          }`}
-                        >
-                          <input
-                            type="radio"
-                            name="profile-auth-proxy"
-                            value={value}
-                            checked={authProxyMode === value}
-                            onChange={() => setAuthProxyMode(value)}
-                            className="mt-0.5 w-3.5 h-3.5 text-emerald-600 border-gray-300 dark:border-gray-600 focus:ring-emerald-500"
-                          />
-                          <span>
-                            <span className="block text-xs font-medium text-gray-700 dark:text-gray-300">{label}</span>
-                            <span className="block text-xs text-gray-400 dark:text-gray-500">{description}</span>
-                          </span>
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Sandbox Policy */}
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      サンドボックスポリシー
-                    </label>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                      事前定義されたポリシーを選択すると、セッション作成時にそのドメインルールが自動的に適用されます。
-                    </p>
-                    <select
-                      value={sandboxPolicyId}
-                      onChange={(e) => setSandboxPolicyId(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    >
-                      <option value="">使用しない</option>
-                      {availablePolicies.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}{p.description ? ` — ${p.description}` : ''}
-                        </option>
-                      ))}
-                    </select>
-                    {sandboxPolicyId && (
-                      <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">
-                        ポリシーのドメインルールが自動でサンドボックスを有効にします。追加の制限は下の設定で上書きできます。
-                      </p>
-                    )}
-                  </div>
-
-                  {/* Sandbox manual override */}
-                  <div>
-                    <label className="flex items-start gap-2 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={sandboxEnabled}
-                        onChange={(e) => setSandboxEnabled(e.target.checked)}
-                        className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
-                      />
-                      <div>
-                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                          {sandboxPolicyId ? 'ドメインを追加で上書き設定する' : 'サンドボックス（ネットワーク制限）を有効にする'}
-                        </span>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                          {sandboxPolicyId
-                            ? 'ポリシーのドメインリストに加えて、追加の許可/拒否ドメインを設定します。'
-                            : 'セッションのアウトバウンドネットワークアクセスをドメインレベルで制限します。'}
-                        </p>
-                      </div>
-                    </label>
-
-                    {sandboxEnabled && (
-                      <div className="mt-3 ml-6 space-y-3">
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
-                            モード
-                          </label>
-                          <div className="flex gap-4">
-                            <label className="flex items-center gap-1.5 cursor-pointer">
-                              <input
-                                type="radio"
-                                value="allowlist"
-                                checked={sandboxMode === 'allowlist'}
-                                onChange={() => setSandboxMode('allowlist')}
-                                className="h-3.5 w-3.5 text-blue-600 focus:ring-blue-500"
-                              />
-                              <span className="text-xs text-gray-700 dark:text-gray-300">許可リスト（指定ドメインのみ許可）</span>
-                            </label>
-                            <label className="flex items-center gap-1.5 cursor-pointer">
-                              <input
-                                type="radio"
-                                value="denylist"
-                                checked={sandboxMode === 'denylist'}
-                                onChange={() => setSandboxMode('denylist')}
-                                className="h-3.5 w-3.5 text-blue-600 focus:ring-blue-500"
-                              />
-                              <span className="text-xs text-gray-700 dark:text-gray-300">拒否リスト（指定ドメインをブロック）</span>
-                            </label>
-                          </div>
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
-                            ドメインリスト（1行に1ドメイン）
-                          </label>
-                          <textarea
-                            value={sandboxDomains}
-                            onChange={(e) => setSandboxDomains(e.target.value)}
-                            placeholder={sandboxMode === 'allowlist' ? 'example.com\napi.github.com' : 'example.com\nbad-domain.com'}
-                            rows={4}
-                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono resize-y"
-                          />
-                        </div>
-                        <div>
-                          <label className="flex items-start gap-1.5 cursor-pointer">
-                            <input
-                              type="checkbox"
-                              checked={sandboxCountMode}
-                              onChange={(e) => setSandboxCountMode(e.target.checked)}
-                              className="mt-0.5 h-3.5 w-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"
-                            />
-                            <div>
-                              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">カウントモード</span>
-                              <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">ポリシーを評価してブロック対象ドメインを記録するが、トラフィックは実際にはブロックしない。本番適用前の監査に利用できる。</p>
-                            </div>
-                          </label>
-                        </div>
-                      </div>
-                    )}
-                  </div>
                   {/* Docker in Docker (DinD) */}
                   <div>
                     <label className="flex items-start gap-2 cursor-pointer">

--- a/src/app/components/SessionProfileSelect.tsx
+++ b/src/app/components/SessionProfileSelect.tsx
@@ -119,19 +119,6 @@ export default function SessionProfileSelect({
               {selected.config.params.agent_type}
             </span>
           )}
-          {selected.config?.params?.sandbox?.enabled && (
-            <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-orange-600 dark:text-orange-400">
-              <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-              サンドボックス
-            </span>
-          )}
-          {selected.config?.params?.auth_proxy !== undefined && (
-            <span className={`text-[10px] font-medium ${selected.config.params.auth_proxy ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-500 dark:text-gray-400'}`}>
-              認証プロキシ{selected.config.params.auth_proxy ? '' : 'OFF'}
-            </span>
-          )}
           {selected.config?.environment && Object.keys(selected.config.environment).length > 0 && (
             <span className="text-[10px] text-gray-500 dark:text-gray-400">
               ENV×{Object.keys(selected.config.environment).length}

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -19,7 +19,6 @@ import SessionProfileSelect from '../../components/SessionProfileSelect'
 import { SessionCreationProgress, SessionCreationStatus } from '../../../types/sessionProgress'
 import { useTeamScope } from '../../../contexts/TeamScopeContext'
 
-type AuthProxyMode = 'default' | 'enabled' | 'disabled'
 type CheckoutTarget = 'branch' | 'pr' | ''
 
 const getAgentTypeLabel = (agentType: AgentApiType): string => {
@@ -90,12 +89,8 @@ export default function NewSessionPage() {
   const [cycleMessage, setCycleMessage] = useState('')
   const [cycleMaxCount, setCycleMaxCount] = useState(10)
   const [sessionProfileId, setSessionProfileId] = useState('')
-  const [sandboxEnabled, setSandboxEnabled] = useState(false)
-  const [sandboxMode, setSandboxMode] = useState<'allowlist' | 'denylist'>('allowlist')
-  const [sandboxDomains, setSandboxDomains] = useState('')
   const [dockerEnabled, setDockerEnabled] = useState(false)
   const [dockerRegistries, setDockerRegistries] = useState<Array<{ server: string; username: string; password: string; secretName: string; insecure: boolean }>>([])
-  const [authProxyMode, setAuthProxyMode] = useState<AuthProxyMode>('default')
   const [sessionTTL, setSessionTTL] = useState('')
 
   const addDockerRegistry = () => {
@@ -221,24 +216,6 @@ export default function NewSessionPage() {
         params.cycle_message = cycleMessage.trim()
         if (cycleMaxCount > 0) {
           params.cycle_max_count = cycleMaxCount
-        }
-      }
-
-      // 認証プロキシが明示指定されている場合は送信
-      if (authProxyMode !== 'default') {
-        params.auth_proxy = authProxyMode === 'enabled'
-      }
-
-      // サンドボックスが有効な場合はsandboxを送信
-      if (sandboxEnabled) {
-        const domains = sandboxDomains
-          .split('\n')
-          .map(d => d.trim())
-          .filter(d => d.length > 0)
-        params.sandbox = {
-          enabled: true,
-          ...(sandboxMode === 'allowlist' && domains.length > 0 ? { allowed_domains: domains } : {}),
-          ...(sandboxMode === 'denylist' && domains.length > 0 ? { denied_domains: domains } : {}),
         }
       }
 
@@ -702,11 +679,6 @@ export default function NewSessionPage() {
                     サイクル{cycleMaxCount > 0 ? ` (${cycleMaxCount}回)` : ''}
                   </span>
                 )}
-                {sandboxEnabled && (
-                  <span className="px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900/40 text-orange-600 dark:text-orange-400 text-xs rounded-full">
-                    サンドボックス
-                  </span>
-                )}
               </button>
 
               {showAdvancedSettings && (
@@ -837,110 +809,6 @@ export default function NewSessionPage() {
                           />
                           <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
                             0 の場合は無制限。<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">/tmp/check/CYCLE_COUNT</code> で進捗を確認できます。
-                          </p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* 認証プロキシ */}
-                  <div>
-                    <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">認証プロキシ</p>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                      {([
-                        { value: 'default', label: 'デフォルト', description: 'profile/server に従う' },
-                        { value: 'enabled', label: '有効', description: 'このセッションに追加' },
-                        { value: 'disabled', label: '無効', description: 'このセッションでは使わない' },
-                      ] as { value: AuthProxyMode; label: string; description: string }[]).map(({ value, label, description }) => (
-                        <label key={value} className={`flex items-start gap-2 p-2 rounded-lg border cursor-pointer transition-colors ${authProxyMode === value ? 'border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20' : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'}`}>
-                          <input
-                            type="radio"
-                            name="auth-proxy-mode"
-                            value={value}
-                            checked={authProxyMode === value}
-                            onChange={() => setAuthProxyMode(value)}
-                            disabled={isCreating}
-                            className="mt-0.5 w-3.5 h-3.5 text-emerald-600 border-gray-300 dark:border-gray-600 focus:ring-emerald-500 flex-shrink-0"
-                          />
-                          <span>
-                            <span className="block text-xs font-medium text-gray-700 dark:text-gray-300">{label}</span>
-                            <span className="block text-xs text-gray-400 dark:text-gray-500">{description}</span>
-                          </span>
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* サンドボックス */}
-                  <div>
-                    <div className="flex items-center justify-between mb-2">
-                      <p className="text-xs font-medium text-gray-600 dark:text-gray-400">ネットワークサンドボックス</p>
-                      <label className="flex items-center gap-2 cursor-pointer">
-                        <span className="text-xs text-gray-400 dark:text-gray-500">
-                          {sandboxEnabled ? '有効' : '無効'}
-                        </span>
-                        <button
-                          type="button"
-                          role="switch"
-                          aria-checked={sandboxEnabled}
-                          onClick={() => setSandboxEnabled(!sandboxEnabled)}
-                          disabled={isCreating}
-                          className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${
-                            sandboxEnabled ? 'bg-orange-500' : 'bg-gray-300 dark:bg-gray-600'
-                          }`}
-                        >
-                          <span
-                            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                              sandboxEnabled ? 'translate-x-4' : 'translate-x-0'
-                            }`}
-                          />
-                        </button>
-                      </label>
-                    </div>
-                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">
-                      iptables でセッションの外部ネットワークアクセスを制限します。ブロックするドメインを指定できます。
-                    </p>
-                    {sandboxEnabled && (
-                      <div className="pl-1 space-y-3">
-                        {/* モード選択 */}
-                        <div className="flex gap-3">
-                          {([
-                            { value: 'allowlist', label: '許可リスト', description: '指定ドメインのみ通過' },
-                            { value: 'denylist', label: 'ブロックリスト', description: '指定ドメインのみ拒否' },
-                          ] as { value: 'allowlist' | 'denylist'; label: string; description: string }[]).map(({ value, label, description }) => (
-                            <label key={value} className={`flex-1 flex items-start gap-2 p-2 rounded-lg border cursor-pointer transition-colors ${sandboxMode === value ? 'border-orange-400 bg-orange-50 dark:bg-orange-900/20' : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'}`}>
-                              <input
-                                type="radio"
-                                name="sandbox-mode"
-                                value={value}
-                                checked={sandboxMode === value}
-                                onChange={() => setSandboxMode(value)}
-                                disabled={isCreating}
-                                className="mt-0.5 w-3.5 h-3.5 text-orange-500 border-gray-300 dark:border-gray-600 focus:ring-orange-500 flex-shrink-0"
-                              />
-                              <span>
-                                <span className="block text-xs font-medium text-gray-700 dark:text-gray-300">{label}</span>
-                                <span className="block text-xs text-gray-400 dark:text-gray-500">{description}</span>
-                              </span>
-                            </label>
-                          ))}
-                        </div>
-                        {/* ドメイン入力 */}
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
-                            {sandboxMode === 'allowlist' ? '許可するドメイン' : 'ブロックするドメイン'}
-                          </label>
-                          <textarea
-                            value={sandboxDomains}
-                            onChange={(e) => setSandboxDomains(e.target.value)}
-                            placeholder={sandboxMode === 'allowlist' ? 'api.example.com\n*.trusted.com' : 'github.com\n*.github.com'}
-                            rows={3}
-                            disabled={isCreating}
-                            className="w-full px-3 py-2 text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 dark:bg-gray-700 dark:text-white resize-y font-mono"
-                          />
-                          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                            1行に1ドメイン。ワイルドカード（<code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">*.example.com</code>）も使用可能。
-                            {sandboxMode === 'allowlist' && '空の場合はすべてのドメインをブロック。'}
                           </p>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- remove auth proxy (scia) controls from session creation and session profile forms
- remove sandbox/network policy (nfa) controls and badges from profile UI
- stop sending auth_proxy, sandbox, or sandbox_policy_id from these forms

## Verification
- npm run type-check
- npm run lint
- npm run build