### PR TITLE
Configure session managers in session profiles

### DIFF
--- a/src/app/components/SessionProfileCard.tsx
+++ b/src/app/components/SessionProfileCard.tsx
@@ -90,6 +90,11 @@ export default function SessionProfileCard({
             {profile.config.params.agent_type}
           </span>
         )}
+        {profile.config?.params?.manager_id && (
+          <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+            Manager: {profile.config.params.manager_id}
+          </span>
+        )}
         {profile.config?.environment && Object.keys(profile.config.environment).length > 0 && (
           <span>環境変数: <strong className="text-gray-700 dark:text-gray-300">{Object.keys(profile.config.environment).length}</strong></span>
         )}

--- a/src/app/components/SessionProfileFormModal.tsx
+++ b/src/app/components/SessionProfileFormModal.tsx
@@ -8,6 +8,7 @@ import {
   CredentialSource,
 } from '../../types/session_profile'
 import { SandboxPolicy } from '../../types/sandbox_policy'
+import { AvailableManager } from '../../types/settings'
 import { createAgentAPIProxyClientFromStorage } from '../../lib/agentapi-proxy-client'
 import { useTeamScope } from '../../contexts/TeamScopeContext'
 
@@ -42,6 +43,8 @@ export default function SessionProfileFormModal({
   const [envPairs, setEnvPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [tagPairs, setTagPairs] = useState<KeyValuePair[]>([{ key: '', value: '' }])
   const [agentType, setAgentType] = useState('')
+  const [managerId, setManagerId] = useState('')
+  const [availableManagers, setAvailableManagers] = useState<AvailableManager[]>([])
 
   // Docker / DinD fields
   const [dockerEnabled, setDockerEnabled] = useState(false)
@@ -74,10 +77,20 @@ export default function SessionProfileFormModal({
     const fetchSandboxPolicies = async () => {
       try {
         const client = createAgentAPIProxyClientFromStorage()
-        const response = await client.getSandboxPolicies({ ...getScopeParams() })
-        setSandboxPolicies(response.sandbox_policies || [])
+        const scopeParams = getScopeParams()
+        const [policyResponse, managers] = await Promise.all([
+          client.getSandboxPolicies({ ...scopeParams }),
+          client.getAvailableManagers(),
+        ])
+        setSandboxPolicies(policyResponse.sandbox_policies || [])
+        setAvailableManagers(
+          scopeParams.scope === 'team'
+            ? managers.filter(manager => manager.source === 'team' && manager.source_name === scopeParams.team_id)
+            : managers
+        )
       } catch {
         setSandboxPolicies([])
+        setAvailableManagers([])
       }
     }
     fetchSandboxPolicies()
@@ -92,6 +105,7 @@ export default function SessionProfileFormModal({
 
       const cfg = editingProfile.config
       setAgentType(normalizeAgentType(cfg?.params?.agent_type))
+      setManagerId(cfg?.params?.manager_id ?? '')
 
       if (cfg?.environment && Object.keys(cfg.environment).length > 0) {
         setEnvPairs(Object.entries(cfg.environment).map(([key, value]) => ({ key, value })))
@@ -108,6 +122,9 @@ export default function SessionProfileFormModal({
       }
 
       if (cfg?.params?.agent_type) {
+        setShowAdvanced(true)
+      }
+      if (cfg?.params?.manager_id) {
         setShowAdvanced(true)
       }
 
@@ -153,6 +170,7 @@ export default function SessionProfileFormModal({
       setEnvPairs([{ key: '', value: '' }])
       setTagPairs([{ key: '', value: '' }])
       setAgentType('')
+      setManagerId('')
       setDockerEnabled(false)
       setDockerRegistries([])
       setSandboxPolicyId('')
@@ -259,6 +277,7 @@ export default function SessionProfileFormModal({
       // Build params if any param is set
       const params = {
         ...(agentType.trim() ? { agent_type: agentType.trim() } : {}),
+        ...(managerId ? { manager_id: managerId } : {}),
         sandbox: sandboxConfig,
         ...(dockerConfig ? { docker: dockerConfig } : {}),
         ...(credentialSource ? { credential_source: credentialSource } : {}),
@@ -438,6 +457,31 @@ export default function SessionProfileFormModal({
 
               {showAdvanced && (
                 <div className="mt-4 space-y-5 pl-4 border-l-2 border-gray-200 dark:border-gray-700">
+                  {/* Session Manager */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      セッションマネージャー
+                    </label>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                      このプロファイルを使うセッションの配置先を指定します。セッション作成時の明示指定が優先されます。
+                    </p>
+                    <select
+                      value={managerId}
+                      onChange={(e) => setManagerId(e.target.value)}
+                      className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    >
+                      <option value="">自動選択（allocatorタグ / デフォルト / ローカル）</option>
+                      {managerId && !availableManagers.some(manager => manager.id === managerId) && (
+                        <option value={managerId}>{managerId}（現在利用不可）</option>
+                      )}
+                      {availableManagers.map((manager) => (
+                        <option key={manager.id} value={manager.id}>
+                          {manager.name}{manager.default ? '（デフォルト）' : ''} [{manager.source === 'team' ? 'チーム' : '個人'}]
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
                   {/* Environment Variables */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">

--- a/src/app/components/SessionProfileSelect.tsx
+++ b/src/app/components/SessionProfileSelect.tsx
@@ -119,6 +119,11 @@ export default function SessionProfileSelect({
               {selected.config.params.agent_type}
             </span>
           )}
+          {selected.config?.params?.manager_id && (
+            <span className="text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+              Manager: {selected.config.params.manager_id}
+            </span>
+          )}
           {selected.config?.environment && Object.keys(selected.config.environment).length > 0 && (
             <span className="text-[10px] text-gray-500 dark:text-gray-400">
               ENV×{Object.keys(selected.config.environment).length}

--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -151,11 +151,6 @@ export default function NewSessionPage() {
       const client = createAgentAPIProxyClientFromStorage()
       const managers = await client.getAvailableManagers()
       setAvailableManagers(managers)
-      // auto-select the default manager if one exists
-      const defaultManager = managers.find(m => m.default)
-      if (defaultManager) {
-        setSelectedManagerId(defaultManager.id)
-      }
     } catch (error) {
       console.error('Failed to load available managers:', error)
     }
@@ -641,7 +636,10 @@ export default function NewSessionPage() {
               </label>
               <SessionProfileSelect
                 value={sessionProfileId}
-                onChange={setSessionProfileId}
+                onChange={(profileId) => {
+                  setSessionProfileId(profileId)
+                  setSelectedManagerId('')
+                }}
                 disabled={isCreating}
               />
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
@@ -690,7 +688,7 @@ export default function NewSessionPage() {
                     <div>
                       <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">セッションマネージャー</p>
                       <div className="space-y-1.5">
-                        {/* ローカル（マネージャーなし）オプション */}
+                        {/* Profile / automatic placement option */}
                         <label
                           className={`flex items-start gap-3 p-2.5 rounded-lg border cursor-pointer transition-colors ${
                             selectedManagerId === ''
@@ -708,8 +706,14 @@ export default function NewSessionPage() {
                             className="mt-0.5 w-3.5 h-3.5 text-blue-600 border-gray-300 dark:border-gray-600 focus:ring-blue-500 flex-shrink-0"
                           />
                           <span className="flex-1 min-w-0">
-                            <span className="block text-xs font-medium text-gray-800 dark:text-gray-200">ローカル</span>
-                            <span className="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">このサーバー上で作成</span>
+                            <span className="block text-xs font-medium text-gray-800 dark:text-gray-200">
+                              {sessionProfileId ? 'プロファイルの設定を使用' : '自動選択'}
+                            </span>
+                            <span className="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+                              {sessionProfileId
+                                ? 'プロファイルのManager、allocatorタグ、デフォルトの順で選択'
+                                : 'allocatorタグ、デフォルト、ローカルの順で選択'}
+                            </span>
                           </span>
                         </label>
                         {/* 各マネージャーオプション */}

--- a/src/types/session_profile.ts
+++ b/src/types/session_profile.ts
@@ -5,6 +5,7 @@ export interface SessionProfileParams {
   initial_message?: string;
   github_token?: string;
   agent_type?: string;
+  manager_id?: string;
   sandbox?: SandboxConfig;
   docker?: DockerConfig;
   auth_proxy?: boolean;


### PR DESCRIPTION
## Summary
- add an External Session Manager selector to Session Profile create/edit
- persist the selection as `config.params.manager_id`
- restrict Team Profile choices to managers owned by that team
- show the configured manager on Profile cards and selectors
- make the new-session manager choice an explicit override instead of auto-sending the default manager
- preserve sandbox/DinD profile settings; placement allocators decide how to handle capabilities and native managers ignore unsupported fields

## Verification
- `bun run type-check` ✅
- `bun run test` ✅ (32 tests)
- `bun run build` ✅

## Backend dependency
- takutakahashi/agentapi-proxy#936
