### PR TITLE
Add Claude Legacy agent type option

### DIFF
--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -18,7 +18,7 @@ interface SessionProfileFormModalProps {
 }
 
 type KeyValuePair = { key: string; value: string }
-const SUPPORTED_AGENT_TYPES = new Set(['claude-acp', 'codex-acp', 'pi-ollama', 'cursor'])
+const SUPPORTED_AGENT_TYPES = new Set(['claude-legacy', 'claude-acp', 'codex-acp', 'pi-ollama', 'cursor'])
 
 const normalizeAgentType = (value?: string): string => {
   return value && SUPPORTED_AGENT_TYPES.has(value) ? value : ''
@@ -515,6 +515,7 @@ export default function SessionProfileFormModal({
                     <div className="space-y-2">
                       {([
                         { value: '', label: 'デフォルト', description: 'agent_type を送信しない' },
+                        { value: 'claude-legacy', label: 'Claude Legacy', description: 'agent_type=claude-legacy を送信' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
                         { value: 'pi-ollama', label: 'Pi Ollama', description: 'agent_type=pi-ollama を送信' },

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -23,6 +23,8 @@ type CheckoutTarget = 'branch' | 'pr' | ''
 
 const getAgentTypeLabel = (agentType: AgentApiType): string => {
   switch (agentType) {
+    case 'claude-legacy':
+      return 'Claude Legacy'
     case 'claude-acp':
       return 'Claude ACP'
     case 'codex-acp':
@@ -970,6 +972,7 @@ export default function NewSessionPage() {
                       <div className="space-y-2">
                       {([
                         { value: 'default', label: 'デフォルト', description: 'agent_type を送信しない' },
+                        { value: 'claude-legacy', label: 'Claude Legacy', description: 'agent_type=claude-legacy を送信' },
                         { value: 'claude-acp', label: 'Claude ACP', description: 'agent_type=claude-acp を送信' },
                         { value: 'codex-acp', label: 'Codex ACP', description: 'agent_type=codex-acp を送信' },
                         { value: 'pi-ollama', label: 'Pi Ollama', description: 'agent_type=pi-ollama を送信' },

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -206,11 +206,12 @@ export interface FontSettings {
 
 // セッション作成時に使用するエージェント種別
 // 'default': agent_type を送信しない（バックエンドのデフォルト動作）
+// 'claude-legacy': 従来の agentapi + Claude CLI を使用
 // 'claude-acp': claude-acp を使用
 // 'codex-acp': codex-acp を使用
 // 'pi-ollama': Pi + pi-acp + pi-ollama-cloud を使用
 // 'cursor': Cursor ACP を使用
-export type AgentApiType = 'default' | 'claude-acp' | 'codex-acp' | 'pi-ollama' | 'cursor'
+export type AgentApiType = 'default' | 'claude-legacy' | 'claude-acp' | 'codex-acp' | 'pi-ollama' | 'cursor'
 
 export interface GlobalSettings {
   agentApiProxy: AgentApiProxySettings
@@ -817,6 +818,7 @@ export const setFontSettings = (fontSettings: FontSettings): void => {
 export const getAgentApiType = (): AgentApiType => {
   const settings = loadFullGlobalSettings()
   if (
+    settings.agentApiType === 'claude-legacy' ||
     settings.agentApiType === 'claude-acp' ||
     settings.agentApiType === 'codex-acp' ||
     settings.agentApiType === 'pi-ollama' ||


### PR DESCRIPTION
## Summary
- add `claude-legacy` to the persisted agent type union and validation
- expose Claude Legacy in new-session and session-profile forms
- continue omitting `agent_type` for the default selection to preserve existing behavior

## Validation
- `bun run type-check`
- `bun run lint` (passes with pre-existing warnings)
- `bun run test` (16 tests pass)
- `bun run build`