### PR TITLE
全リソースのIDをコピー可能にする

### DIFF
--- a/src/app/components/ConversationCard.tsx
+++ b/src/app/components/ConversationCard.tsx
@@ -1,6 +1,7 @@
 import { Chat } from '../../types/chat'
 import StatusBadge from './StatusBadge'
 import { formatDate } from '../../utils/timeUtils'
+import CopyableResourceId from './CopyableResourceId'
 
 interface ConversationCardProps {
   chat: Chat
@@ -59,9 +60,7 @@ export default function ConversationCard({ chat }: ConversationCardProps) {
 
       <div className="mt-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-400 dark:text-gray-500">
-            ID: {chat.id.slice(0, 8)}...
-          </span>
+          <CopyableResourceId id={chat.id} />
           {chat.metadata?.repository && (
             <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
               {chat.metadata.repository}

--- a/src/app/components/CopyableResourceId.tsx
+++ b/src/app/components/CopyableResourceId.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+
+interface CopyableResourceIdProps {
+  id: string
+  className?: string
+}
+
+export default function CopyableResourceId({ id, className = '' }: CopyableResourceIdProps) {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+  }, [])
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(id)
+      setCopied(true)
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+      resetTimer.current = setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      console.error('Failed to copy resource ID:', error)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`group inline-flex max-w-full items-center gap-1 rounded px-1.5 py-0.5 text-xs text-gray-400 transition-colors hover:bg-gray-100 hover:text-blue-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-blue-400 ${className}`}
+      title={copied ? 'IDをコピーしました' : `${id} をコピー`}
+      aria-label={copied ? 'IDをコピーしました' : `ID ${id} をコピー`}
+    >
+      <span className="truncate font-mono">ID: {id}</span>
+      {copied ? (
+        <Check className="h-3.5 w-3.5 flex-shrink-0 text-green-500" aria-hidden="true" />
+      ) : (
+        <Copy className="h-3.5 w-3.5 flex-shrink-0 opacity-60 group-hover:opacity-100" aria-hidden="true" />
+      )}
+    </button>
+  )
+}

