### PR TITLE
feat: ACP 画像入出力と effort 設定 UI

### DIFF
--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -152,6 +152,21 @@ function getACPModelConfigOption(info: ACPSessionInfo | null): ACPConfigOption |
   }) ?? null;
 }
 
+function getACPEffortConfigOption(info: ACPSessionInfo | null): ACPConfigOption | null {
+  if (!info?.configOptions?.length) return null;
+
+  const byCategory = info.configOptions.find(option => option.category?.toLowerCase() === 'effort');
+  if (byCategory) return byCategory;
+
+  return info.configOptions.find(option => {
+    const haystack = [option.id, option.key, option.name, option.description]
+      .filter((value): value is string => typeof value === 'string')
+      .join(' ')
+      .toLowerCase();
+    return /\b(effort|reasoning effort)\b/.test(haystack);
+  }) ?? null;
+}
+
 function flattenACPModelOptions(options: unknown): ACPModelOption[] {
   if (!Array.isArray(options)) return [];
 
@@ -403,6 +418,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   onChunk: (msgId: number, text: string) => {
                     setMessages(prev => prev.map(m =>
                       m.id === msgId ? { ...m, content: m.content + text } : m
+                    ));
+                  },
+                  onImageChunk: (msgId: number, image: { mimeType: string; data: string }) => {
+                    setMessages(prev => prev.map(m =>
+                      m.id === msgId ? { ...m, images: [...(m.images ?? []), image] } : m
                     ));
                   },
                   onThoughtChunk: (msgId: number, thought: string) => {
@@ -676,6 +696,12 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [isInitialLoadComplete, setIsInitialLoadComplete] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const [attachedImages, setAttachedImages] = useState<Array<{
+    name: string;
+    mimeType: string;
+    data: string;
+  }>>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [fontSettings, setFontSettings] = useState<FontSettings>(() => getFontSettings());
   const [agentStatus, setAgentStatus] = useState<AgentStatus | null>(null);
@@ -727,6 +753,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const [selectedACPModel, setSelectedACPModel] = useState('');
   const [isSettingACPModel, setIsSettingACPModel] = useState(false);
   const [acpModelMessage, setACPModelMessage] = useState<string | null>(null);
+  const acpEffortConfigOption = useMemo(() => getACPEffortConfigOption(acpInfo), [acpInfo]);
+  const acpEffortConfigId = useMemo(() => getACPConfigOptionId(acpEffortConfigOption ?? undefined), [acpEffortConfigOption]);
+  const acpEffortOptions = useMemo(() => flattenACPModelOptions(acpEffortConfigOption?.options), [acpEffortConfigOption]);
+  const acpCurrentEffortValue = useMemo(() => getACPConfigOptionCurrentValue(acpEffortConfigOption ?? undefined), [acpEffortConfigOption]);
+  const [selectedACPEffort, setSelectedACPEffort] = useState('');
+  const [isSettingACPEffort, setIsSettingACPEffort] = useState(false);
+  const [acpEffortMessage, setACPEffortMessage] = useState<string | null>(null);
   const isACPSession = !!acpInfo || isACPAgentType(agentType) || acpServerEnabled;
   const isMessageSSEConnected = !isACPSession || messageSSEConnectionStatus === 'connected';
   const isConnectionStatusConnected = isConnected && isMessageSSEConnected;
@@ -774,6 +807,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     setSelectedACPModel(acpCurrentModelValue ?? '');
     setACPModelMessage(null);
   }, [acpCurrentModelValue, acpModelConfigId]);
+
+  useEffect(() => {
+    setSelectedACPEffort(acpCurrentEffortValue ?? '');
+    setACPEffortMessage(null);
+  }, [acpCurrentEffortValue, acpEffortConfigId]);
 
   const applyACPConfigOptions = useCallback((configOptions: ACPConfigOption[]) => {
     setACPInfo(prev => {
@@ -921,6 +959,71 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     acpCurrentModelValue,
     applyACPConfigOptions,
   ]);
+
+  const handleSetACPEffort = useCallback(async () => {
+    if (!sessionId || !acpEffortConfigId || !selectedACPEffort) return;
+    if (selectedACPEffort === acpCurrentEffortValue) return;
+
+    setIsSettingACPEffort(true);
+    setACPEffortMessage(null);
+    try {
+      let result: { configOptions?: ACPConfigOption[] } | undefined;
+      if (acpServerEnabled && acpServerClientRef.current) {
+        result = await acpServerClientRef.current.setSessionConfigOption(
+          sessionId,
+          acpEffortConfigId,
+          selectedACPEffort
+        );
+      } else {
+        if (!acpInfo || !agentAPIRef.current) return;
+        result = await agentAPIRef.current.setACPSessionConfigOption(
+          sessionId,
+          acpInfo.sessionId,
+          acpEffortConfigId,
+          selectedACPEffort
+        );
+      }
+      if (result?.configOptions) applyACPConfigOptions(result.configOptions);
+      setACPEffortMessage('Effort updated');
+    } catch (err) {
+      console.error('Failed to update ACP effort:', err);
+      setACPEffortMessage(err instanceof Error ? err.message : 'Failed to update effort');
+    } finally {
+      setIsSettingACPEffort(false);
+    }
+  }, [
+    sessionId,
+    acpInfo,
+    acpServerEnabled,
+    acpEffortConfigId,
+    selectedACPEffort,
+    acpCurrentEffortValue,
+    applyACPConfigOptions,
+  ]);
+
+  const handleImageSelection = useCallback(async (files: FileList | null) => {
+    if (!files) return;
+    const selected = Array.from(files).filter(file => file.type.startsWith('image/'));
+    const encoded = await Promise.all(selected.map(file => new Promise<{
+      name: string;
+      mimeType: string;
+      data: string;
+    }>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error ?? new Error(`Failed to read ${file.name}`));
+      reader.onload = () => {
+        const result = String(reader.result ?? '');
+        resolve({
+          name: file.name,
+          mimeType: file.type,
+          data: result.split(',', 2)[1] ?? '',
+        });
+      };
+      reader.readAsDataURL(file);
+    })));
+    setAttachedImages(prev => [...prev, ...encoded].slice(0, 4));
+    if (imageInputRef.current) imageInputRef.current.value = '';
+  }, []);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -1364,6 +1467,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               m.id === msgId ? { ...m, content: m.content + text } : m
             ));
           },
