### PR TITLE
feat: manage personal and team API tokens

### DIFF
--- a/src/app/components/ApiTokenCreateModal.tsx
+++ b/src/app/components/ApiTokenCreateModal.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  API_TOKEN_PERMISSIONS,
+  API_TOKEN_PERMISSION_LABELS,
+  ApiTokenPermission,
+  ApiTokenScope,
+  CreateApiTokenRequest,
+  CreateApiTokenResponse,
+} from '../../types/api_token'
+import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
+
+interface ApiTokenCreateModalProps {
+  isOpen: boolean
+  scope: ApiTokenScope
+  teamId?: string
+  onClose: () => void
+  onCreated: (response: CreateApiTokenResponse) => void
+}
+
+/** Expiry choices in days; `null` means no expiration. */
+const EXPIRY_OPTIONS: Array<{ label: string; days: number | null }> = [
+  { label: '30日', days: 30 },
+  { label: '90日', days: 90 },
+  { label: '365日', days: 365 },
+  { label: '無期限', days: null },
+]
+
+const NAME_MAX_LENGTH = 64
+
+export default function ApiTokenCreateModal({
+  isOpen,
+  scope,
+  teamId,
+  onClose,
+  onCreated,
+}: ApiTokenCreateModalProps) {
+  const [name, setName] = useState('')
+  const [selectedPermissions, setSelectedPermissions] = useState<string[]>([])
+  const [expiryDays, setExpiryDays] = useState<number | null>(30)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const resetForm = useCallback(() => {
+    setName('')
+    setSelectedPermissions([])
+    setExpiryDays(30)
+    setError(null)
+  }, [])
+
+  useEffect(() => {
+    if (isOpen) resetForm()
+  }, [isOpen, resetForm])
+
+  // ESC to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen && !isSubmitting) onClose()
+    }
+    if (isOpen) document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose, isSubmitting])
+
+  const togglePermission = (perm: ApiTokenPermission) => {
+    setSelectedPermissions((prev) =>
+      prev.includes(perm) ? prev.filter((p) => p !== perm) : [...prev, perm]
+    )
+  }
+
+  const trimmedName = name.trim()
+  const nameValid = trimmedName.length >= 1 && trimmedName.length <= NAME_MAX_LENGTH
+  const canSubmit = nameValid && !isSubmitting
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!nameValid) {
+      setError('トークン名は1〜64文字で入力してください')
+      return
+    }
+
+    // For team scope, teamId is required and fixed by the parent section.
+    if (scope === 'team' && !teamId) {
+      setError('チームが選択されていません')
+      return
+    }
+
+    let expires_at: string | null = null
+    if (expiryDays !== null) {
+      const d = new Date()
+      d.setDate(d.getDate() + expiryDays)
+      expires_at = d.toISOString()
+    }
+
+    const payload: CreateApiTokenRequest = {
+      name: trimmedName,
+      scope,
+      team_id: scope === 'team' ? teamId : undefined,
+      permissions: selectedPermissions.length > 0 ? selectedPermissions : undefined,
+      expires_at,
+    }
+
+    try {
+      setIsSubmitting(true)
+      setError(null)
+      const client = createAgentAPIProxyClientFromStorage()
+      const response = await client.createApiToken(payload)
+      // Clear sensitive form state before handing off.
+      resetForm()
+      onCreated(response)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'トークンの作成に失敗しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg w-full max-w-lg shadow-xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {scope === 'team' ? 'チーム API トークンを作成' : 'API トークンを作成'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-50"
+            aria-label="閉じる"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4 max-h-[75vh] overflow-y-auto">
+          {error && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3 text-sm text-red-700 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              トークン名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={NAME_MAX_LENGTH}
+              placeholder="例: CI 用トークン"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+              required
+              autoFocus
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {trimmedName.length}/{NAME_MAX_LENGTH} 文字
+            </p>
+          </div>
+
+          {/* Scope (informational, fixed) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              スコープ
+            </label>
+            <div className="px-3 py-2 text-sm bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300">
+              {scope === 'team' ? (
+                <>チーム (Team) — {teamId || '未選択'}</>
+              ) : (
+                <>パーソナル (Personal)</>
+              )}
+            </div>
+          </div>
+
+          {/* Permissions */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              権限 (パーミッション)
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+              付与する権限を選択してください。未選択の場合は既定の権限が適用されます。
+            </p>
+            <div className="space-y-2">
+              {API_TOKEN_PERMISSIONS.map((perm) => (
+                <label
+                  key={perm}
+                  className="flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-gray-300"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedPermissions.includes(perm)}
+                    onChange={() => togglePermission(perm)}
+                    className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                  />
+                  <span>{API_TOKEN_PERMISSION_LABELS[perm]}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Expiry */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              有効期限
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {EXPIRY_OPTIONS.map((opt) => {
+                const active = expiryDays === opt.days
+                return (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    onClick={() => setExpiryDays(opt.days)}
+                    className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
+                      active
+                        ? 'bg-blue-600 text-white border-blue-600'
+                        : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-blue-400'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </form>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md transition-colors disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            form=""
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="px-4 py-2 text-sm text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 rounded-md transition-colors inline-flex items-center gap-2"
+          >
+            {isSubmitting && (
+              <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            )}
+            {isSubmitting ? '作成中...' : '作成'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/ApiTokenDeleteConfirmModal.tsx
+++ b/src/app/components/ApiTokenDeleteConfirmModal.tsx
@@ -57,11 +57,9 @@ export default function ApiTokenDeleteConfirmModal({
             <div className="text-sm font-medium text-gray-900 dark:text-white">
               {token.name}
             </div>
-            {token.token_prefix && (
-              <div className="mt-1 text-xs font-mono text-gray-500 dark:text-gray-400">
-                {token.token_prefix}
-              </div>
-            )}
+            <div className="mt-1 text-xs font-mono text-gray-500 dark:text-gray-400">
+              {token.token_prefix}
+            </div>
           </div>
           <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-md p-3">
             <p className="text-xs text-yellow-800 dark:text-yellow-300">

--- a/src/app/components/ApiTokenDeleteConfirmModal.tsx
+++ b/src/app/components/ApiTokenDeleteConfirmModal.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useEffect } from 'react'
+import { ApiToken } from '../../types/api_token'
+
+interface ApiTokenDeleteConfirmModalProps {
+  token: ApiToken | null
+  isDeleting?: boolean
+  error?: string | null
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ApiTokenDeleteConfirmModal({
+  token,
+  isDeleting,
+  error,
+  onConfirm,
+  onCancel,
+}: ApiTokenDeleteConfirmModalProps) {
+  // ESC to cancel (not while deleting)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && token && !isDeleting) onCancel()
+    }
+    if (token) document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [token, isDeleting, onCancel])
+
+  if (!token) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg w-full max-w-md shadow-xl overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            トークンを削除
+          </h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isDeleting}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-50"
+            aria-label="閉じる"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-3">
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            以下の API トークンを削除します。この操作は取り消せません。
+          </p>
+          <div className="bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 rounded-md p-3">
+            <div className="text-sm font-medium text-gray-900 dark:text-white">
+              {token.name}
+            </div>
+            {token.token_prefix && (
+              <div className="mt-1 text-xs font-mono text-gray-500 dark:text-gray-400">
+                {token.token_prefix}
+              </div>
+            )}
+          </div>
+          <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-md p-3">
+            <p className="text-xs text-yellow-800 dark:text-yellow-300">
+              削除したトークンが現在の UI セッションで使用されている場合、以降の操作で認証エラーとなりログイン画面に遷移します。
+            </p>
+          </div>
+          {error && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3 text-sm text-red-700 dark:text-red-400">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isDeleting}
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md transition-colors disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="px-4 py-2 text-sm text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 rounded-md transition-colors inline-flex items-center gap-2"
+          >
+            {isDeleting && (
+              <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            )}
+            {isDeleting ? '削除中...' : '削除'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/ApiTokenResultModal.tsx
+++ b/src/app/components/ApiTokenResultModal.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { CreateApiTokenResponse } from '../../types/api_token'
+
+interface ApiTokenResultModalProps {
+  /** The creation response to display. When provided the modal is open. */
+  response: CreateApiTokenResponse | null
+  onClose: () => void
+}
+
+/**
+ * Shows the plaintext API token exactly once after creation.
+ *
+ * Security requirements:
+ *  - The plaintext token is kept only in component state (never localStorage).
+ *  - On close, the parent clears `response` so the token is garbage-collected.
+ *  - A strong one-time warning is shown and the copy action is provided.
+ */
+export default function ApiTokenResultModal({ response, onClose }: ApiTokenResultModalProps) {
+  const [copied, setCopied] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  // Reset transient state whenever a new token is shown.
+  useEffect(() => {
+    if (response) {
+      setCopied(false)
+      setDismissed(false)
+    }
+  }, [response])
+
+  const handleCopy = useCallback(async () => {
+    if (!response) return
+    try {
+      await navigator.clipboard.writeText(response.plaintext_token)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be unavailable; the user can still manually select the text.
+      setCopied(false)
+    }
+  }, [response])
+
+  // ESC to close (after acknowledging)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && response && dismissed) handleClose()
+    }
+    if (response) document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [response, dismissed])
+
+  // handleClose clears local state and notifies the parent to drop the token.
+  const handleClose = useCallback(() => {
+    setDismissed(false)
+    setCopied(false)
+    onClose()
+  }, [onClose])
+
+  if (!response) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg w-full max-w-lg shadow-xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            API トークンを作成しました
+          </h2>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            aria-label="閉じる"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          {/* One-time warning */}
+          <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 rounded-md p-3">
+            <div className="flex items-start gap-2">
+              <svg className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.66-3.12L13.66 4.8a2 2 0 00-3.32 0L3.34 15.88A2 2 0 005 19z" />
+              </svg>
+              <p className="text-sm text-yellow-800 dark:text-yellow-300">
+                <strong>重要:</strong> このトークンは<strong>今度一度だけ</strong>表示されます。
+                閉じると二度と確認できません。今すぐ安全な場所にコピー・保存してください。
+              </p>
+            </div>
+          </div>
+
+          {/* Token name */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+              トークン名
+            </label>
+            <div className="text-sm text-gray-900 dark:text-white">
+              {response.token.name}
+            </div>
+          </div>
+
+          {/* Plaintext token */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+              API トークン
+            </label>
+            <div className="flex items-center gap-2">
+              <code
+                data-testid="api-token-plaintext"
+                className="flex-1 px-3 py-2 text-sm font-mono bg-gray-100 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white break-all select-all"
+              >
+                {response.plaintext_token}
+              </code>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="flex-shrink-0 px-3 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors inline-flex items-center gap-1"
+              >
+                {copied ? (
+                  <>
+                    <svg className="w-4 h-4 text-green-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    コピー済み
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                    コピー
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="px-4 py-2 text-sm text-white bg-gray-700 hover:bg-gray-800 dark:bg-gray-600 dark:hover:bg-gray-500 rounded-md transition-colors"
+          >
+            閉じる（トークンを非表示）
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/ApiTokensSection.tsx
+++ b/src/app/components/ApiTokensSection.tsx
@@ -190,11 +190,9 @@ export default function ApiTokensSection({
                       <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
                         {token.name}
                       </span>
-                      {token.token_prefix && (
-                        <code className="text-xs font-mono text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">
-                          {token.token_prefix}
-                        </code>
-                      )}
+                      <code className="text-xs font-mono text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">
+                        {token.token_prefix}
+                      </code>
                     </div>
                     <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
                       {scope === 'team' && token.created_by && (

--- a/src/app/components/ApiTokensSection.tsx
+++ b/src/app/components/ApiTokensSection.tsx
@@ -1,0 +1,257 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  ApiToken,
+  ApiTokenScope,
+  CreateApiTokenResponse,
+} from '../../types/api_token'
+import { SettingsAccordion } from '../../components/settings'
+import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError } from '../../lib/agentapi-proxy-client'
+import { useToast } from '../../contexts/ToastContext'
+import ApiTokenCreateModal from './ApiTokenCreateModal'
+import ApiTokenResultModal from './ApiTokenResultModal'
+import ApiTokenDeleteConfirmModal from './ApiTokenDeleteConfirmModal'
+
+interface ApiTokensSectionProps {
+  /** Which settings page this section is rendered in. */
+  scope: ApiTokenScope
+  /** Required and fixed for team scope; ignored for personal scope. */
+  teamId?: string
+  /** Whether the accordion is open by default. */
+  defaultOpen?: boolean
+}
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return '無期限'
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+export default function ApiTokensSection({
+  scope,
+  teamId,
+  defaultOpen = false,
+}: ApiTokensSectionProps) {
+  const { showToast } = useToast()
+  const [tokens, setTokens] = useState<ApiToken[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [showCreate, setShowCreate] = useState(false)
+  // Plaintext token shown once. Stored only in memory; cleared on close.
+  const [createdResponse, setCreatedResponse] = useState<CreateApiTokenResponse | null>(null)
+
+  const [deleteTarget, setDeleteTarget] = useState<ApiToken | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const loadTokens = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      const params =
+        scope === 'team'
+          ? { scope, team_id: teamId }
+          : { scope }
+      const res = await client.getApiTokens(params)
+      setTokens(res.items || [])
+    } catch (err) {
+      if (err instanceof AgentAPIProxyError && err.status === 401) {
+        // Auth flow already triggered in makeRequest; surface a message.
+        setError('認証が必要です。ログインし直してください。')
+      } else {
+        setError(err instanceof Error ? err.message : 'API トークンの取得に失敗しました')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [scope, teamId])
+
+  useEffect(() => {
+    // For team scope, only load when a team is selected.
+    if (scope === 'team' && !teamId) return
+    loadTokens()
+  }, [scope, teamId, loadTokens])
+
+  const handleCreated = (response: CreateApiTokenResponse) => {
+    setShowCreate(false)
+    // Keep plaintext only in memory; it will be cleared when the result modal closes.
+    setCreatedResponse(response)
+    // Refresh the list so the new token's metadata appears.
+    loadTokens()
+    showToast('API トークンを作成しました', 'success')
+  }
+
+  const handleResultClose = useCallback(() => {
+    // Discard the plaintext token immediately.
+    setCreatedResponse(null)
+  }, [])
+
+  const handleDeleteRequest = (token: ApiToken) => {
+    setDeleteError(null)
+    setDeleteTarget(token)
+  }
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return
+    const targetId = deleteTarget.id
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      const client = createAgentAPIProxyClientFromStorage()
+      await client.deleteApiToken(targetId)
+      setDeleteTarget(null)
+      showToast('API トークンを削除しました', 'success')
+      // Refresh the list. If the deleted token backed this UI session, the
+      // next request may return 401; the existing auth flow (logout → /login)
+      // handles that. We do not compare plaintext tokens.
+      await loadTokens()
+    } catch (err) {
+      if (err instanceof AgentAPIProxyError && err.status === 401) {
+        // Session lost (likely the deleted token was in use). Auth flow handled.
+        setDeleteError('認証エラーが発生しました。ログインし直してください。')
+      } else {
+        setDeleteError(err instanceof Error ? err.message : '削除に失敗しました')
+      }
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const handleDeleteCancel = () => {
+    if (deleting) return
+    setDeleteTarget(null)
+    setDeleteError(null)
+  }
+
+  return (
+    <SettingsAccordion
+      title="API トークン"
+      description={scope === 'team' ? 'チーム用 API トークンを管理します' : 'パーソナル API トークンを管理します'}
+      defaultOpen={defaultOpen}
+    >
+      <div className="space-y-4">
+        {/* Toolbar */}
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            トークンは作成時に一度だけ表示されます。安全な場所に保存してください。
+          </p>
+          <button
+            type="button"
+            onClick={() => setShowCreate(true)}
+            disabled={scope === 'team' && !teamId}
+            className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            トークンを作成
+          </button>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3 text-sm text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        )}
+
+        {/* Loading */}
+        {loading && tokens.length === 0 && (
+          <div className="flex items-center justify-center py-6">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+          </div>
+        )}
+
+        {/* Empty */}
+        {!loading && !error && tokens.length === 0 && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
+            API トークンがありません
+          </p>
+        )}
+
+        {/* Token list */}
+        {tokens.length > 0 && (
+          <div className="space-y-2">
+            {tokens.map((token) => (
+              <div
+                key={token.id}
+                data-testid={`api-token-row-${token.id}`}
+                className="border border-gray-200 dark:border-gray-700 rounded-lg p-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        {token.name}
+                      </span>
+                      {token.token_prefix && (
+                        <code className="text-xs font-mono text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">
+                          {token.token_prefix}
+                        </code>
+                      )}
+                    </div>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+                      {scope === 'team' && token.created_by && (
+                        <span>作成者: {token.created_by}</span>
+                      )}
+                      <span>作成: {formatDate(token.created_at)}</span>
+                      <span>有効期限: {formatDate(token.expires_at)}</span>
+                    </div>
+                    {token.permissions && token.permissions.length > 0 && (
+                      <div className="mt-1.5 flex flex-wrap gap-1">
+                        {token.permissions.map((p) => (
+                          <span
+                            key={p}
+                            className="px-1.5 py-0.5 text-xs bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded"
+                          >
+                            {p}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteRequest(token)}
+                    disabled={deleting && deleteTarget?.id === token.id}
+                    className="flex-shrink-0 text-xs px-2 py-1 rounded border border-red-200 dark:border-red-700 text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 transition-colors"
+                    aria-label={`トークン ${token.name} を削除`}
+                  >
+                    削除
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Create modal */}
+      <ApiTokenCreateModal
+        isOpen={showCreate}
+        scope={scope}
+        teamId={teamId}
+        onClose={() => setShowCreate(false)}
+        onCreated={handleCreated}
+      />
+
+      {/* One-time result modal (plaintext in memory only) */}
+      <ApiTokenResultModal response={createdResponse} onClose={handleResultClose} />
+
+      {/* Delete confirm modal */}
+      <ApiTokenDeleteConfirmModal
+        token={deleteTarget}
+        isDeleting={deleting}
+        error={deleteError}
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
+      />
+    </SettingsAccordion>
+  )
+}

--- a/src/app/components/__tests__/ApiTokensSection.test.tsx
+++ b/src/app/components/__tests__/ApiTokensSection.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, within, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ApiTokensSection from '../ApiTokensSection'
+import ApiTokenResultModal from '../ApiTokenResultModal'
+import { ApiToken, CreateApiTokenResponse } from '../../../types/api_token'
+import { ToastProvider } from '@/contexts/ToastContext'
+
+// --- Mock the proxy client -------------------------------------------------
+const fakeClient = {
+  getApiTokens: vi.fn(),
+  createApiToken: vi.fn(),
+  getApiToken: vi.fn(),
+  deleteApiToken: vi.fn(),
+}
+
+vi.mock('@/lib/agentapi-proxy-client', () => ({
+  createAgentAPIProxyClientFromStorage: () => fakeClient,
+  AgentAPIProxyError: class AgentAPIProxyError extends Error {
+    status: number
+    code: string
+    constructor(status: number, code: string, message: string) {
+      super(message)
+      this.status = status
+      this.code = code
+      this.name = 'AgentAPIProxyError'
+    }
+  },
+}))
+
+// --- Mock clipboard ---------------------------------------------------------
+const clipboardWrite = vi.fn()
+beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: clipboardWrite },
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+// Helper: render the section. ToastProvider is required by the section.
+function renderSection(props: Partial<React.ComponentProps<typeof ApiTokensSection>> = {}) {
+  return render(
+    <ToastProvider>
+      <ApiTokensSection scope="personal" {...props} />
+    </ToastProvider>
+  )
+}
+
+const sampleToken: ApiToken = {
+  id: 'tok_1',
+  name: 'CI 用',
+  token_prefix: 'ap_user_abc',
+  scope: 'personal',
+  permissions: ['session:create', 'session:list'],
+  created_at: '2024-06-14T00:00:00Z',
+  expires_at: '2025-06-14T00:00:00Z',
+}
+
+describe('ApiTokensSection', () => {
+  it('loads and lists personal tokens', async () => {
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    renderSection({ scope: 'personal' })
+
+    await waitFor(() => expect(screen.getByText('CI 用')).toBeInTheDocument())
+    expect(screen.getByText('ap_user_abc')).toBeInTheDocument()
+    expect(screen.getByText(/session:create/)).toBeInTheDocument()
+    // Query params: personal scope, no team_id
+    expect(fakeClient.getApiTokens).toHaveBeenCalledWith({ scope: 'personal' })
+  })
+
+  it('loads team tokens with team_id', async () => {
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    renderSection({ scope: 'team', teamId: 'org/team' })
+
+    await waitFor(() => expect(screen.getByText('CI 用')).toBeInTheDocument())
+    expect(fakeClient.getApiTokens).toHaveBeenCalledWith({ scope: 'team', team_id: 'org/team' })
+  })
+
+  it('shows empty state', async () => {
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    renderSection()
+    await waitFor(() => expect(screen.getByText('API トークンがありません')).toBeInTheDocument())
+  })
+
+  it('shows error on load failure', async () => {
+    fakeClient.getApiTokens.mockRejectedValue(new Error('boom'))
+    renderSection()
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+  })
+
+  it('creates a token and shows the plaintext exactly once, then clears on close', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    const created: CreateApiTokenResponse = {
+      token: { ...sampleToken, id: 'tok_new', name: 'My Token' },
+      plaintext_token: 'ap_secret_plaintext_123',
+    }
+    fakeClient.createApiToken.mockResolvedValue(created)
+
+    renderSection()
+    await waitFor(() => expect(screen.queryByText('API トークンがありません')).toBeInTheDocument())
+
+    // Open create modal
+    await user.click(screen.getByText('トークンを作成'))
+
+    // Fill form
+    const nameInput = await screen.findByPlaceholderText('例: CI 用トークン')
+    await user.type(nameInput, 'My Token')
+
+    // Submit
+    await user.click(screen.getByRole('button', { name: '作成' }))
+
+    // Result modal shows plaintext exactly once
+    const plaintext = await screen.findByTestId('api-token-plaintext')
+    expect(plaintext).toHaveTextContent('ap_secret_plaintext_123')
+    expect(screen.getByText(/今度一度だけ/)).toBeInTheDocument()
+
+    // createApiToken was called with personal scope, no team_id
+    expect(fakeClient.createApiToken).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'My Token', scope: 'personal' })
+    )
+    expect(fakeClient.createApiToken.mock.calls[0][0].team_id).toBeUndefined()
+
+    // List refreshed
+    await waitFor(() => expect(fakeClient.getApiTokens).toHaveBeenCalledTimes(2))
+
+    // Close result modal -> plaintext disappears
+    await user.click(screen.getByText('閉じる（トークンを非表示）'))
+    await waitFor(() => expect(screen.queryByTestId('api-token-plaintext')).not.toBeInTheDocument())
+    expect(screen.queryByText('ap_secret_plaintext_123')).not.toBeInTheDocument()
+  })
+
+  it('copies plaintext token to clipboard', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    fakeClient.createApiToken.mockResolvedValue({
+      token: { ...sampleToken, name: 'C' },
+      plaintext_token: 'ap_copy_me',
+    })
+    clipboardWrite.mockResolvedValue(undefined)
+    renderSection()
+    await user.click(await screen.findByText('トークンを作成'))
+    await user.type(screen.getByPlaceholderText('例: CI 用トークン'), 'C')
+    await user.click(screen.getByRole('button', { name: '作成' }))
+    await screen.findByTestId('api-token-plaintext')
+
+    await user.click(screen.getByRole('button', { name: /コピー/ }))
+    // The copy path executed and the button switched to the "copied" state.
+    await waitFor(() => expect(screen.getByText('コピー済み')).toBeInTheDocument())
+  })
+
+  it('confirms destructive deletion and refreshes the list', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    fakeClient.deleteApiToken.mockResolvedValue(undefined)
+    renderSection()
+    await screen.findByText('CI 用')
+
+    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
+    // Confirm modal appears
+    expect(screen.getByText(/API トークンを削除します/)).toBeInTheDocument()
+    // Confirm
+    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed')!
+    await user.click(within(dialog).getByRole('button', { name: '削除' }))
+
+    expect(fakeClient.deleteApiToken).toHaveBeenCalledWith('tok_1')
+    // List refreshed after delete
+    await waitFor(() => expect(fakeClient.getApiTokens.mock.calls.length).toBeGreaterThanOrEqual(2))
+  })
+
+  it('cancels deletion', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    renderSection()
+    await screen.findByText('CI 用')
+
+    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
+    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed')!
+    await user.click(within(dialog).getByRole('button', { name: 'キャンセル' }))
+
+    await waitFor(() => expect(screen.queryByText(/API トークンを削除します/)).not.toBeInTheDocument())
+    expect(fakeClient.deleteApiToken).not.toHaveBeenCalled()
+  })
+
+  it('shows delete error without crashing', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    fakeClient.deleteApiToken.mockRejectedValue(new Error('forbidden'))
+    renderSection()
+    await screen.findByText('CI 用')
+
+    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
+    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed')!
+    await user.click(within(dialog).getByRole('button', { name: '削除' }))
+
+    await waitFor(() => expect(screen.getByText('forbidden')).toBeInTheDocument())
+  })
+
+  it('does not persist plaintext token in localStorage', async () => {
+    const user = userEvent.setup()
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    fakeClient.createApiToken.mockResolvedValue({
+      token: { ...sampleToken, name: 'X' },
+      plaintext_token: 'ap_persist_test',
+    })
+    renderSection()
+    await user.click(await screen.findByText('トークンを作成'))
+    await user.type(screen.getByPlaceholderText('例: CI 用トークン'), 'X')
+    await user.click(screen.getByRole('button', { name: '作成' }))
+    await screen.findByTestId('api-token-plaintext')
+
+    // Ensure no localStorage entry ever contained the plaintext.
+    for (const call of setItemSpy.mock.calls) {
+      expect(JSON.stringify(call[1])).not.toContain('ap_persist_test')
+    }
+    setItemSpy.mockRestore()
+  })
+
+  it('validates name length (1-64)', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    renderSection()
+    await user.click(await screen.findByText('トークンを作成'))
+
+    // Submit empty -> button disabled
+    expect(screen.getByRole('button', { name: '作成' })).toBeDisabled()
+
+    // Type name -> enabled
+    await user.type(screen.getByPlaceholderText('例: CI 用トークン'), 'ab')
+    expect(screen.getByRole('button', { name: '作成' })).toBeEnabled()
+  })
+
+  it('team section is fixed to selected team and does not allow personal scope switching', async () => {
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    renderSection({ scope: 'team', teamId: 'org/team' })
+    await waitFor(() => expect(fakeClient.getApiTokens).toHaveBeenCalledWith({ scope: 'team', team_id: 'org/team' }))
+    // No scope selector exists
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+})
+
+describe('ApiTokenResultModal (one-time display)', () => {
+  it('renders nothing when response is null', () => {
+    const { container } = render(<ApiTokenResultModal response={null} onClose={() => {}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('clears plaintext state on close', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const response: CreateApiTokenResponse = {
+      token: { ...sampleToken, name: 'Z' },
+      plaintext_token: 'ap_clear_me',
+    }
+    const { unmount } = render(<ApiTokenResultModal response={response} onClose={onClose} />)
+    expect(screen.getByTestId('api-token-plaintext')).toHaveTextContent('ap_clear_me')
+    await user.click(screen.getByText('閉じる（トークンを非表示）'))
+    expect(onClose).toHaveBeenCalled()
+    // Unmount to simulate parent dropping the response.
+    unmount()
+  })
+})

--- a/src/app/components/__tests__/ApiTokensSection.test.tsx
+++ b/src/app/components/__tests__/ApiTokensSection.test.tsx
@@ -1,12 +1,25 @@
 /**
  * @vitest-environment happy-dom
+ *
+ * Tests for the API Tokens settings section. These assert the *canonical*
+ * agentapi-proxy API contract (spec/openapi.json):
+ *
+ *   GET    /api-tokens?scope=personal|team[&team_id=...]   -> { items: [...] }
+ *   POST   /api-tokens                                    -> { token, plaintext_token }
+ *   DELETE /api-tokens/:id                                -> 204
+ *
+ * - scope vocabulary is `personal` | `team` (never `user`).
+ * - permissions enum is `session:create | session:read | session:update
+ *   | session:delete | admin` (never `session:list`, `session:access`, `*`).
+ * - list items expose `token_prefix`, `permissions`, `created_by`, `created_at`.
+ * - create returns the plaintext secret exactly once in `plaintext_token`.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, within, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ApiTokensSection from '../ApiTokensSection'
 import ApiTokenResultModal from '../ApiTokenResultModal'
-import { ApiToken, CreateApiTokenResponse } from '../../../types/api_token'
+import { ApiToken, CreateApiTokenResponse, CreateApiTokenRequest } from '../../../types/api_token'
 import { ToastProvider } from '@/contexts/ToastContext'
 
 // --- Mock the proxy client -------------------------------------------------
@@ -54,37 +67,68 @@ function renderSection(props: Partial<React.ComponentProps<typeof ApiTokensSecti
   )
 }
 
+// A token matching the canonical APITokenMetadata schema (no obsolete perms).
 const sampleToken: ApiToken = {
   id: 'tok_1',
   name: 'CI 用',
   token_prefix: 'ap_user_abc',
   scope: 'personal',
-  permissions: ['session:create', 'session:list'],
+  user_id: 'user-1',
+  permissions: ['session:create', 'session:read'],
+  created_by: 'user-1',
   created_at: '2024-06-14T00:00:00Z',
+  updated_at: '2024-06-14T00:00:00Z',
   expires_at: '2025-06-14T00:00:00Z',
 }
 
-describe('ApiTokensSection', () => {
-  it('loads and lists personal tokens', async () => {
+const teamToken: ApiToken = {
+  id: 'tok_team_1',
+  name: 'チーム用',
+  token_prefix: 'ap_team_xyz',
+  scope: 'team',
+  user_id: 'svcacct-team-1',
+  team_id: 'org/team',
+  permissions: ['session:read', 'session:update', 'admin'],
+  created_by: 'admin-user',
+  created_at: '2024-07-01T00:00:00Z',
+  updated_at: '2024-07-01T00:00:00Z',
+  expires_at: null,
+}
+
+describe('ApiTokensSection — list (GET /api-tokens)', () => {
+  it('GET /api-tokens?scope=personal returns {items:[...]} and renders them', async () => {
     fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
     renderSection({ scope: 'personal' })
 
     await waitFor(() => expect(screen.getByText('CI 用')).toBeInTheDocument())
+    // token_prefix is always rendered (required field in the contract)
     expect(screen.getByText('ap_user_abc')).toBeInTheDocument()
-    expect(screen.getByText(/session:create/)).toBeInTheDocument()
-    // Query params: personal scope, no team_id
+    // canonical permissions are shown
+    expect(screen.getByText('session:create')).toBeInTheDocument()
+    expect(screen.getByText('session:read')).toBeInTheDocument()
+    // obsolete permissions must never appear in the rendered permissions
+    expect(screen.queryByText('session:list')).not.toBeInTheDocument()
+    expect(screen.queryByText('session:access')).not.toBeInTheDocument()
+    expect(screen.queryByText('*')).not.toBeInTheDocument()
+    // exact query params: personal scope, no team_id
     expect(fakeClient.getApiTokens).toHaveBeenCalledWith({ scope: 'personal' })
   })
 
-  it('loads team tokens with team_id', async () => {
-    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+  it('GET /api-tokens?scope=team&team_id=... returns team tokens with created_by', async () => {
+    fakeClient.getApiTokens.mockResolvedValue({ items: [teamToken] })
     renderSection({ scope: 'team', teamId: 'org/team' })
 
-    await waitFor(() => expect(screen.getByText('CI 用')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('チーム用')).toBeInTheDocument())
+    expect(screen.getByText('ap_team_xyz')).toBeInTheDocument()
+    // team tokens show the creator
+    expect(screen.getByText('作成者: admin-user')).toBeInTheDocument()
+    // canonical perms incl. session:update and admin
+    expect(screen.getByText('session:update')).toBeInTheDocument()
+    expect(screen.getByText('admin')).toBeInTheDocument()
     expect(fakeClient.getApiTokens).toHaveBeenCalledWith({ scope: 'team', team_id: 'org/team' })
   })
 
-  it('shows empty state', async () => {
+  it('shows empty state when items is []', async () => {
     fakeClient.getApiTokens.mockResolvedValue({ items: [] })
     renderSection()
     await waitFor(() => expect(screen.getByText('API トークンがありません')).toBeInTheDocument())
@@ -96,7 +140,16 @@ describe('ApiTokensSection', () => {
     await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
   })
 
-  it('creates a token and shows the plaintext exactly once, then clears on close', async () => {
+  it('team section is fixed to selected team and has no scope switcher', async () => {
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    renderSection({ scope: 'team', teamId: 'org/team' })
+    await waitFor(() => expect(fakeClient.getApiTokens).toHaveBeenCalledWith({ scope: 'team', team_id: 'org/team' }))
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+})
+
+describe('ApiTokensSection — create (POST /api-tokens)', () => {
+  it('POST /api-tokens sends canonical scope=personal and renders {token, plaintext_token} once', async () => {
     const user = userEvent.setup()
     fakeClient.getApiTokens.mockResolvedValue({ items: [] })
     const created: CreateApiTokenResponse = {
@@ -115,6 +168,9 @@ describe('ApiTokensSection', () => {
     const nameInput = await screen.findByPlaceholderText('例: CI 用トークン')
     await user.type(nameInput, 'My Token')
 
+    // Select a canonical permission (session:read) — not session:list/access.
+    await user.click(screen.getByText('セッション読み取り (session:read)'))
+
     // Submit
     await user.click(screen.getByRole('button', { name: '作成' }))
 
@@ -123,19 +179,49 @@ describe('ApiTokensSection', () => {
     expect(plaintext).toHaveTextContent('ap_secret_plaintext_123')
     expect(screen.getByText(/今度一度だけ/)).toBeInTheDocument()
 
-    // createApiToken was called with personal scope, no team_id
-    expect(fakeClient.createApiToken).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'My Token', scope: 'personal' })
+    // Exact create request: canonical scope, no team_id for personal, only
+    // the selected canonical permission, and an ISO-8601 expires_at.
+    expect(fakeClient.createApiToken).toHaveBeenCalledTimes(1)
+    const req = fakeClient.createApiToken.mock.calls[0][0] as CreateApiTokenRequest
+    expect(req).toEqual(
+      expect.objectContaining({
+        name: 'My Token',
+        scope: 'personal',
+        permissions: ['session:read'],
+      })
     )
-    expect(fakeClient.createApiToken.mock.calls[0][0].team_id).toBeUndefined()
+    expect(req.team_id).toBeUndefined()
+    expect(req.expires_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
 
-    // List refreshed
+    // List refreshed after create
     await waitFor(() => expect(fakeClient.getApiTokens).toHaveBeenCalledTimes(2))
 
     // Close result modal -> plaintext disappears
     await user.click(screen.getByText('閉じる（トークンを非表示）'))
     await waitFor(() => expect(screen.queryByTestId('api-token-plaintext')).not.toBeInTheDocument())
     expect(screen.queryByText('ap_secret_plaintext_123')).not.toBeInTheDocument()
+  })
+
+  it('POST with team scope includes team_id and omits permissions when none selected', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [] })
+    fakeClient.createApiToken.mockResolvedValue({
+      token: { ...teamToken, id: 'tok_team_new', name: 'T' },
+      plaintext_token: 'ap_team_secret',
+    })
+    renderSection({ scope: 'team', teamId: 'org/team' })
+
+    await user.click(await screen.findByText('トークンを作成'))
+    await user.type(screen.getByPlaceholderText('例: CI 用トークン'), 'T')
+    // No permission checkbox selected -> permissions omitted (defaults apply).
+    await user.click(screen.getByRole('button', { name: '作成' }))
+
+    await screen.findByTestId('api-token-plaintext')
+    const req = fakeClient.createApiToken.mock.calls[0][0] as CreateApiTokenRequest
+    expect(req).toEqual(
+      expect.objectContaining({ name: 'T', scope: 'team', team_id: 'org/team' })
+    )
+    expect(req.permissions).toBeUndefined()
   })
 
   it('copies plaintext token to clipboard', async () => {
@@ -153,55 +239,7 @@ describe('ApiTokensSection', () => {
     await screen.findByTestId('api-token-plaintext')
 
     await user.click(screen.getByRole('button', { name: /コピー/ }))
-    // The copy path executed and the button switched to the "copied" state.
     await waitFor(() => expect(screen.getByText('コピー済み')).toBeInTheDocument())
-  })
-
-  it('confirms destructive deletion and refreshes the list', async () => {
-    const user = userEvent.setup()
-    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
-    fakeClient.deleteApiToken.mockResolvedValue(undefined)
-    renderSection()
-    await screen.findByText('CI 用')
-
-    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
-    // Confirm modal appears
-    expect(screen.getByText(/API トークンを削除します/)).toBeInTheDocument()
-    // Confirm
-    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed')!
-    await user.click(within(dialog).getByRole('button', { name: '削除' }))
-
-    expect(fakeClient.deleteApiToken).toHaveBeenCalledWith('tok_1')
-    // List refreshed after delete
-    await waitFor(() => expect(fakeClient.getApiTokens.mock.calls.length).toBeGreaterThanOrEqual(2))
-  })
-
-  it('cancels deletion', async () => {
-    const user = userEvent.setup()
-    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
-    renderSection()
-    await screen.findByText('CI 用')
-
-    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
-    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed')!
-    await user.click(within(dialog).getByRole('button', { name: 'キャンセル' }))
-
-    await waitFor(() => expect(screen.queryByText(/API トークンを削除します/)).not.toBeInTheDocument())
-    expect(fakeClient.deleteApiToken).not.toHaveBeenCalled()
-  })
-
-  it('shows delete error without crashing', async () => {
-    const user = userEvent.setup()
-    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
-    fakeClient.deleteApiToken.mockRejectedValue(new Error('forbidden'))
-    renderSection()
-    await screen.findByText('CI 用')
-
-    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
-    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed')!
-    await user.click(within(dialog).getByRole('button', { name: '削除' }))
-
-    await waitFor(() => expect(screen.getByText('forbidden')).toBeInTheDocument())
   })
 
   it('does not persist plaintext token in localStorage', async () => {
@@ -218,7 +256,6 @@ describe('ApiTokensSection', () => {
     await user.click(screen.getByRole('button', { name: '作成' }))
     await screen.findByTestId('api-token-plaintext')
 
-    // Ensure no localStorage entry ever contained the plaintext.
     for (const call of setItemSpy.mock.calls) {
       expect(JSON.stringify(call[1])).not.toContain('ap_persist_test')
     }
@@ -231,20 +268,73 @@ describe('ApiTokensSection', () => {
     renderSection()
     await user.click(await screen.findByText('トークンを作成'))
 
-    // Submit empty -> button disabled
     expect(screen.getByRole('button', { name: '作成' })).toBeDisabled()
 
-    // Type name -> enabled
     await user.type(screen.getByPlaceholderText('例: CI 用トークン'), 'ab')
     expect(screen.getByRole('button', { name: '作成' })).toBeEnabled()
   })
 
-  it('team section is fixed to selected team and does not allow personal scope switching', async () => {
+  it('offers only canonical permission labels (no session:list/session:access/*)', async () => {
+    const user = userEvent.setup()
     fakeClient.getApiTokens.mockResolvedValue({ items: [] })
-    renderSection({ scope: 'team', teamId: 'org/team' })
-    await waitFor(() => expect(fakeClient.getApiTokens).toHaveBeenCalledWith({ scope: 'team', team_id: 'org/team' }))
-    // No scope selector exists
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    renderSection()
+    await user.click(await screen.findByText('トークンを作成'))
+
+    const labels = ['session:create', 'session:read', 'session:update', 'session:delete', 'admin']
+    for (const l of labels) {
+      expect(screen.getByText(new RegExp(l))).toBeInTheDocument()
+    }
+    // The obsolete wildcard-permission label ('すべての操作 (*)') must not be offered.
+    expect(screen.queryByText(/すべての操作/)).not.toBeInTheDocument()
+    // Obsolete permission names must never appear as selectable labels.
+    expect(screen.queryByText(/session:list/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/session:access/)).not.toBeInTheDocument()
+  })
+})
+
+describe('ApiTokensSection — delete (DELETE /api-tokens/:id)', () => {
+  it('confirms destructive deletion and refreshes the list', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    fakeClient.deleteApiToken.mockResolvedValue(undefined)
+    renderSection()
+    await screen.findByText('CI 用')
+
+    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
+    expect(screen.getByText(/API トークンを削除します/)).toBeInTheDocument()
+    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed') as HTMLElement
+    await user.click(within(dialog).getByRole('button', { name: '削除' }))
+
+    expect(fakeClient.deleteApiToken).toHaveBeenCalledWith('tok_1')
+    await waitFor(() => expect(fakeClient.getApiTokens.mock.calls.length).toBeGreaterThanOrEqual(2))
+  })
+
+  it('cancels deletion', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    renderSection()
+    await screen.findByText('CI 用')
+
+    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
+    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed') as HTMLElement
+    await user.click(within(dialog).getByRole('button', { name: 'キャンセル' }))
+
+    await waitFor(() => expect(screen.queryByText(/API トークンを削除します/)).not.toBeInTheDocument())
+    expect(fakeClient.deleteApiToken).not.toHaveBeenCalled()
+  })
+
+  it('shows delete error without crashing', async () => {
+    const user = userEvent.setup()
+    fakeClient.getApiTokens.mockResolvedValue({ items: [sampleToken] })
+    fakeClient.deleteApiToken.mockRejectedValue(new Error('forbidden'))
+    renderSection()
+    await screen.findByText('CI 用')
+
+    await user.click(screen.getByRole('button', { name: /トークン CI 用 を削除/ }))
+    const dialog = screen.getByText(/API トークンを削除します/).closest('.fixed') as HTMLElement
+    await user.click(within(dialog).getByRole('button', { name: '削除' }))
+
+    await waitFor(() => expect(screen.getByText('forbidden')).toBeInTheDocument())
   })
 })
 
@@ -265,7 +355,6 @@ describe('ApiTokenResultModal (one-time display)', () => {
     expect(screen.getByTestId('api-token-plaintext')).toHaveTextContent('ap_clear_me')
     await user.click(screen.getByText('閉じる（トークンを非表示）'))
     expect(onClose).toHaveBeenCalled()
-    // Unmount to simulate parent dropping the response.
     unmount()
   })
 })

--- a/src/app/settings/personal/page.tsx
+++ b/src/app/settings/personal/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { SettingsData, BedrockConfig, APIMCPServerConfig, MarketplaceConfig, AuthMode, ExternalSessionManagerConfig, GitSyncConfig, prepareSettingsForSave, getSendGithubTokenOnSessionStart, setSendGithubTokenOnSessionStart, EnterKeyBehavior, getEnterKeyBehavior, setEnterKeyBehavior, FontSettings as FontSettingsType, getFontSettings, setFontSettings } from '@/types/settings'
 import { BedrockSettings, SettingsAccordion, GithubTokenSettings, MCPServerSettings, MarketplaceSettings, PluginSettings, KeyBindingSettings, ClaudeOAuthSettings, FontSettings, EnvVarsSettings, SlackSettings, FileSettings, GitHubSyncSettings, CodexDeviceAuthSettings } from '@/components/settings'
+import ApiTokensSection from '@/app/components/ApiTokensSection'
 import { createAgentAPIProxyClientFromStorage, AgentAPIProxyError, CredentialsMetadata } from '@/lib/agentapi-proxy-client'
 import { useToast } from '@/contexts/ToastContext'
 
@@ -533,6 +534,8 @@ export default function PersonalSettingsPage() {
 
       {userName && (
         <>
+          <ApiTokensSection scope="personal" defaultOpen={false} />
+
           <SettingsAccordion
             title="Marketplace"
             description="Configure plugin marketplaces"

--- a/src/app/settings/team/page.tsx
+++ b/src/app/settings/team/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { SettingsData, BedrockConfig, APIMCPServerConfig, MarketplaceConfig, GitSyncConfig, prepareSettingsForSave } from '@/types/settings'
 import { BedrockSettings, SettingsAccordion, MCPServerSettings, MarketplaceSettings, PluginSettings, EnvVarsSettings, GitHubSyncSettings, CodexDeviceAuthSettings } from '@/components/settings'
 import { createAgentAPIProxyClientFromStorage, CredentialsMetadata } from '@/lib/agentapi-proxy-client'
+import ApiTokensSection from '@/app/components/ApiTokensSection'
 import { useToast } from '@/contexts/ToastContext'
 
 export default function TeamSettingsPage() {
@@ -268,6 +269,8 @@ export default function TeamSettingsPage() {
 
       {isTeamLoaded && (
         <>
+          <ApiTokensSection scope="team" teamId={teamName} defaultOpen={false} />
+
           <SettingsAccordion
             title="Codex Authentication"
             description="Register a shared Codex auth.json for the team"

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -50,6 +50,13 @@ import {
   UpdateSessionProfileRequest
 } from '../types/session_profile';
 import {
+  ApiToken,
+  ApiTokenListParams,
+  ApiTokenListResponse,
+  CreateApiTokenRequest,
+  CreateApiTokenResponse
+} from '../types/api_token';
+import {
   SandboxPolicy,
   SandboxPolicyListParams,
   SandboxPolicyListResponse,
@@ -2193,6 +2200,83 @@ export class AgentAPIProxyClient {
     await this.makeRequest<void>(`/sandbox-policies/${policyId}`, {
       method: 'DELETE',
     });
+  }
+
+  // ============================================================
+  // API Token methods (multi-token management)
+  // ============================================================
+
+  /**
+   * List API tokens for a scope. Use scope="personal" for the user's tokens,
+   * or scope="team" with team_id for a team's tokens.
+   */
+  async getApiTokens(params: ApiTokenListParams): Promise<ApiTokenListResponse> {
+    const searchParams = new URLSearchParams();
+    if (params?.scope) searchParams.set('scope', params.scope);
+    if (params?.team_id) searchParams.set('team_id', params.team_id);
+
+    const endpoint = `/api-tokens${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
+    const result = await this.makeRequest<ApiToken[] | ApiTokenListResponse>(endpoint);
+
+    // Tolerate both wrapped ({items:[]}) and bare-array responses.
+    if (Array.isArray(result)) {
+      return { items: result };
+    }
+    return { items: result.items || [] };
+  }
+
+  /**
+   * Create a new API token. The plaintext token is returned exactly once in
+   * `plaintext_token` and must never be persisted by the caller.
+   */
+  async createApiToken(data: CreateApiTokenRequest): Promise<CreateApiTokenResponse> {
+    if (this.debug) {
+      // Never log the token itself; only the non-sensitive request fields.
+      console.log('[AgentAPIProxy] Creating API token:', {
+        name: data.name,
+        scope: data.scope,
+        team_id: data.team_id,
+        permissions: data.permissions,
+        expires_at: data.expires_at,
+      });
+    }
+
+    const result = await this.makeRequest<CreateApiTokenResponse>('/api-tokens', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Created API token: ${result.token?.id}`);
+    }
+
+    return result;
+  }
+
+  /**
+   * Get metadata for a single API token. Never returns the plaintext token.
+   */
+  async getApiToken(tokenId: string): Promise<ApiToken> {
+    return this.makeRequest<ApiToken>(`/api-tokens/${encodeURIComponent(tokenId)}`);
+  }
+
+  /**
+   * Delete an API token. If the deleted token backs the current UI session,
+   * subsequent requests will return 401 and the existing auth flow will
+   * handle re-authentication; we do not compare plaintext tokens.
+   */
+  async deleteApiToken(tokenId: string): Promise<void> {
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Deleting API token: ${tokenId}`);
+    }
+
+    await this.makeRequest<void>(`/api-tokens/${encodeURIComponent(tokenId)}`, {
+      method: 'DELETE',
+    });
+
+    if (this.debug) {
+      console.log(`[AgentAPIProxy] Deleted API token: ${tokenId}`);
+    }
   }
 
   // ============================================================

--- a/src/types/api_token.ts
+++ b/src/types/api_token.ts
@@ -11,16 +11,20 @@
  * The list endpoint returns `{ items: [...] }`.
  */
 
-/** Token scope. Note that the API uses `personal` (not `user`) for user tokens. */
+/** Token scope. The API uses the public vocabulary `personal` (not `user`) for user tokens. */
 export type ApiTokenScope = 'personal' | 'team';
 
-/** Permissions offered when creating a token. Mirrors the proxy RBAC model. */
+/**
+ * Permissions offered when creating a token. Mirrors the proxy RBAC model
+ * (internal/domain/entities/user.go) and the OpenAPI `CreateAPITokenRequest`
+ * enum: session:create, session:read, session:update, session:delete, admin.
+ */
 export const API_TOKEN_PERMISSIONS = [
   'session:create',
-  'session:list',
+  'session:read',
+  'session:update',
   'session:delete',
-  'session:access',
-  '*',
+  'admin',
 ] as const;
 
 export type ApiTokenPermission = (typeof API_TOKEN_PERMISSIONS)[number];
@@ -28,24 +32,35 @@ export type ApiTokenPermission = (typeof API_TOKEN_PERMISSIONS)[number];
 /** Human-readable labels for the permission checkboxes. */
 export const API_TOKEN_PERMISSION_LABELS: Record<ApiTokenPermission, string> = {
   'session:create': 'セッション作成 (session:create)',
-  'session:list': 'セッション一覧 (session:list)',
+  'session:read': 'セッション読み取り (session:read)',
+  'session:update': 'セッション更新 (session:update)',
   'session:delete': 'セッション削除 (session:delete)',
-  'session:access': 'セッションアクセス (session:access)',
-  '*': 'すべての操作 (*)',
+  'admin': '管理者 (admin)',
 };
 
-/** Token metadata returned by list / GET / DELETE. Never contains plaintext. */
+/**
+ * Token metadata returned by list / GET / DELETE. Never contains plaintext.
+ * Mirrors the OpenAPI `APITokenMetadata` schema: `token_prefix`, `permissions`,
+ * `created_by` and `created_at` are required by the contract; they are typed
+ * as required here to match the canonical response shape.
+ */
 export interface ApiToken {
   id: string;
   name: string;
-  /** Safe prefix of the token, e.g. `ap_user_abc…`. Never the full token. */
-  token_prefix?: string;
+  /** Short, safe prefix of the secret for display, e.g. `ap_user_abc…`. */
+  token_prefix: string;
   scope: ApiTokenScope;
+  /** Identity the token authenticates as (owner for personal, service account id for team). */
+  user_id?: string;
+  /** Team ID (populated when scope is 'team'). */
   team_id?: string;
-  permissions?: string[];
-  /** Creator of the token (team scope only). */
-  created_by?: string;
+  /** Granted permissions, bounded by the creator's permissions. */
+  permissions: string[];
+  /** User ID of the token creator. */
+  created_by: string;
   created_at: string;
+  /** Last update timestamp. */
+  updated_at?: string;
   /** ISO 8601 expiry timestamp, or null/undefined for no expiration. */
   expires_at?: string | null;
 }

--- a/src/types/api_token.ts
+++ b/src/types/api_token.ts
@@ -1,0 +1,79 @@
+/**
+ * API Token types for the agentapi-proxy multi-token management API.
+ *
+ * Backend contract:
+ *   GET    /api-tokens?scope=personal
+ *   GET    /api-tokens?scope=team&team_id=org%2Fteam
+ *   POST   /api-tokens            -> returns the plaintext token exactly once
+ *   GET    /api-tokens/:id        -> metadata only (no plaintext)
+ *   DELETE /api-tokens/:id
+ *
+ * The list endpoint returns `{ items: [...] }`.
+ */
+
+/** Token scope. Note that the API uses `personal` (not `user`) for user tokens. */
+export type ApiTokenScope = 'personal' | 'team';
+
+/** Permissions offered when creating a token. Mirrors the proxy RBAC model. */
+export const API_TOKEN_PERMISSIONS = [
+  'session:create',
+  'session:list',
+  'session:delete',
+  'session:access',
+  '*',
+] as const;
+
+export type ApiTokenPermission = (typeof API_TOKEN_PERMISSIONS)[number];
+
+/** Human-readable labels for the permission checkboxes. */
+export const API_TOKEN_PERMISSION_LABELS: Record<ApiTokenPermission, string> = {
+  'session:create': 'セッション作成 (session:create)',
+  'session:list': 'セッション一覧 (session:list)',
+  'session:delete': 'セッション削除 (session:delete)',
+  'session:access': 'セッションアクセス (session:access)',
+  '*': 'すべての操作 (*)',
+};
+
+/** Token metadata returned by list / GET / DELETE. Never contains plaintext. */
+export interface ApiToken {
+  id: string;
+  name: string;
+  /** Safe prefix of the token, e.g. `ap_user_abc…`. Never the full token. */
+  token_prefix?: string;
+  scope: ApiTokenScope;
+  team_id?: string;
+  permissions?: string[];
+  /** Creator of the token (team scope only). */
+  created_by?: string;
+  created_at: string;
+  /** ISO 8601 expiry timestamp, or null/undefined for no expiration. */
+  expires_at?: string | null;
+}
+
+export interface ApiTokenListParams {
+  scope: ApiTokenScope;
+  team_id?: string;
+}
+
+export interface ApiTokenListResponse {
+  items: ApiToken[];
+}
+
+export interface CreateApiTokenRequest {
+  name: string;
+  scope: ApiTokenScope;
+  team_id?: string;
+  permissions?: string[];
+  /** ISO 8601 expiry timestamp, or null/omitted for no expiration. */
+  expires_at?: string | null;
+}
+
+/**
+ * Response from POST /api-tokens. Contains the full plaintext token exactly
+ * once. The UI must never persist this value (no localStorage, no logs).
+ */
+export interface CreateApiTokenResponse {
+  token: ApiToken;
+  /** Plaintext API token. Shown once, then discarded. */
+  plaintext_token: string;
+}


### PR DESCRIPTION
## Summary
- add multiple API token management to personal and team settings
- support named tokens, expiry, scoped permissions, one-time plaintext display, copy, and deletion
- keep plaintext only in component memory
- align client types with the proxy API contract

## Verification
- npx tsc --noEmit
- bun run lint
- bun run test (32/32)
- bun run build

## Backend
- Companion PR: takutakahashi/agentapi-proxy feature/multi-api-tokens