--- a/src/app/components/MemoryCard.tsx
+++ b/src/app/components/MemoryCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Memory, MemoryScope } from '../../types/memory'
+import CopyableResourceId from './CopyableResourceId'
 
 interface MemoryCardProps {
   memory: Memory
@@ -69,6 +70,8 @@ export default function MemoryCard({
         </div>
         <ScopeBadge scope={memory.scope} />
       </div>
+
+      <CopyableResourceId id={memory.id} className="mb-3" />
 
       {/* Content preview */}
       {memory.content && (

--- a/src/app/components/ScheduleCard.tsx
+++ b/src/app/components/ScheduleCard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { Schedule } from '../../types/schedule'
 import ScheduleStatusBadge from './ScheduleStatusBadge'
+import CopyableResourceId from './CopyableResourceId'
 
 interface ScheduleCardProps {
   schedule: Schedule
@@ -77,6 +78,7 @@ export default function ScheduleCard({
           <h3 className="text-lg font-medium text-gray-900 dark:text-white truncate">
             {schedule.name}
           </h3>
+          <CopyableResourceId id={schedule.id} className="mt-1" />
           <div className="flex items-center gap-2 mt-1">
             <ScheduleStatusBadge status={schedule.status} />
             {schedule.timezone && (

--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { SessionProfile } from '../../types/session_profile'
+import CopyableResourceId from './CopyableResourceId'
 
 interface SessionProfileCardProps {
   profile: SessionProfile
@@ -67,6 +68,8 @@ export default function SessionProfileCard({
           )}
         </div>
       </div>
+
+      <CopyableResourceId id={profile.id} className="mb-3" />
 
       {/* Description */}
       {profile.description && (

--- a/src/app/components/SlackbotCard.tsx
+++ b/src/app/components/SlackbotCard.tsx
@@ -2,6 +2,7 @@
 
 import { SlackBot, SlackBotStatus } from '../../types/slackbot'
 import SlackbotStatusBadge from './SlackbotStatusBadge'
+import CopyableResourceId from './CopyableResourceId'
 
 interface SlackbotCardProps {
   slackbot: SlackBot
@@ -62,6 +63,8 @@ export default function SlackbotCard({
         </div>
         <SlackbotStatusBadge status={slackbot.status} />
       </div>
+
+      <CopyableResourceId id={slackbot.id} className="mb-3" />
 
       {/* Allowed Channel Names */}
       {slackbot.allowed_channel_names && slackbot.allowed_channel_names.length > 0 && (

--- a/src/app/components/TaskListPanel.tsx
+++ b/src/app/components/TaskListPanel.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { ExternalLink, Terminal, RefreshCw, AlertCircle, ClipboardList } from 'lucide-react'
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
 import { Task } from '../../types/task'
+import CopyableResourceId from './CopyableResourceId'
 
 const REFRESH_INTERVAL_MS = 30000
 
@@ -58,6 +59,7 @@ function TaskItem({ task }: { task: Task }) {
           >
             {task.title}
           </p>
+          <CopyableResourceId id={task.id} className="mt-1" />
           <div className="flex items-center gap-1.5 mt-1 flex-wrap">
             <StatusBadge status={task.status} />
             <TypeBadge type={task.task_type} />

--- a/src/app/components/WebhookCard.tsx
+++ b/src/app/components/WebhookCard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { Webhook } from '../../types/webhook'
 import WebhookStatusBadge from './WebhookStatusBadge'
+import CopyableResourceId from './CopyableResourceId'
 
 interface WebhookCardProps {
   webhook: Webhook
@@ -99,6 +100,7 @@ export default function WebhookCard({
           <h3 className="text-lg font-medium text-gray-900 dark:text-white truncate">
             {webhook.name}
           </h3>
+          <CopyableResourceId id={webhook.id} className="mt-1" />
           <div className="flex items-center gap-2 mt-1">
             <WebhookStatusBadge status={webhook.status} />
             <span className="text-xs px-2 py-0.5 bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400 rounded-full">

--- a/src/app/sandbox-policies/page.tsx
+++ b/src/app/sandbox-policies/page.tsx
@@ -7,6 +7,7 @@ import { useTeamScope } from '../../contexts/TeamScopeContext'
 import TopBar from '../components/TopBar'
 import NavigationTabs from '../components/NavigationTabs'
 import TagFilterSidebar from '../components/TagFilterSidebar'
+import CopyableResourceId from '../components/CopyableResourceId'
 
 // ---- Session Domain Import Page ----
 interface SessionDomainImportPanelProps {
@@ -642,7 +643,7 @@ function PolicyCard({
       ) : (
         <p className="text-xs text-gray-400">ドメイン未設定</p>
       )}
-      <p className="truncate text-xs text-gray-400 dark:text-gray-500">ID: {policy.id}</p>
+      <CopyableResourceId id={policy.id} />
     </div>
   )
 }

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { ExternalLink, Terminal, RefreshCw, CheckCircle2, Circle, AlertCircle, ClipboardList, ArrowLeft } from 'lucide-react'
 import TopBar from '../components/TopBar'
+import CopyableResourceId from '../components/CopyableResourceId'
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
 import { Task } from '../../types/task'
 
@@ -60,6 +61,8 @@ function TaskItem({
         >
           {task.title}
         </p>
+
+        <CopyableResourceId id={task.id} className="mt-1" />
 
         {task.description && (
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2">


### PR DESCRIPTION
## 概要
- 共通のIDコピーコンポーネントを追加
- Schedule / Webhook / SlackBot / Memory / Session Profile / Sandbox Policy / Task / SessionのID表示にコピー操作を追加
- コピー成功時にチェックアイコンを2秒間表示

## 検証
- npm test -- --passWithNoTests（16 tests passed）
- Next.js production compile 成功
- git diff --check 成功

## 既知の検証環境上の問題
- 完全な型チェックは、既存の lucide-react 型定義欠落および src/utils/pushNotification.ts の既存型エラーで停止