+          onImageChunk: (msgId: number, image: { mimeType: string; data: string }) => {
+            setMessages(prev => prev.map(m =>
+              m.id === msgId ? { ...m, images: [...(m.images ?? []), image] } : m
+            ));
+          },
           onThoughtChunk: (msgId: number, thought: string) => {
             setMessages(prev => prev.map(m =>
               m.id === msgId ? { ...m, thought: (m.thought ?? '') + thought } : m
@@ -1489,7 +1597,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const sendMessage = useCallback(async (messageType: 'user' | 'raw' = 'user', content?: string) => {
     const messageContent = content || inputValue.trim();
     
-    if (!messageContent && messageType === 'user') return;
+    if (!messageContent && attachedImages.length === 0 && messageType === 'user') return;
     if (isLoading || !isConnected) return;
     
     if (agentStatus?.status === 'running' && messageType === 'user') {
@@ -1515,19 +1623,35 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           // The bridge broadcasts a synthetic user_message_chunk via SSE,
           // which will arrive via onMessage and be added to the message list.
           setAgentStatus({ status: 'running' });
+          const prompt = [
+            ...(messageContent ? [{ type: 'text' as const, text: messageContent }] : []),
+            ...attachedImages.map(image => ({
+              type: 'image' as const,
+              mimeType: image.mimeType,
+              data: image.data,
+            })),
+          ];
           if (acpServerEnabled && acpServerClientRef.current) {
             // ACP server mode: global POST /acp endpoint with proxy session ID
-            await acpServerClientRef.current.sendPrompt(sessionId!, messageContent, promptId);
+            await acpServerClientRef.current.sendPrompt(sessionId!, prompt, promptId);
           } else {
             // Per-session bridge mode: POST /{proxySessionId}/rpc directly to the bridge.
             // acpInfo.sessionId is the bridge-internal ACP session ID.
-            await agentAPIRef.current.sendACPPrompt(sessionId!, acpInfo.sessionId, messageContent, promptId);
+            await agentAPIRef.current.sendACPPrompt(sessionId!, acpInfo.sessionId, prompt, promptId);
           }
         } else if (acpServerEnabled && acpServerClientRef.current) {
           // ── Global ACP server only (no per-session bridge) ────────────
           const promptId = acpNextPromptId.current++;
           setAgentStatus({ status: 'running' });
-          await acpServerClientRef.current.sendPrompt(sessionId, messageContent, promptId);
+          const prompt = [
+            ...(messageContent ? [{ type: 'text' as const, text: messageContent }] : []),
+            ...attachedImages.map(image => ({
+              type: 'image' as const,
+              mimeType: image.mimeType,
+              data: image.data,
+            })),
+          ];
+          await acpServerClientRef.current.sendPrompt(sessionId, prompt, promptId);
         } else {
           // ── Regular session ───────────────────────────────────────────
           const sessionMessage = await agentAPIRef.current.sendSessionMessage(sessionId, {
@@ -1551,6 +1675,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         await loadRecentMessages();
 
         setInputValue('');
+        setAttachedImages([]);
         // メッセージ送信時は必ずスクロール
         setShouldAutoScroll(true);
         setTimeout(() => scrollToBottom(), 100);
@@ -1572,7 +1697,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     } finally {
       setIsLoading(false);
     }
-  }, [inputValue, isLoading, isConnected, sessionId, agentStatus, loadRecentMessages, acpInfo, acpServerEnabled]);
+  }, [inputValue, attachedImages, isLoading, isConnected, sessionId, agentStatus, loadRecentMessages, acpInfo, acpServerEnabled]);
 
   const handleShowPlanModal = useCallback((content: string) => {
     setPlanContent(content);
@@ -2270,6 +2395,48 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     </div>
                   </div>
                 )}
+                {acpEffortConfigId && acpEffortOptions.length > 0 && (
+                  <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
+                    <label htmlFor="acp-effort-select" className="pt-2 text-gray-500 dark:text-gray-400">
+                      Effort
+                    </label>
+                    <div className="min-w-0">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+                        <select
+                          id="acp-effort-select"
+                          value={selectedACPEffort}
+                          onChange={(event) => setSelectedACPEffort(event.target.value)}
+                          disabled={isSettingACPEffort || agentStatus?.status === 'running'}
+                          className="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-2 py-1.5 text-xs text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-100 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:disabled:bg-gray-700"
+                        >
+                          {acpEffortOptions.map(option => (
+                            <option key={`effort:${option.value}`} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          type="button"
+                          onClick={handleSetACPEffort}
+                          disabled={
+                            isSettingACPEffort ||
+                            agentStatus?.status === 'running' ||
+                            !selectedACPEffort ||
+                            selectedACPEffort === acpCurrentEffortValue
+                          }
+                          className="shrink-0 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:disabled:bg-gray-600"
+                        >
+                          {isSettingACPEffort ? 'Applying...' : 'Apply'}
+                        </button>
+                      </div>
+                      {acpEffortMessage && (
+                        <p className={`mt-1 text-[11px] ${acpEffortMessage === 'Effort updated' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                          {acpEffortMessage}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )}
                 <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
                   <span className="text-gray-500 dark:text-gray-400">ACP Status</span>
                   <span className="break-all text-gray-900 dark:text-gray-100">{acpInfo.status || '-'}</span>
@@ -2288,6 +2455,37 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             </div>
           </div>
           <div className="flex-1 relative">
+            {attachedImages.length > 0 && (
+              <div className="mb-2 flex flex-wrap gap-2">
+                {attachedImages.map((image, index) => (
+                  <div key={`${image.name}:${index}`} className="relative">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={`data:${image.mimeType};base64,${image.data}`}
+                      alt={image.name}
+                      className="h-20 w-20 rounded-md border border-gray-300 object-cover dark:border-gray-600"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setAttachedImages(prev => prev.filter((_, itemIndex) => itemIndex !== index))}
+                      className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 text-xs text-white shadow"
+                      aria-label={`${image.name} を削除`}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={(event) => void handleImageSelection(event.target.files)}
+              aria-label="画像を添付"
+            />
             <textarea
               ref={messageInputRef}
               aria-label="Message"
@@ -2362,6 +2560,20 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 })()}
               </div>
               <div className="flex items-center space-x-2">
+                {isACPSession && (
+                  <button
+                    type="button"
+                    onClick={() => imageInputRef.current?.click()}
+                    disabled={!isConnected || isLoading || agentStatus?.status === 'running' || attachedImages.length >= 4}
+                    className="rounded-md bg-sky-600 px-2 py-2 text-xs text-white transition-colors hover:bg-sky-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:disabled:bg-gray-600"
+                    title="画像を添付（最大4枚）"
+                    aria-label="画像を添付"
+                  >
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4-4a2 2 0 012.828 0L16 17m-2-2l1-1a2 2 0 012.828 0L20 16m-2-9h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  </button>
+                )}
                 {isACPSession ? (
                   <button
                     onClick={() => setShowSessionInfo(prev => !prev)}
@@ -2414,7 +2626,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                 
                 <button
                   onClick={() => sendMessage()}
-                  disabled={!isConnected || isLoading || !inputValue.trim() || agentStatus?.status === 'running'}
+                  disabled={!isConnected || isLoading || (!inputValue.trim() && attachedImages.length === 0) || agentStatus?.status === 'running'}
                   aria-label="Send"
                   className="px-3 sm:px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed text-sm font-medium"
                 >

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, useMemo, type TouchEvent } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type ClipboardEvent, type TouchEvent } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createAgentAPIProxyClientFromStorage, ACPSessionInfo, ACPConfigOption, ACPUserPromptInfo } from '../../lib/agentapi-proxy-client';
@@ -1001,7 +1001,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     applyACPConfigOptions,
   ]);
 
-  const handleImageSelection = useCallback(async (files: FileList | null) => {
+  const handleImageSelection = useCallback(async (files: FileList | File[] | null) => {
     if (!files) return;
     const selected = Array.from(files).filter(file => file.type.startsWith('image/'));
     const encoded = await Promise.all(selected.map(file => new Promise<{
@@ -1024,6 +1024,17 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     setAttachedImages(prev => [...prev, ...encoded].slice(0, 4));
     if (imageInputRef.current) imageInputRef.current.value = '';
   }, []);
+
+  const handleImagePaste = useCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
+    const images = Array.from(event.clipboardData.items)
+      .filter(item => item.kind === 'file' && item.type.startsWith('image/'))
+      .map(item => item.getAsFile())
+      .filter((file): file is File => file !== null);
+    if (images.length === 0) return;
+
+    event.preventDefault();
+    void handleImageSelection(images);
+  }, [handleImageSelection]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -2492,6 +2503,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
+              onPaste={handleImagePaste}
               onFocus={() => {
                 // テンプレートの自動表示を無効化
               }}
@@ -2566,11 +2578,12 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     onClick={() => imageInputRef.current?.click()}
                     disabled={!isConnected || isLoading || agentStatus?.status === 'running' || attachedImages.length >= 4}
                     className="rounded-md bg-sky-600 px-2 py-2 text-xs text-white transition-colors hover:bg-sky-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:disabled:bg-gray-600"
-                    title="画像を添付（最大4枚）"
+                    title="画像をアップロード（最大4枚、ペースト対応）"
                     aria-label="画像を添付"
                   >
-                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4-4a2 2 0 012.828 0L16 17m-2-2l1-1a2 2 0 012.828 0L20 16m-2-9h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15V3m0 0L8 7m4-4 4 4" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13v5a2 2 0 002 2h14a2 2 0 002-2v-5" />
                     </svg>
                   </button>
                 )}

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -640,6 +640,19 @@ function MessageItem({
           >
             {renderContent(message.content, isClaudeAgent)}
           </div>
+          {message.images && message.images.length > 0 && (
+            <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {message.images.map((image, index) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={`${image.mimeType}:${index}`}
+                  src={`data:${image.mimeType};base64,${image.data}`}
+                  alt={`Message image ${index + 1}`}
+                  className="max-h-96 w-auto max-w-full rounded-lg border border-gray-200 object-contain dark:border-gray-700"
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -654,6 +667,7 @@ function areEqual(prevProps: MessageItemProps, nextProps: MessageItemProps): boo
     prevProps.message.role === nextProps.message.role &&
     prevProps.message.content === nextProps.message.content &&
     prevProps.message.thought === nextProps.message.thought &&
+    JSON.stringify(prevProps.message.images) === JSON.stringify(nextProps.message.images) &&
     prevProps.message.type === nextProps.message.type &&
     prevProps.message.toolUseId === nextProps.message.toolUseId &&
     prevProps.message.parentToolUseId === nextProps.message.parentToolUseId &&

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -453,6 +453,19 @@ function MessageItem({
               )}
             </div>
           )}
+          {toolResult?.images && toolResult.images.length > 0 && (
+            <div className="ml-3 mt-2 mb-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {toolResult.images.map((image, index) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={`${image.mimeType}:${index}`}
+                  src={`data:${image.mimeType};base64,${image.data}`}
+                  alt={`Agent output image ${index + 1}`}
+                  className="max-h-96 w-auto max-w-full rounded-lg border border-gray-200 object-contain dark:border-gray-700"
+                />
+              ))}
+            </div>
+          )}
         </div>
       );
     }
@@ -679,7 +692,8 @@ function areEqual(prevProps: MessageItemProps, nextProps: MessageItemProps): boo
   const toolResultEqual =
     prevProps.toolResult?.id === nextProps.toolResult?.id &&
     prevProps.toolResult?.content === nextProps.toolResult?.content &&
-    prevProps.toolResult?.status === nextProps.toolResult?.status;
+    prevProps.toolResult?.status === nextProps.toolResult?.status &&
+    JSON.stringify(prevProps.toolResult?.images) === JSON.stringify(nextProps.toolResult?.images);
 
   // Compare fontSettings
   const fontSettingsEqual =

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -307,8 +307,9 @@ function CopyableMessageImage({ mimeType, data, alt }: CopyableMessageImageProps
       if (!navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
         throw new Error('Image clipboard is not supported');
       }
-      const response = await fetch(src);
-      const blob = await response.blob();
+      const binary = atob(data);
+      const bytes = Uint8Array.from(binary, character => character.charCodeAt(0));
+      const blob = new Blob([bytes], { type: mimeType });
       await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
       setCopyStatus('copied');
     } catch (error) {

--- a/src/app/components/MessageItem.tsx
+++ b/src/app/components/MessageItem.tsx
@@ -292,6 +292,66 @@ function renderContent(content: string, enableMarkdown: boolean = false): JSX.El
   return <MarkdownContent content={content} />;
 }
 
+interface CopyableMessageImageProps {
+  mimeType: string;
+  data: string;
+  alt: string;
+}
+
+function CopyableMessageImage({ mimeType, data, alt }: CopyableMessageImageProps) {
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+  const src = `data:${mimeType};base64,${data}`;
+
+  const handleCopy = async () => {
+    try {
+      if (!navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
+        throw new Error('Image clipboard is not supported');
+      }
+      const response = await fetch(src);
+      const blob = await response.blob();
+      await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+      setCopyStatus('copied');
+    } catch (error) {
+      console.error('Failed to copy image:', error);
+      setCopyStatus('error');
+    }
+    window.setTimeout(() => setCopyStatus('idle'), 2000);
+  };
+
+  return (
+    <div className="group relative w-fit max-w-full">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt={alt}
+        className="max-h-96 w-auto max-w-full rounded-lg border border-gray-200 object-contain dark:border-gray-700"
+      />
+      <button
+        type="button"
+        onClick={() => void handleCopy()}
+        aria-label={`${alt}をコピー`}
+        title={copyStatus === 'copied' ? 'コピーしました' : copyStatus === 'error' ? 'コピーに失敗しました' : '画像をコピー'}
+        className={`absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-md text-white shadow-md transition-colors ${
+          copyStatus === 'copied'
+            ? 'bg-green-600'
+            : copyStatus === 'error'
+              ? 'bg-red-600'
+              : 'bg-gray-900/70 hover:bg-gray-900'
+        }`}
+      >
+        {copyStatus === 'copied' ? (
+          <span aria-hidden="true">✓</span>
+        ) : (
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 01-2 2h-2" />
+            <rect x="4" y="7" width="12" height="14" rx="2" strokeWidth={2} />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}
+
 interface MessageItemProps {
   message: SessionMessage;
   toolResult?: SessionMessage; // 対応するツール結果（オプショナル）
@@ -456,12 +516,11 @@ function MessageItem({
           {toolResult?.images && toolResult.images.length > 0 && (
             <div className="ml-3 mt-2 mb-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
               {toolResult.images.map((image, index) => (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
+                <CopyableMessageImage
                   key={`${image.mimeType}:${index}`}
-                  src={`data:${image.mimeType};base64,${image.data}`}
+                  mimeType={image.mimeType}
+                  data={image.data}
                   alt={`Agent output image ${index + 1}`}
-                  className="max-h-96 w-auto max-w-full rounded-lg border border-gray-200 object-contain dark:border-gray-700"
                 />
               ))}
             </div>
@@ -656,12 +715,11 @@ function MessageItem({
           {message.images && message.images.length > 0 && (
             <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
               {message.images.map((image, index) => (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
+                <CopyableMessageImage
                   key={`${image.mimeType}:${index}`}
-                  src={`data:${image.mimeType};base64,${image.data}`}
+                  mimeType={image.mimeType}
+                  data={image.data}
                   alt={`Message image ${index + 1}`}
-                  className="max-h-96 w-auto max-w-full rounded-lg border border-gray-200 object-contain dark:border-gray-700"
                 />
               ))}
             </div>

--- a/src/app/components/__tests__/MessageItem.test.tsx
+++ b/src/app/components/__tests__/MessageItem.test.tsx
@@ -25,4 +25,41 @@ describe('MessageItem ACP images', () => {
       'data:image/png;base64,iVBORw0KGgo=',
     );
   });
+
+  it('renders an image returned by an agent tool', () => {
+    render(
+      <MessageItem
+        message={{
+          id: 1,
+          role: 'agent',
+          content: JSON.stringify({
+            type: 'tool_use',
+            name: 'GenerateImage',
+            id: 'image-tool-1',
+            input: {},
+          }),
+          time: '2026-07-25T00:00:00Z',
+          type: 'normal',
+          toolUseId: 'image-tool-1',
+        }}
+        toolResult={{
+          id: 2,
+          role: 'tool_result',
+          content: '',
+          images: [{ mimeType: 'image/png', data: 'generated-image-data' }],
+          time: '2026-07-25T00:00:01Z',
+          type: 'normal',
+          parentToolUseId: 'image-tool-1',
+          status: 'success',
+        }}
+        formatTimestamp={() => '00:00'}
+        fontSettings={{ fontSize: 14, fontFamily: 'sans-serif' }}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'Agent output image 1' })).toHaveAttribute(
+      'src',
+      'data:image/png;base64,generated-image-data',
+    );
+  });
 });

--- a/src/app/components/__tests__/MessageItem.test.tsx
+++ b/src/app/components/__tests__/MessageItem.test.tsx
@@ -1,9 +1,14 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import MessageItem from '../MessageItem';
 
 describe('MessageItem ACP images', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   it('renders an image-only agent message in the chat', () => {
     render(
       <MessageItem
@@ -60,6 +65,43 @@ describe('MessageItem ACP images', () => {
     expect(screen.getByRole('img', { name: 'Agent output image 1' })).toHaveAttribute(
       'src',
       'data:image/png;base64,generated-image-data',
+    );
+  });
+
+  it('copies an agent output image to the clipboard', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { write },
+    });
+    vi.stubGlobal('ClipboardItem', class {
+      constructor(public items: Record<string, Blob>) {}
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(new Blob(['image'], { type: 'image/png' })),
+    );
+
+    render(
+      <MessageItem
+        message={{
+          id: 1,
+          role: 'agent',
+          content: '',
+          images: [{ mimeType: 'image/png', data: 'image-data' }],
+          time: '2026-07-25T00:00:00Z',
+          type: 'normal',
+        }}
+        formatTimestamp={() => '00:00'}
+        fontSettings={{ fontSize: 14, fontFamily: 'sans-serif' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Message image 1をコピー' }));
+
+    await waitFor(() => expect(write).toHaveBeenCalledOnce());
+    expect(screen.getByRole('button', { name: 'Message image 1をコピー' })).toHaveAttribute(
+      'title',
+      'コピーしました',
     );
   });
 });

--- a/src/app/components/__tests__/MessageItem.test.tsx
+++ b/src/app/components/__tests__/MessageItem.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import MessageItem from '../MessageItem';
+
+describe('MessageItem ACP images', () => {
+  it('renders an image-only agent message in the chat', () => {
+    render(
+      <MessageItem
+        message={{
+          id: 1,
+          role: 'agent',
+          content: '',
+          images: [{ mimeType: 'image/png', data: 'iVBORw0KGgo=' }],
+          time: '2026-07-25T00:00:00Z',
+          type: 'normal',
+        }}
+        formatTimestamp={() => '00:00'}
+        fontSettings={{ fontSize: 14, fontFamily: 'sans-serif' }}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'Message image 1' })).toHaveAttribute(
+      'src',
+      'data:image/png;base64,iVBORw0KGgo=',
+    );
+  });
+});

--- a/src/app/components/__tests__/MessageItem.test.tsx
+++ b/src/app/components/__tests__/MessageItem.test.tsx
@@ -77,17 +77,13 @@ describe('MessageItem ACP images', () => {
     vi.stubGlobal('ClipboardItem', class {
       constructor(public items: Record<string, Blob>) {}
     });
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(new Blob(['image'], { type: 'image/png' })),
-    );
-
     render(
       <MessageItem
         message={{
           id: 1,
           role: 'agent',
           content: '',
-          images: [{ mimeType: 'image/png', data: 'image-data' }],
+          images: [{ mimeType: 'image/png', data: 'aW1hZ2U=' }],
           time: '2026-07-25T00:00:00Z',
           type: 'normal',
         }}

--- a/src/lib/__tests__/agentapi-proxy-client.test.ts
+++ b/src/lib/__tests__/agentapi-proxy-client.test.ts
@@ -17,4 +17,69 @@ describe('AgentAPIProxyClient ACP message history', () => {
       message: 'connection lost',
     } satisfies Partial<AgentAPIProxyError>);
   });
+
+  it('sends text and image content blocks unchanged to an ACP session', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const client = new AgentAPIProxyClient({ baseURL: 'http://proxy.example.test' });
+
+    await client.sendACPPrompt(
+      'session-1',
+      'acp-session-1',
+      [
+        { type: 'text', text: 'What is in this image?' },
+        { type: 'image', mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+      ],
+      42
+    );
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(request.body))).toMatchObject({
+      id: 42,
+      method: 'session/prompt',
+      params: {
+        sessionId: 'acp-session-1',
+        prompt: [
+          { type: 'text', text: 'What is in this image?' },
+          { type: 'image', mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+        ],
+      },
+    });
+  });
+
+  it('restores ACP image output from message history', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        messages: [{
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId: 'acp-session-1',
+            time: '2026-07-25T00:00:00Z',
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'image', mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+            },
+          },
+        }],
+        userPromptCount: 0,
+        userPrompts: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const client = new AgentAPIProxyClient({ baseURL: 'http://proxy.example.test' });
+
+    const history = await client.getACPMessageHistory('session-1', 'acp-session-1');
+
+    expect(history.messages).toHaveLength(1);
+    expect(history.messages[0].images).toEqual([
+      { mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+    ]);
+  });
 });

--- a/src/lib/__tests__/agentapi-proxy-client.test.ts
+++ b/src/lib/__tests__/agentapi-proxy-client.test.ts
@@ -82,4 +82,60 @@ describe('AgentAPIProxyClient ACP message history', () => {
       { mimeType: 'image/png', data: 'iVBORw0KGgo=' },
     ]);
   });
+
+  it('restores images nested in completed ACP tool results', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        messages: [
+          {
+            jsonrpc: '2.0',
+            method: 'session/update',
+            params: {
+              sessionId: 'acp-session-1',
+              update: {
+                sessionUpdate: 'tool_call',
+                toolCallId: 'image-tool-1',
+                kind: 'other',
+                title: 'Generate image',
+              },
+            },
+          },
+          {
+            jsonrpc: '2.0',
+            method: 'session/update',
+            params: {
+              sessionId: 'acp-session-1',
+              update: {
+                sessionUpdate: 'tool_call_update',
+                toolCallId: 'image-tool-1',
+                status: 'completed',
+                content: [{
+                  type: 'content',
+                  content: {
+                    type: 'image',
+                    mimeType: 'image/png',
+                    data: 'generated-image-data',
+                    uri: '/tmp/generated.png',
+                  },
+                }],
+              },
+            },
+          },
+        ],
+        userPromptCount: 0,
+        userPrompts: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const client = new AgentAPIProxyClient({ baseURL: 'http://proxy.example.test' });
+
+    const history = await client.getACPMessageHistory('session-1', 'acp-session-1');
+    const toolResult = history.messages.find(message => message.role === 'tool_result');
+
+    expect(toolResult?.images).toEqual([
+      { mimeType: 'image/png', data: 'generated-image-data' },
+    ]);
+  });
 });

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -208,6 +208,17 @@ function extractACPToolContent(content: unknown): string {
   return texts.join('\n');
 }
 
+function extractACPToolImages(content: unknown): Array<{ mimeType: string; data: string }> {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap(item => {
+    if (!item || typeof item !== 'object') return [];
+    const block = item as Record<string, unknown>;
+    if (block.type !== 'content' || !block.content || typeof block.content !== 'object') return [];
+    const image = acpExtractImage(block.content);
+    return image ? [image] : [];
+  });
+}
+
 function extractRawOutputText(rawOutput: unknown): string {
   if (rawOutput == null) return '';
   if (typeof rawOutput === 'string') return rawOutput;
@@ -505,11 +516,13 @@ export class ACPServerClient {
               callbacks.onToolUpdate?.(update.toolCallId!, isError ? 'error' : 'success');
 
               const acpText = extractACPToolContent(update.content);
+              const images = extractACPToolImages(update.content);
               const resultContent = acpText || extractRawOutputText(update.rawOutput);
               callbacks.onMessage({
                 id: nextId(),
                 role: 'tool_result',
                 content: resultContent,
+                images: images.length > 0 ? images : undefined,
                 time: now,
                 type: 'normal',
                 parentToolUseId: update.toolCallId,

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -102,6 +102,13 @@ export interface ACPConfigOption {
   options?: unknown;
 }
 
+export interface ACPPromptContentBlock {
+  type: 'text' | 'image';
+  text?: string;
+  mimeType?: string;
+  data?: string;
+}
+
 interface ACPPermissionOption {
   optionId: string;
   name: string;
@@ -119,6 +126,7 @@ interface ACPPermissionParams {
 export interface ACPServerEventCallbacks {
   onMessage: (message: SessionMessage) => void;
   onChunk?: (msgId: number, text: string) => void;
+  onImageChunk?: (msgId: number, image: { mimeType: string; data: string }) => void;
   onThoughtChunk?: (msgId: number, thought: string) => void;
   onToolUpdate?: (toolCallId: string, status: string) => void;
   onToolInputUpdate?: (toolCallId: string, input: unknown, title?: string, locations?: Array<{ path: string; line?: number }>) => void;
@@ -172,6 +180,15 @@ function acpExtractText(content: unknown): string {
   const obj = content as Record<string, unknown>;
   if (typeof obj.text === 'string') return obj.text;
   return '';
+}
+
+function acpExtractImage(content: unknown): { mimeType: string; data: string } | null {
+  if (!content || typeof content !== 'object' || Array.isArray(content)) return null;
+  const obj = content as Record<string, unknown>;
+  if (obj.type === 'image' && typeof obj.mimeType === 'string' && typeof obj.data === 'string') {
+    return { mimeType: obj.mimeType, data: obj.data };
+  }
+  return null;
 }
 
 function extractACPToolContent(content: unknown): string {
@@ -326,7 +343,7 @@ export class ACPServerClient {
   }
 
   /** Send a prompt to the session. Response arrives via the SSE stream. */
-  async sendPrompt(sessionId: string, message: string, promptId?: number): Promise<void> {
+  async sendPrompt(sessionId: string, prompt: ACPPromptContentBlock[], promptId?: number): Promise<void> {
     const id = promptId ?? this.requestId++;
     const body: JSONRPCRequest = {
       jsonrpc: '2.0',
@@ -334,7 +351,7 @@ export class ACPServerClient {
       method: 'session/prompt',
       params: {
         sessionId,
-        prompt: [{ type: 'text', text: message }],
+        prompt,
       },
     };
     const response = await fetch(this.acpUrl, {
@@ -404,6 +421,7 @@ export class ACPServerClient {
 
     let streamingMsgId: number | null = null;
     let streamingThoughtId: number | null = null;
+    let streamingUserMsgId: number | null = null;
 
     const dispatchEvent = (data: string) => {
       try {
@@ -418,12 +436,21 @@ export class ACPServerClient {
           switch (update.sessionUpdate) {
             case 'agent_message_chunk': {
               const text = acpExtractText(update.content);
-              if (!text) return;
+              const image = acpExtractImage(update.content);
+              if (!text && !image) return;
               if (streamingMsgId === null) {
                 streamingMsgId = nextId();
-                callbacks.onMessage({ id: streamingMsgId, role: 'agent', content: text, time: now, type: 'normal' });
+                callbacks.onMessage({
+                  id: streamingMsgId,
+                  role: 'agent',
+                  content: text,
+                  images: image ? [image] : undefined,
+                  time: now,
+                  type: 'normal',
+                });
               } else {
-                callbacks.onChunk?.(streamingMsgId, text);
+                if (text) callbacks.onChunk?.(streamingMsgId, text);
+                if (image) callbacks.onImageChunk?.(streamingMsgId, image);
               }
               callbacks.onStatus?.({ status: 'running' });
               break;
@@ -507,8 +534,21 @@ export class ACPServerClient {
 
             case 'user_message_chunk': {
               const text = acpExtractText(update.content);
-              if (!text) return;
-              callbacks.onMessage({ id: nextId(), role: 'user', content: text, time: now, type: 'normal' });
+              const image = acpExtractImage(update.content);
+              if (!text && !image) return;
+              if (image && streamingUserMsgId !== null) {
+                callbacks.onImageChunk?.(streamingUserMsgId, image);
+              } else {
+                streamingUserMsgId = nextId();
+                callbacks.onMessage({
+                  id: streamingUserMsgId,
+                  role: 'user',
+                  content: text,
+                  images: image ? [image] : undefined,
+                  time: now,
+                  type: 'normal',
+                });
+              }
               break;
             }
 

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -202,6 +202,13 @@ export interface ACPSessionInfo {
   _meta?: Record<string, unknown>;
 }
 
+export interface ACPPromptContentBlock {
+  type: 'text' | 'image';
+  text?: string;
+  mimeType?: string;
+  data?: string;
+}
+
 /** Discriminated union for ACP session/update payloads. */
 export interface ACPSessionUpdate {
   sessionUpdate: string;
@@ -322,6 +329,8 @@ export interface ACPSessionCallbacks {
   onMessage: (message: SessionMessage) => void;
   /** Called with additional text to append to an existing streaming message. */
   onChunk: (messageId: number, text: string) => void;
+  /** Called when an image is appended to an existing streaming message. */
+  onImageChunk?: (messageId: number, image: { mimeType: string; data: string }) => void;
   /**
    * Called with additional thought text to append to an existing streaming message.
    * The thought is displayed in a collapsible "Thinking…" section.
@@ -376,6 +385,15 @@ function acpExtractText(content: unknown): string {
   const obj = content as Record<string, unknown>;
   if (obj.type === 'text' && typeof obj.text === 'string') return obj.text;
   return '';
+}
+
+function acpExtractImage(content: unknown): { mimeType: string; data: string } | null {
+  if (!content || typeof content !== 'object' || Array.isArray(content)) return null;
+  const obj = content as Record<string, unknown>;
+  if (obj.type === 'image' && typeof obj.mimeType === 'string' && typeof obj.data === 'string') {
+    return { mimeType: obj.mimeType, data: obj.data };
+  }
+  return null;
 }
 
 /**
@@ -479,14 +497,21 @@ function parseACPJSONRPCMessages(rawMsgs: ACPJSONRPCMessage[]): SessionMessage[]
       switch (update.sessionUpdate) {
         case 'agent_message_chunk': {
           const text = acpExtractText(update.content);
-          if (!text) continue;
+          const image = acpExtractImage(update.content);
+          if (!text && !image) continue;
           if (streamingMsgId !== null) {
             const idx = result.findIndex(m => m.id === streamingMsgId);
-            if (idx >= 0) result[idx] = { ...result[idx], content: result[idx].content + text };
+            if (idx >= 0) {
+              result[idx] = {
+                ...result[idx],
+                content: result[idx].content + text,
+                images: image ? [...(result[idx].images ?? []), image] : result[idx].images,
+              };
+            }
           } else {
             const id = nextLocalId++;
             streamingMsgId = id;
-            result.push({ id, role: 'agent', content: text, time: now, type: 'normal' });
+            result.push({ id, role: 'agent', content: text, images: image ? [image] : undefined, time: now, type: 'normal' });
           }
           break;
         }
@@ -554,8 +579,21 @@ function parseACPJSONRPCMessages(rawMsgs: ACPJSONRPCMessage[]): SessionMessage[]
         }
         case 'user_message_chunk': {
           const text = acpExtractText(update.content);
-          if (!text) continue;
-          result.push({ id: nextLocalId++, role: 'user', content: text, time: now, type: 'normal' });
+          const image = acpExtractImage(update.content);
+          if (!text && !image) continue;
+          const previous = result[result.length - 1];
+          if (image && previous?.role === 'user') {
+            previous.images = [...(previous.images ?? []), image];
+          } else {
+            result.push({
+              id: nextLocalId++,
+              role: 'user',
+              content: text,
+              images: image ? [image] : undefined,
+              time: now,
+              type: 'normal',
+            });
+          }
           break;
         }
         default:
@@ -2505,6 +2543,7 @@ export class AgentAPIProxyClient {
     let nextLocalId = 1;
     // Track the current streaming agent message id (for chunk accumulation).
     let streamingMsgId: number | null = null;
+    let streamingUserMsgId: number | null = null;
 
     console.log(`[ACP] EventSource subscription created (url=${sseUrl}, acpSessionId=${acpSessionId})`);
 
@@ -2534,7 +2573,8 @@ export class AgentAPIProxyClient {
           switch (update.sessionUpdate) {
             case 'agent_message_chunk': {
               const text = acpExtractText(update.content);
-              if (!text) return;
+              const image = acpExtractImage(update.content);
+              if (!text && !image) return;
 
               // Agent is actively streaming — mark as running so the UI
               // suppresses input and shows the stop button even when the
@@ -2543,7 +2583,8 @@ export class AgentAPIProxyClient {
 
               if (streamingMsgId !== null) {
                 // Append to existing streaming message.
-                callbacks.onChunk(streamingMsgId, text);
+                if (text) callbacks.onChunk(streamingMsgId, text);
+                if (image) callbacks.onImageChunk?.(streamingMsgId, image);
               } else {
                 // Start a new streaming message.
                 const id = nextLocalId++;
@@ -2552,6 +2593,7 @@ export class AgentAPIProxyClient {
                   id,
                   role: 'agent',
                   content: text,
+                  images: image ? [image] : undefined,
                   time: now,
                   type: 'normal',
                 });
@@ -2666,14 +2708,21 @@ export class AgentAPIProxyClient {
 
             case 'user_message_chunk': {
               const text = acpExtractText(update.content);
-              if (!text) return;
-              callbacks.onMessage({
-                id: nextLocalId++,
-                role: 'user',
-                content: text,
-                time: now,
-                type: 'normal',
-              });
+              const image = acpExtractImage(update.content);
+              if (!text && !image) return;
+              if (image && streamingUserMsgId !== null) {
+                callbacks.onImageChunk?.(streamingUserMsgId, image);
+              } else {
+                streamingUserMsgId = nextLocalId++;
+                callbacks.onMessage({
+                  id: streamingUserMsgId,
+                  role: 'user',
+                  content: text,
+                  images: image ? [image] : undefined,
+                  time: now,
+                  type: 'normal',
+                });
+              }
               break;
             }
 
@@ -2777,7 +2826,7 @@ export class AgentAPIProxyClient {
   async sendACPPrompt(
     sessionId: string,
     acpSessionId: string,
-    text: string,
+    prompt: ACPPromptContentBlock[],
     promptId: number
   ): Promise<void> {
     await this.makeRequest<unknown>(`/${sessionId}/rpc`, {
@@ -2788,7 +2837,7 @@ export class AgentAPIProxyClient {
         method: 'session/prompt',
         params: {
           sessionId: acpSessionId,
-          prompt: [{ type: 'text', text }],
+          prompt,
         },
       }),
     });

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -420,6 +420,17 @@ function extractACPToolContent(content: unknown): string {
   return texts.join('\n');
 }
 
+function extractACPToolImages(content: unknown): Array<{ mimeType: string; data: string }> {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap(item => {
+    if (!item || typeof item !== 'object') return [];
+    const block = item as Record<string, unknown>;
+    if (block.type !== 'content' || !block.content || typeof block.content !== 'object') return [];
+    const image = acpExtractImage(block.content);
+    return image ? [image] : [];
+  });
+}
+
 /**
  * Extract human-readable text from rawOutput.
  * rawOutput can be:
@@ -567,8 +578,9 @@ function parseACPJSONRPCMessages(rawMsgs: ACPJSONRPCMessage[]): SessionMessage[]
           }
 
           const acpText = extractACPToolContent(update.content);
+          const images = extractACPToolImages(update.content);
           const resultContent = acpText || extractRawOutputText(update.rawOutput);
-          result.push({ id: nextLocalId++, role: 'tool_result', content: resultContent, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isError ? 'error' : 'success' });
+          result.push({ id: nextLocalId++, role: 'tool_result', content: resultContent, images: images.length > 0 ? images : undefined, time: now, type: 'normal', parentToolUseId: update.toolCallId, status: isError ? 'error' : 'success' });
           break;
         }
         case 'plan': {
@@ -2679,11 +2691,13 @@ export class AgentAPIProxyClient {
 
               // Step 3: result (status = completed/failed) — prefer ACP content[] over rawOutput
               const acpText = extractACPToolContent(update.content);
+              const images = extractACPToolImages(update.content);
               const resultContent = acpText || extractRawOutputText(update.rawOutput);
               callbacks.onMessage({
                 id: nextLocalId++,
                 role: 'tool_result',
                 content: resultContent,
+                images: images.length > 0 ? images : undefined,
                 time: now,
                 type: 'normal',
                 parentToolUseId: update.toolCallId,

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -252,6 +252,8 @@ export interface SessionMessage {
   content: string;
   /** Agent thinking / reasoning text (ACP agent_thought_chunk). Shown in a collapsible section. */
   thought?: string;
+  /** Images carried by ACP image content blocks. */
+  images?: Array<{ mimeType: string; data: string }>;
   timestamp?: string; // Made optional (for backwards compatibility)
   time: string; // ISO 8601 timestamp from API
   session_id?: string; // Made optional (not in API spec)


### PR DESCRIPTION
## Summary
- ACP チャットで画像を最大4枚添付し、ContentBlock として送信
- ACP の画像出力を履歴/SSEから復元して表示
- chat の info パネルから reasoning effort を変更

## Verification
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run test` (35 tests)
- `bun run build`
- dev 環境での Playwright E2E はデプロイ後に追記予定