### PR TITLE
feat: add team Codex device auth settings

### DIFF
--- a/src/app/settings/team/page.tsx
+++ b/src/app/settings/team/page.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { SettingsData, BedrockConfig, APIMCPServerConfig, MarketplaceConfig, GitSyncConfig, prepareSettingsForSave } from '@/types/settings'
-import { BedrockSettings, SettingsAccordion, MCPServerSettings, MarketplaceSettings, PluginSettings, EnvVarsSettings, GitHubSyncSettings } from '@/components/settings'
-import { createAgentAPIProxyClientFromStorage } from '@/lib/agentapi-proxy-client'
+import { BedrockSettings, SettingsAccordion, MCPServerSettings, MarketplaceSettings, PluginSettings, EnvVarsSettings, GitHubSyncSettings, CodexDeviceAuthSettings } from '@/components/settings'
+import { createAgentAPIProxyClientFromStorage, CredentialsMetadata } from '@/lib/agentapi-proxy-client'
 import { useToast } from '@/contexts/ToastContext'
 
 export default function TeamSettingsPage() {
@@ -16,6 +16,7 @@ export default function TeamSettingsPage() {
   const [error, setError] = useState<string | null>(null)
   const [isTeamLoaded, setIsTeamLoaded] = useState(false)
   const [gitSyncConfig, setGitSyncConfig] = useState<GitSyncConfig | undefined>(undefined)
+  const [credentialsMetadata, setCredentialsMetadata] = useState<CredentialsMetadata | null>(null)
   const { showToast } = useToast()
   const hasUnsavedChangesRef = useRef(false)
 
@@ -53,6 +54,12 @@ export default function TeamSettingsPage() {
       setOriginalSettings(data)
       setTeamName(name)
       setIsTeamLoaded(true)
+
+      try {
+        setCredentialsMetadata(await client.getCredentials(name))
+      } catch {
+        setCredentialsMetadata(null)
+      }
 
       // GitHub Sync 設定を読み込み
       try {
@@ -261,6 +268,23 @@ export default function TeamSettingsPage() {
 
       {isTeamLoaded && (
         <>
+          <SettingsAccordion
+            title="Codex Authentication"
+            description="Register a shared Codex auth.json for the team"
+            defaultOpen={false}
+          >
+            <CodexDeviceAuthSettings
+              scope="team"
+              teamId={teamName}
+              hasCredentials={!!credentialsMetadata?.has_data}
+              onAuthComplete={async () => {
+                const client = createAgentAPIProxyClientFromStorage()
+                setCredentialsMetadata(await client.getCredentials(teamName))
+                showToast('チームの Codex 認証情報を保存しました', 'success')
+              }}
+            />
+          </SettingsAccordion>
+
           <SettingsAccordion
             title="Marketplace"
             description="Configure plugin marketplaces"

--- a/src/components/settings/CodexDeviceAuthSettings.tsx
+++ b/src/components/settings/CodexDeviceAuthSettings.tsx
@@ -13,11 +13,13 @@ interface DeviceAuthState {
 interface CodexDeviceAuthSettingsProps {
   hasCredentials: boolean
   onAuthComplete?: () => void
+  scope?: 'user' | 'team'
+  teamId?: string
 }
 
 const POLL_INTERVAL_MS = 3000
 
-export function CodexDeviceAuthSettings({ hasCredentials, onAuthComplete }: CodexDeviceAuthSettingsProps) {
+export function CodexDeviceAuthSettings({ hasCredentials, onAuthComplete, scope = 'user', teamId }: CodexDeviceAuthSettingsProps) {
   const [phase, setPhase] = useState<AuthPhase>('idle')
   const [starting, setStarting] = useState(false)
   const [deviceAuth, setDeviceAuth] = useState<DeviceAuthState | null>(null)
@@ -78,7 +80,9 @@ export function CodexDeviceAuthSettings({ hasCredentials, onAuthComplete }: Code
 
     const client = createAgentAPIProxyClientFromStorage()
     try {
-      const res = await client.startCodexDeviceAuth()
+      const res = await client.startCodexDeviceAuth(
+        scope === 'team' ? { scope, team_id: teamId } : { scope }
+      )
       setDeviceAuth({ userCode: res.user_code, verificationUri: res.verification_uri })
       setPhase('polling')
       pollTimerRef.current = setTimeout(poll, POLL_INTERVAL_MS)
@@ -133,7 +137,7 @@ export function CodexDeviceAuthSettings({ hasCredentials, onAuthComplete }: Code
             デバイス認証
           </label>
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            codex コマンドを使って認証を行います。auth.json を手動でアップロードする代わりに利用できます。
+            codex コマンドを使って認証を行います。{scope === 'team' ? `${teamId} の共有 auth.json` : '個人の auth.json'} として保存されます。
           </p>
         </div>
         <div>

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -102,6 +102,11 @@ export interface CodexDeviceAuthStatus {
   status: 'pending' | 'authorized' | 'denied';
 }
 
+export interface CodexDeviceAuthTarget {
+  scope?: 'user' | 'team';
+  team_id?: string;
+}
+
 // GitHubUser type (moved from profile.ts)
 export interface GitHubUser {
   id: number;
@@ -1698,12 +1703,13 @@ export class AgentAPIProxyClient {
    * Start Codex OAuth device authorization flow
    * POST /codex/device-auth
    */
-  async startCodexDeviceAuth(): Promise<CodexDeviceAuthStart> {
+  async startCodexDeviceAuth(target?: CodexDeviceAuthTarget): Promise<CodexDeviceAuthStart> {
     if (this.debug) {
       console.log('[AgentAPIProxy] Starting Codex device auth');
     }
     return await this.makeRequest<CodexDeviceAuthStart>('/codex/device-auth', {
       method: 'POST',
+      ...(target ? { body: JSON.stringify(target) } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary
- add a Codex authentication section to Team Settings
- send team scope and team_id to the device auth API
- refresh team credential metadata after authorization
- preserve the existing personal device auth flow

## Validation
- bun run type-check: passed
- bun run test: 16 tests passed
- next build: compilation and type validation passed; environment stopped during static page generation