### PR TITLE
feat: select credentials in session profiles

### DIFF
--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -99,6 +99,13 @@ export default function SessionProfileCard({
         {profile.config?.unsynced_file_paths && profile.config.unsynced_file_paths.length > 0 && (
           <span>同期除外: <strong className="text-gray-700 dark:text-gray-300">{profile.config.unsynced_file_paths.length}</strong></span>
         )}
+        {profile.config?.params?.credential_source && (
+          <span>
+            認証情報: <strong className="text-gray-700 dark:text-gray-300">
+              {{ session_user: '作成者', team: 'チーム', none: '配布なし' }[profile.config.params.credential_source]}
+            </strong>
+          </span>
+        )}
       </div>
 
       {/* Timestamps */}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -145,7 +145,6 @@ export default function SessionProfileFormModal({
 
       const source = cfg?.params?.credential_source ?? ''
       setCredentialSource(source)
-      if (source) setShowAdvanced(true)
     } else {
       // Reset form
       setName('')
@@ -377,6 +376,26 @@ export default function SessionProfileFormModal({
                 rows={2}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y"
               />
+            </div>
+
+            {/* Credential source */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                認証情報の配布元
+              </label>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                Codex の <code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">auth.json</code> など、セッションへ配布する認証情報を選択します。
+              </p>
+              <select
+                value={credentialSource}
+                onChange={(e) => setCredentialSource(e.target.value as CredentialSource | '')}
+                className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+              >
+                <option value="">デフォルト（個人: 作成者 / チーム: 配布なし）</option>
+                <option value="session_user">セッションを作成したユーザー</option>
+                <option value="team">セッションのチーム</option>
+                <option value="none">配布しない</option>
+              </select>
             </div>
 
             {/* is_default */}
@@ -698,26 +717,6 @@ export default function SessionProfileFormModal({
                       placeholder="例: 24h、72h、168h"
                       className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                     />
-                  </div>
-
-                  {/* 認証情報の配布元 */}
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      認証情報の配布元
-                    </label>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                      Codex の <code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">auth.json</code> など、セッションへ配布する管理認証ファイルの所有者を選択します。
-                    </p>
-                    <select
-                      value={credentialSource}
-                      onChange={(e) => setCredentialSource(e.target.value as CredentialSource | '')}
-                      className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
-                    >
-                      <option value="">デフォルト（個人セッション: 作成者 / チームセッション: 配布なし）</option>
-                      <option value="session_user">セッションを作成したユーザー</option>
-                      <option value="team">セッションのチーム</option>
-                      <option value="none">配布しない</option>
-                    </select>
                   </div>
 
                   {/* 同期しないファイルパス */}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -5,6 +5,7 @@ import {
   SessionProfile,
   CreateSessionProfileRequest,
   UpdateSessionProfileRequest,
+  CredentialSource,
 } from '../../types/session_profile'
 import { SandboxPolicy } from '../../types/sandbox_policy'
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
@@ -54,6 +55,7 @@ export default function SessionProfileFormModal({
   // Session TTL
   const [sessionTTL, setSessionTTL] = useState('')
   const [unsyncedFilePaths, setUnsyncedFilePaths] = useState('')
+  const [credentialSource, setCredentialSource] = useState<CredentialSource | ''>('')
 
   const addDockerRegistry = () => setDockerRegistries(prev => [...prev, { server: '', username: '', password: '', secretName: '', insecure: false }])
   const removeDockerRegistry = (index: number) => setDockerRegistries(prev => prev.filter((_, i) => i !== index))
@@ -140,6 +142,10 @@ export default function SessionProfileFormModal({
       const paths = cfg?.unsynced_file_paths ?? cfg?.params?.unsynced_file_paths ?? []
       setUnsyncedFilePaths(paths.join('\n'))
       if (paths.length > 0) setShowAdvanced(true)
+
+      const source = cfg?.params?.credential_source ?? ''
+      setCredentialSource(source)
+      if (source) setShowAdvanced(true)
     } else {
       // Reset form
       setName('')
@@ -153,6 +159,7 @@ export default function SessionProfileFormModal({
       setSandboxPolicyId('')
       setSessionTTL('')
       setUnsyncedFilePaths('')
+      setCredentialSource('')
       setShowAdvanced(false)
     }
     setError(null)
@@ -255,6 +262,7 @@ export default function SessionProfileFormModal({
         ...(agentType.trim() ? { agent_type: agentType.trim() } : {}),
         sandbox: sandboxConfig,
         ...(dockerConfig ? { docker: dockerConfig } : {}),
+        ...(credentialSource ? { credential_source: credentialSource } : {}),
       }
 
       const config = {
@@ -690,6 +698,26 @@ export default function SessionProfileFormModal({
                       placeholder="例: 24h、72h、168h"
                       className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                     />
+                  </div>
+
+                  {/* 認証情報の配布元 */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      認証情報の配布元
+                    </label>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                      Codex の <code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">auth.json</code> など、セッションへ配布する管理認証ファイルの所有者を選択します。
+                    </p>
+                    <select
+                      value={credentialSource}
+                      onChange={(e) => setCredentialSource(e.target.value as CredentialSource | '')}
+                      className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    >
+                      <option value="">デフォルト（個人セッション: 作成者 / チームセッション: 配布なし）</option>
+                      <option value="session_user">セッションを作成したユーザー</option>
+                      <option value="team">セッションのチーム</option>
+                      <option value="none">配布しない</option>
+                    </select>
                   </div>
 
                   {/* 同期しないファイルパス */}

--- a/src/types/session_profile.ts
+++ b/src/types/session_profile.ts
@@ -10,7 +10,10 @@ export interface SessionProfileParams {
   auth_proxy?: boolean;
   session_ttl?: string;
   unsynced_file_paths?: string[];
+  credential_source?: CredentialSource;
 }
+
+export type CredentialSource = 'session_user' | 'team' | 'none';
 
 // Session profile config
 export interface SessionProfileConfig {


### PR DESCRIPTION
## Summary
- add a managed credential source selector to the Session Profile form
- support `session_user`, `team`, `none`, and the backward-compatible default
- preserve and submit the selection through `config.params.credential_source`
- show the selected credential source on Session Profile cards

## Backend dependency
- Depends on takutakahashi/agentapi-proxy#925

## Validation
- `bun run type-check` ✅
- `bun run lint` ✅ (existing warnings only)
- `mise exec node@20.20.2 -- node node_modules/vitest/vitest.mjs run` ✅ (16 tests)
- `bun run build` ✅
