### PR TITLE
Fix ACP chat history loss after reconnect

### DIFF
--- a/src/lib/__tests__/agentapi-proxy-client.test.ts
+++ b/src/lib/__tests__/agentapi-proxy-client.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentAPIProxyClient, AgentAPIProxyError } from '../agentapi-proxy-client';
+
+describe('AgentAPIProxyClient ACP message history', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects when history cannot be fetched instead of returning an empty history', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('connection lost'));
+    const client = new AgentAPIProxyClient({ baseURL: 'http://proxy.example.test' });
+
+    await expect(client.getACPMessageHistory('session-1', 'acp-session-1')).rejects.toMatchObject({
+      status: 0,
+      code: 'NETWORK_ERROR',
+      message: 'connection lost',
+    } satisfies Partial<AgentAPIProxyError>);
+  });
+});

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -464,12 +464,6 @@ function acpPlanToMarkdown(entries: NonNullable<ACPSessionUpdate['entries']>): s
   return md;
 }
 
-const emptyACPMessageHistory = (): ACPMessageHistoryResult => ({
-  messages: [],
-  userPromptCount: 0,
-  userPrompts: [],
-});
-
 function parseACPJSONRPCMessages(rawMsgs: ACPJSONRPCMessage[]): SessionMessage[] {
   const result: SessionMessage[] = [];
   let nextLocalId = Date.now();
@@ -2465,28 +2459,23 @@ export class AgentAPIProxyClient {
     _acpSessionId: string,
     userPromptIndex?: number
   ): Promise<ACPMessageHistoryResult> {
-    try {
-      const query = userPromptIndex !== undefined ? `?userPromptIndex=${userPromptIndex}` : '';
-      const resp = await this.makeRequest<{
-        messages: ACPJSONRPCMessage[];
-        userPromptCount?: number;
-        userPromptIndex?: number;
-        userPrompts?: ACPUserPromptInfo[];
-      }>(`/${sessionId}/messages${query}`);
+    const query = userPromptIndex !== undefined ? `?userPromptIndex=${userPromptIndex}` : '';
+    const resp = await this.makeRequest<{
+      messages: ACPJSONRPCMessage[];
+      userPromptCount?: number;
+      userPromptIndex?: number;
+      userPrompts?: ACPUserPromptInfo[];
+    }>(`/${sessionId}/messages${query}`);
 
-      const messages = parseACPJSONRPCMessages(resp?.messages ?? []);
-      console.log(`[ACP] getACPMessageHistory: ${messages.length} messages restored (userPromptIndex=${userPromptIndex ?? 'latest'})`);
+    const messages = parseACPJSONRPCMessages(resp?.messages ?? []);
+    console.log(`[ACP] getACPMessageHistory: ${messages.length} messages restored (userPromptIndex=${userPromptIndex ?? 'latest'})`);
 
-      return {
-        messages,
-        userPromptCount: resp?.userPromptCount ?? 0,
-        userPromptIndex: resp?.userPromptIndex,
-        userPrompts: resp?.userPrompts ?? [],
-      };
-    } catch (err) {
-      console.warn(`[ACP] getACPMessageHistory failed:`, err);
-      return emptyACPMessageHistory();
-    }
+    return {
+      messages,
+      userPromptCount: resp?.userPromptCount ?? 0,
+      userPromptIndex: resp?.userPromptIndex,
+      userPrompts: resp?.userPrompts ?? [],
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- propagate ACP history fetch failures instead of converting them into an empty history
- preserve the currently displayed messages when reconnect-time history refresh fails
- add a regression test for network failures while fetching ACP history

## Verification
- `bun run test` (33 tests)
- `bun run lint` (passes with existing warnings)
- `bun run type-check`
- `bun run build`