### PR TITLE
feat(acp): render form elicitation questions

### DIFF
--- a/src/app/components/ACPElicitationModal.tsx
+++ b/src/app/components/ACPElicitationModal.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { ACPElicitationParams, ACPElicitationProperty } from '../../types/agentapi';
+
+interface Props {
+  elicitation: ACPElicitationParams;
+  onSubmit: (content: Record<string, unknown>) => void;
+  onCancel: () => void;
+}
+
+function optionsFor(property: ACPElicitationProperty) {
+  return property.oneOf ?? property.items?.anyOf ?? [];
+}
+
+export default function ACPElicitationModal({ elicitation, onSubmit, onCancel }: Props) {
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const properties: Array<[string, ACPElicitationProperty]> = [];
+  const schemaProperties = elicitation.requestedSchema?.properties ?? {};
+  Object.keys(schemaProperties).forEach(key => properties.push([key, schemaProperties[key]]));
+
+  const select = (key: string, value: string, multiple: boolean) => {
+    if (!multiple) {
+      setValues(current => ({ ...current, [key]: value }));
+      return;
+    }
+    setValues(current => {
+      const selected = Array.isArray(current[key]) ? current[key] as string[] : [];
+      return {
+        ...current,
+        [key]: selected.indexOf(value) >= 0
+          ? selected.filter(item => item !== value)
+          : [...selected, value],
+      };
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
+      <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-white shadow-xl dark:bg-gray-800">
+        <div className="p-6">
+          <div className="mb-6 flex items-start justify-between gap-4">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              {elicitation.message || 'Agent question'}
+            </h2>
+            <button onClick={onCancel} aria-label="Cancel" className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+              <span aria-hidden="true" className="text-2xl">&times;</span>
+            </button>
+          </div>
+
+          <div className="space-y-6">
+            {properties.map(([key, property]) => {
+              const options = optionsFor(property);
+              const multiple = property.type === 'array';
+              const selected = values[key];
+
+              return (
+                <fieldset key={key}>
+                  <legend className="mb-1 font-medium text-gray-900 dark:text-white">
+                    {property.title || property.description || key}
+                  </legend>
+                  {property.title && property.description && (
+                    <p className="mb-3 text-sm text-gray-600 dark:text-gray-400">{property.description}</p>
+                  )}
+
+                  {options.length > 0 ? (
+                    <div className="space-y-2">
+                      {options.map(option => {
+                        const active = Array.isArray(selected)
+                          ? selected.indexOf(option.const) >= 0
+                          : selected === option.const;
+                        return (
+                          <button
+                            type="button"
+                            key={option.const}
+                            onClick={() => select(key, option.const, multiple)}
+                            className={`w-full rounded-lg border-2 p-3 text-left ${
+                              active
+                                ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20'
+                                : 'border-gray-200 hover:border-gray-300 dark:border-gray-700 dark:hover:border-gray-600'
+                            }`}
+                          >
+                            <span className="font-medium text-gray-900 dark:text-white">{option.title || option.const}</span>
+                            {option.description && (
+                              <span className="mt-1 block text-sm text-gray-600 dark:text-gray-400">{option.description}</span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <input
+                      type="text"
+                      value={typeof selected === 'string' ? selected : ''}
+                      onChange={event => setValues(current => ({ ...current, [key]: event.target.value }))}
+                      className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                    />
+                  )}
+                </fieldset>
+              );
+            })}
+          </div>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button onClick={onCancel} className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+              Cancel
+            </button>
+            <button onClick={() => onSubmit(values)} className="rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-700">
+              Submit answers
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -7,7 +7,7 @@ import { createAgentAPIProxyClientFromStorage, ACPSessionInfo, ACPConfigOption, 
 import { AgentAPIProxyError } from '../../lib/agentapi-proxy-client';
 import { createACPServerClientFromStorage, ACPServerClient } from '../../lib/acp-server-client';
 import { getACPServerEnabled } from '../../types/settings';
-import { Session, SessionAnnotations, SessionMessage, SessionMessageListResponse, PendingAction } from '../../types/agentapi';
+import { Session, SessionAnnotations, SessionMessage, SessionMessageListResponse, PendingAction, ACPElicitationParams } from '../../types/agentapi';
 import { useBackgroundAwareInterval, usePageVisibility } from '../hooks/usePageVisibility';
 import { messageTemplateManager } from '../../utils/messageTemplateManager';
 import { MessageTemplate } from '../../types/messageTemplate';
@@ -19,6 +19,7 @@ import MessageItem from './MessageItem';
 import ToolExecutionPane from './ToolExecutionPane';
 import PlanApprovalModal from './PlanApprovalModal';
 import AskUserQuestionModal from './AskUserQuestionModal';
+import ACPElicitationModal from './ACPElicitationModal';
 import SessionListSidebar from './SessionListSidebar';
 
 const SIDEBAR_VISIBLE_KEY = 'session_list_sidebar_visible';
@@ -471,6 +472,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                     setPendingAction(action);
                     setShowQuestionModal(true);
                   },
+                  onElicitation: (elicitation: ACPElicitationParams, rpcId: number) => {
+                    setACPPendingElicitation({ elicitation, rpcId });
+                  },
                   onConnectionOpen: () => {
                     setMessageSSEConnectionStatus('connected');
                   },
@@ -771,6 +775,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
   const tokenUsage = useMemo(() => getSessionTokenUsage(acpInfo, messages), [acpInfo, messages]);
   const relatedLinks = useMemo(() => getRelatedLinks(sessionAnnotations), [sessionAnnotations]);
   const [acpPendingPermission, setACPPendingPermission] = useState<{ action: PendingAction; rpcId: number } | null>(null);
+  const [acpPendingElicitation, setACPPendingElicitation] = useState<{ elicitation: ACPElicitationParams; rpcId: number } | null>(null);
   const [acpUserPrompts, setACPUserPrompts] = useState<ACPUserPromptInfo[]>([]);
   const [isLoadingACPPromptHistory, setIsLoadingACPPromptHistory] = useState(false);
   const [loadedACPStartPromptIndex, setLoadedACPStartPromptIndex] = useState<number | null>(null);
@@ -1388,6 +1393,27 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
     setShowQuestionModal(false);
   }, []);
 
+  const replyToElicitation = useCallback(async (
+    result: { action: 'accept'; content: Record<string, unknown> } | { action: 'cancel' }
+  ) => {
+    if (!sessionId || !agentAPIRef.current || !acpPendingElicitation) return;
+
+    if (acpServerEnabled && acpServerClientRef.current) {
+      await acpServerClientRef.current.sendElicitationResponse(
+        sessionId,
+        acpPendingElicitation.rpcId,
+        result
+      );
+    } else {
+      await agentAPIRef.current.replyToACPElicitation(
+        sessionId,
+        acpPendingElicitation.rpcId,
+        result
+      );
+    }
+    setACPPendingElicitation(null);
+  }, [sessionId, acpPendingElicitation, acpServerEnabled]);
+
   // 1秒インターバルポーリング（接続中かつ非ACPセッションのみ動作）
   const pollingControl = useBackgroundAwareInterval(pollMessages, 1000, false);
 
@@ -1528,6 +1554,9 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
             setACPPendingPermission({ action, rpcId });
             setPendingAction(action);
             setShowQuestionModal(true);
+          },
+          onElicitation: (elicitation: ACPElicitationParams, rpcId: number) => {
+            setACPPendingElicitation({ elicitation, rpcId });
           },
           onConnectionOpen: () => {
             setMessageSSEConnectionStatus('connected');
@@ -2964,6 +2993,14 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           questions={pendingAction.content.questions}
           onSubmit={handleAnswerSubmit}
           onClose={handleQuestionModalClose}
+        />
+      )}
+
+      {acpPendingElicitation && (
+        <ACPElicitationModal
+          elicitation={acpPendingElicitation.elicitation}
+          onSubmit={content => void replyToElicitation({ action: 'accept', content })}
+          onCancel={() => void replyToElicitation({ action: 'cancel' })}
         />
       )}
     </div>

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -454,6 +454,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   },
                   onModeUpdate: (modeId: string) => {
                     console.log('[ACP] current_mode_update:', modeId);
+                    setACPInfo(prev => prev ? {
+                      ...prev,
+                      modes: {
+                        ...prev.modes,
+                        currentModeId: modeId,
+                      },
+                    } : prev);
                   },
                   onConfigOptionsUpdate: (configOptions: ACPConfigOption[]) => {
                     applyACPConfigOptions(configOptions);
@@ -1363,7 +1370,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         const selectedLabel = Object.values(answers)[0] as string | undefined;
         const options = acpPendingPermission.action.content?.questions?.[0]?.options ?? [];
         const matched = options.find(o => o.label === selectedLabel);
-        const optionId = matched ? matched.label : (selectedLabel ?? '');
+        const optionId = matched?.value ?? matched?.label ?? selectedLabel ?? '';
         if (acpServerEnabled && acpServerClientRef.current) {
           await acpServerClientRef.current.sendPermissionResponse(sessionId, acpPendingPermission.rpcId, optionId);
         } else {
@@ -1537,6 +1544,13 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
           },
           onModeUpdate: (modeId: string) => {
             console.log('[ACP] current_mode_update:', modeId);
+            setACPInfo(prev => prev ? {
+              ...prev,
+              modes: {
+                ...prev.modes,
+                currentModeId: modeId,
+              },
+            } : prev);
           },
           onConfigOptionsUpdate: (configOptions: ACPConfigOption[]) => {
             applyACPConfigOptions(configOptions);
@@ -1770,7 +1784,7 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
         const options = acpPendingPermission.action.content?.questions?.[0]?.options ?? [];
         const allowOpt = options.find(o => o.description?.includes('allow'));
         const optionId = approved
-          ? (allowOpt?.label ?? options[0]?.label ?? 'allow-once')
+          ? (allowOpt?.value ?? allowOpt?.label ?? options[0]?.value ?? options[0]?.label ?? 'allow-once')
           : 'plan';
         await agentAPIRef.current.replyToACPPermission(sessionId, acpPendingPermission.rpcId, optionId);
         setACPPendingPermission(null);
@@ -2389,6 +2403,12 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
                   <span className="text-gray-500 dark:text-gray-400">Model</span>
                   <span className="break-all text-gray-900 dark:text-gray-100">{acpModelDisplay || '-'}</span>
                 </div>
+                {acpInfo.modes?.currentModeId && (
+                  <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
+                    <span className="text-gray-500 dark:text-gray-400">Mode</span>
+                    <span className="break-all text-gray-900 dark:text-gray-100">{acpInfo.modes.currentModeId}</span>
+                  </div>
+                )}
                 {acpModelConfigId && acpModelOptions.length > 0 && (
                   <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
                     <label htmlFor="acp-model-select" className="text-gray-500 dark:text-gray-400 pt-2">

--- a/src/app/components/AgentAPIChat.tsx
+++ b/src/app/components/AgentAPIChat.tsx
@@ -3011,6 +3011,11 @@ export default function AgentAPIChat({ sessionId: propSessionId }: AgentAPIChatP
       {showQuestionModal && pendingAction?.content?.questions && (
         <AskUserQuestionModal
           questions={pendingAction.content.questions}
+          details={
+            typeof pendingAction.content.plan === 'string'
+              ? pendingAction.content.plan
+              : undefined
+          }
           onSubmit={handleAnswerSubmit}
           onClose={handleQuestionModalClose}
         />

--- a/src/app/components/AskUserQuestionModal.tsx
+++ b/src/app/components/AskUserQuestionModal.tsx
@@ -1,16 +1,20 @@
 'use client';
 
 import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { Question } from '../../types/agentapi';
 
 interface AskUserQuestionModalProps {
   questions: Question[];
+  details?: string;
   onSubmit: (answers: Record<string, string | string[]>) => void;
   onClose: () => void;
 }
 
 export default function AskUserQuestionModal({
   questions,
+  details,
   onSubmit,
   onClose
 }: AskUserQuestionModalProps) {
@@ -72,6 +76,13 @@ export default function AskUserQuestionModal({
           </div>
 
           <div className="space-y-6">
+            {details && (
+              <div className="max-h-[45vh] overflow-y-auto rounded-md border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/40">
+                <div className="prose prose-sm max-w-none dark:prose-invert">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{details}</ReactMarkdown>
+                </div>
+              </div>
+            )}
             {questions.map((question, questionIndex) => (
               <div key={questionIndex} className="border-b border-gray-200 dark:border-gray-700 pb-6 last:border-0">
                 <div className="mb-3">

--- a/src/app/components/__tests__/ACPElicitationModal.test.tsx
+++ b/src/app/components/__tests__/ACPElicitationModal.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ACPElicitationModal from '../ACPElicitationModal';
+
+describe('ACPElicitationModal', () => {
+  it('submits selected, multi-selected, and custom AskUserQuestion answers', () => {
+    const onSubmit = vi.fn();
+    render(
+      <ACPElicitationModal
+        elicitation={{
+          sessionId: 'session-1',
+          mode: 'form',
+          message: 'Please answer the following questions.',
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              question_0: {
+                type: 'string',
+                title: 'Color',
+                oneOf: [
+                  { const: 'Blue', title: 'Blue' },
+                  { const: 'Green', title: 'Green' },
+                ],
+              },
+              question_1: {
+                type: 'array',
+                title: 'Tools',
+                items: {
+                  anyOf: [
+                    { const: 'Bash', title: 'Bash' },
+                    { const: 'Git', title: 'Git' },
+                  ],
+                },
+              },
+              question_1_custom: {
+                type: 'string',
+                title: 'Other',
+              },
+            },
+          },
+        }}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Blue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Bash' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Git' }));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Mercurial' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit answers' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      question_0: 'Blue',
+      question_1: ['Bash', 'Git'],
+      question_1_custom: 'Mercurial',
+    });
+  });
+});

--- a/src/lib/__tests__/acp-permission.test.ts
+++ b/src/lib/__tests__/acp-permission.test.ts
@@ -10,6 +10,9 @@ describe('createACPPermissionAction', () => {
         toolCallId: 'tool-1',
         kind: 'switch_mode',
         title: 'Ready to code?',
+        rawInput: {
+          plan: '# Plan\n\nImplement it.',
+        },
       },
       options: [
         {
@@ -33,5 +36,25 @@ describe('createACPPermissionAction', () => {
         { label: 'No, keep planning', value: 'plan' },
       ],
     });
+    expect(action.content?.plan).toBe('# Plan\n\nImplement it.');
+  });
+
+  it('uses structured ExitPlanMode content when rawInput is unavailable', () => {
+    const action = createACPPermissionAction({
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'switch_mode',
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: '# Fallback plan' },
+          },
+        ],
+      },
+      options: [],
+    });
+
+    expect(action.content?.plan).toBe('# Fallback plan');
   });
 });

--- a/src/lib/__tests__/acp-permission.test.ts
+++ b/src/lib/__tests__/acp-permission.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { createACPPermissionAction } from '../acp-permission';
+
+describe('createACPPermissionAction', () => {
+  it('preserves ExitPlanMode option ids separately from display labels', () => {
+    const action = createACPPermissionAction({
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'switch_mode',
+        title: 'Ready to code?',
+      },
+      options: [
+        {
+          optionId: 'acceptEdits',
+          name: 'Yes, and auto-accept edits',
+          kind: 'allow_always',
+        },
+        {
+          optionId: 'plan',
+          name: 'No, keep planning',
+          kind: 'reject_once',
+        },
+      ],
+    });
+
+    expect(action.content?.questions?.[0]).toMatchObject({
+      question: 'Ready to code?',
+      header: 'Exit Plan Mode',
+      options: [
+        { label: 'Yes, and auto-accept edits', value: 'acceptEdits' },
+        { label: 'No, keep planning', value: 'plan' },
+      ],
+    });
+  });
+});

--- a/src/lib/acp-permission.ts
+++ b/src/lib/acp-permission.ts
@@ -1,0 +1,38 @@
+import { PendingAction } from '../types/agentapi';
+
+export interface ACPPermissionOption {
+  optionId: string;
+  name: string;
+  kind?: string;
+  description?: string;
+}
+
+export interface ACPPermissionParams {
+  sessionId: string;
+  toolCall: {
+    toolCallId: string;
+    kind?: string;
+    title?: string;
+  };
+  options: ACPPermissionOption[];
+}
+
+export function createACPPermissionAction(params: ACPPermissionParams): PendingAction {
+  const switchingMode = params.toolCall?.kind === 'switch_mode';
+  return {
+    type: 'answer_question',
+    tool_use_id: params.toolCall?.toolCallId ?? '',
+    content: {
+      questions: [{
+        question: params.toolCall?.title || 'Permission required',
+        header: switchingMode ? 'Exit Plan Mode' : 'Permission Required',
+        options: (params.options ?? []).map(option => ({
+          label: option.name || option.optionId,
+          description: option.description || option.kind || '',
+          value: option.optionId,
+        })),
+        multiSelect: false,
+      }],
+    },
+  };
+}

--- a/src/lib/acp-permission.ts
+++ b/src/lib/acp-permission.ts
@@ -13,16 +13,62 @@ export interface ACPPermissionParams {
     toolCallId: string;
     kind?: string;
     title?: string;
+    content?: unknown;
+    rawInput?: unknown;
   };
   options: ACPPermissionOption[];
 }
 
+function extractPlanText(toolCall: ACPPermissionParams['toolCall']): string | undefined {
+  let rawInput = toolCall.rawInput;
+  if (typeof rawInput === 'string') {
+    try {
+      rawInput = JSON.parse(rawInput);
+    } catch {
+      // Fall through to the structured content.
+    }
+  }
+
+  if (
+    rawInput &&
+    typeof rawInput === 'object' &&
+    'plan' in rawInput &&
+    typeof rawInput.plan === 'string'
+  ) {
+    return rawInput.plan;
+  }
+
+  if (!Array.isArray(toolCall.content)) return undefined;
+
+  const text = toolCall.content
+    .map((item) => {
+      if (!item || typeof item !== 'object' || !('content' in item)) return undefined;
+      const content = item.content;
+      if (
+        !content ||
+        typeof content !== 'object' ||
+        !('type' in content) ||
+        content.type !== 'text' ||
+        !('text' in content) ||
+        typeof content.text !== 'string'
+      ) {
+        return undefined;
+      }
+      return content.text;
+    })
+    .filter((item): item is string => Boolean(item));
+
+  return text.length > 0 ? text.join('\n\n') : undefined;
+}
+
 export function createACPPermissionAction(params: ACPPermissionParams): PendingAction {
   const switchingMode = params.toolCall?.kind === 'switch_mode';
+  const plan = switchingMode ? extractPlanText(params.toolCall) : undefined;
   return {
     type: 'answer_question',
     tool_use_id: params.toolCall?.toolCallId ?? '',
     content: {
+      ...(plan ? { plan } : {}),
       questions: [{
         question: params.toolCall?.title || 'Permission required',
         header: switchingMode ? 'Exit Plan Mode' : 'Permission Required',

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -9,7 +9,7 @@
  * these are proxy-wide endpoints that handle full session lifecycle via JSON-RPC 2.0.
  */
 
-import { SessionMessage, PendingAction } from '../types/agentapi';
+import { SessionMessage, PendingAction, ACPElicitationParams } from '../types/agentapi';
 import { loadFullGlobalSettings, getDefaultProxySettings } from '../types/settings';
 
 // ─── JSON-RPC types ───────────────────────────────────────────────────────────
@@ -132,6 +132,7 @@ export interface ACPServerEventCallbacks {
   onToolInputUpdate?: (toolCallId: string, input: unknown, title?: string, locations?: Array<{ path: string; line?: number }>) => void;
   onStatus?: (status: { status: 'stable' | 'running' | 'error'; agent_type?: string }) => void;
   onPermission?: (action: PendingAction, rpcId: number) => void;
+  onElicitation?: (elicitation: ACPElicitationParams, rpcId: number) => void;
   onTitleUpdate?: (title: string) => void;
   onModeUpdate?: (mode: string) => void;
   onConfigOptionsUpdate?: (configOptions: ACPConfigOption[]) => void;
@@ -416,6 +417,18 @@ export class ACPServerClient {
     });
   }
 
+  async sendElicitationResponse(
+    sessionId: string,
+    rpcId: number,
+    result: { action: 'accept'; content: Record<string, unknown> } | { action: 'cancel' | 'decline' }
+  ): Promise<void> {
+    await fetch(this.acpUrl, {
+      method: 'POST',
+      headers: { ...this.getHeaders(), 'Acp-Session-Id': sessionId },
+      body: JSON.stringify({ jsonrpc: '2.0', id: rpcId, result }),
+    });
+  }
+
   /**
    * Subscribe to session/update events via GET /acp with Acp-Session-Id header.
    * Uses fetch() + ReadableStream to allow custom headers (EventSource cannot).
@@ -617,6 +630,14 @@ export class ACPServerClient {
 
           const rpcId = typeof msg.id === 'number' ? msg.id : parseInt(String(msg.id ?? '0'), 10);
           callbacks.onPermission(pendingAction, rpcId);
+          return;
+        }
+
+        if (msg.method === 'session/create_elicitation' && msg.id != null) {
+          callbacks.onElicitation?.(
+            msg.params as ACPElicitationParams,
+            typeof msg.id === 'number' ? msg.id : Number(msg.id)
+          );
           return;
         }
 

--- a/src/lib/acp-server-client.ts
+++ b/src/lib/acp-server-client.ts
@@ -11,6 +11,7 @@
 
 import { SessionMessage, PendingAction, ACPElicitationParams } from '../types/agentapi';
 import { loadFullGlobalSettings, getDefaultProxySettings } from '../types/settings';
+import { ACPPermissionParams, createACPPermissionAction } from './acp-permission';
 
 // ─── JSON-RPC types ───────────────────────────────────────────────────────────
 
@@ -86,6 +87,7 @@ interface ACPSessionUpdate {
   locations?: Array<{ path: string; line?: number }>;
   entries?: Array<{ content: string; status?: string; priority?: number }>;
   mode?: string;
+  currentModeId?: string;
   configOptions?: ACPConfigOption[];
 }
 
@@ -107,18 +109,6 @@ export interface ACPPromptContentBlock {
   text?: string;
   mimeType?: string;
   data?: string;
-}
-
-interface ACPPermissionOption {
-  optionId: string;
-  name: string;
-  description?: string;
-}
-
-interface ACPPermissionParams {
-  sessionId: string;
-  toolCall: { toolCallId: string; kind?: string };
-  options: ACPPermissionOption[];
 }
 
 // ─── Callback types ───────────────────────────────────────────────────────────
@@ -584,7 +574,8 @@ export class ACPServerClient {
             }
 
             case 'current_mode_update': {
-              if (update.mode) callbacks.onModeUpdate?.(update.mode);
+              const modeId = update.currentModeId || update.mode;
+              if (modeId) callbacks.onModeUpdate?.(modeId);
               break;
             }
 
@@ -612,21 +603,7 @@ export class ACPServerClient {
           const permParams = msg.params as ACPPermissionParams;
           if (!permParams || !callbacks.onPermission) return;
 
-          const pendingAction: PendingAction = {
-            type: 'answer_question',
-            tool_use_id: permParams.toolCall?.toolCallId ?? '',
-            content: {
-              questions: [{
-                question: 'Permission required',
-                header: 'Permission Required',
-                options: (permParams.options ?? []).map(o => ({
-                  label: o.name || o.optionId,
-                  description: o.description ?? '',
-                })),
-                multiSelect: false,
-              }],
-            },
-          };
+          const pendingAction = createACPPermissionAction(permParams);
 
           const rpcId = typeof msg.id === 'number' ? msg.id : parseInt(String(msg.id ?? '0'), 10);
           callbacks.onPermission(pendingAction, rpcId);

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -14,6 +14,7 @@ import {
   AgentListParams,
   ToolStatusResponseBody,
   PendingAction,
+  ACPElicitationParams,
   ActionRequest,
   ActionResponse
 } from '../types/agentapi';
@@ -367,6 +368,8 @@ export interface ACPSessionCallbacks {
   onStatus: (status: AgentStatus) => void;
   /** Called when a permission request arrives from the agent. */
   onPermission: (action: PendingAction, rpcId: number) => void;
+  /** Called when an agent requests a structured form response. */
+  onElicitation?: (elicitation: ACPElicitationParams, rpcId: number) => void;
   /** Called when the message SSE stream opens. */
   onConnectionOpen?: () => void;
   /** Called when the message SSE stream is connecting or retrying. */
@@ -2792,6 +2795,11 @@ export class AgentAPIProxyClient {
           return;
         }
 
+        if (msg.method === 'session/create_elicitation' && msg.id != null) {
+          callbacks.onElicitation?.(msg.params as ACPElicitationParams, Number(msg.id));
+          return;
+        }
+
         // ── Result of session/prompt (turn finished) ──────────────────────
         if (msg.result != null && msg.id != null) {
           streamingMsgId = null;
@@ -2876,6 +2884,17 @@ export class AgentAPIProxyClient {
           outcome: { outcome: 'selected', optionId },
         },
       }),
+    });
+  }
+
+  async replyToACPElicitation(
+    sessionId: string,
+    rpcId: number,
+    result: { action: 'accept'; content: Record<string, unknown> } | { action: 'cancel' | 'decline' }
+  ): Promise<void> {
+    await this.makeRequest<unknown>(`/${sessionId}/rpc`, {
+      method: 'POST',
+      body: JSON.stringify({ jsonrpc: '2.0', id: rpcId, result }),
     });
   }
 

--- a/src/lib/agentapi-proxy-client.ts
+++ b/src/lib/agentapi-proxy-client.ts
@@ -43,6 +43,7 @@ import {
   CreateSlackBotRequest,
   UpdateSlackBotRequest
 } from '../types/slackbot';
+import { ACPPermissionParams, createACPPermissionAction } from './acp-permission';
 import {
   SessionProfile,
   SessionProfileListParams,
@@ -200,6 +201,10 @@ export interface ACPSessionInfo {
   selectedModel?: unknown;
   modelInfo?: unknown;
   configOptions?: ACPConfigOption[];
+  modes?: {
+    currentModeId: string;
+    availableModes?: Array<{ id: string; name: string; description?: string }>;
+  };
   _meta?: Record<string, unknown>;
 }
 
@@ -236,6 +241,7 @@ export interface ACPSessionUpdate {
   entries?: Array<{ content: string; status: string; priority: string }>;
   // current_mode_update
   modeId?: string;
+  currentModeId?: string;
   // available_commands_update
   availableCommands?: Array<{ name: string; description: string; input?: { hint?: string } }>;
   // config_option_update
@@ -282,20 +288,6 @@ function acpToolNameFromRawInput(rawInput: unknown): string | undefined {
   const toolName = (rawInput as Record<string, unknown>)._toolName;
   if (typeof toolName !== 'string' || toolName.length === 0) return undefined;
   return ACP_KIND_TO_NAME[toolName] || titleToToolName(toolName) || toolName;
-}
-
-/** A permission option offered by the ACP agent. */
-export interface ACPPermissionOption {
-  optionId: string;
-  name: string;
-  kind?: string;
-}
-
-/** Params for session/request_permission (agent → client). */
-export interface ACPPermissionParams {
-  sessionId: string;
-  toolCall: { toolCallId: string; kind?: string };
-  options: ACPPermissionOption[];
 }
 
 /** Raw JSON-RPC 2.0 message envelope received from the SSE stream. */
@@ -2744,8 +2736,9 @@ export class AgentAPIProxyClient {
             }
 
             case 'current_mode_update': {
-              if (update.modeId) {
-                callbacks.onModeUpdate?.(update.modeId);
+              const modeId = update.currentModeId || update.modeId;
+              if (modeId) {
+                callbacks.onModeUpdate?.(modeId);
               }
               break;
             }
@@ -2776,21 +2769,7 @@ export class AgentAPIProxyClient {
         if (msg.method === 'session/request_permission' && msg.id != null) {
           streamingMsgId = null;
           const params = msg.params as ACPPermissionParams;
-          const action: PendingAction = {
-            type: 'answer_question',
-            tool_use_id: params.toolCall?.toolCallId ?? '',
-            content: {
-              questions: [{
-                question: 'Permission required',
-                header: 'Permission Required',
-                options: (params.options ?? []).map(o => ({
-                  label: o.name || o.optionId,
-                  description: o.kind ?? '',
-                })),
-                multiSelect: false,
-              }],
-            },
-          };
+          const action = createACPPermissionAction(params);
           callbacks.onPermission(action, msg.id as number);
           return;
         }

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -327,6 +327,32 @@ export interface Question {
   multiSelect: boolean;
 }
 
+export interface ACPElicitationOption {
+  const: string;
+  title?: string;
+  description?: string;
+}
+
+export interface ACPElicitationProperty {
+  type: 'string' | 'array';
+  title?: string;
+  description?: string;
+  oneOf?: ACPElicitationOption[];
+  items?: { anyOf?: ACPElicitationOption[] };
+}
+
+export interface ACPElicitationParams {
+  sessionId: string;
+  toolCallId?: string;
+  mode: 'form';
+  message: string;
+  requestedSchema: {
+    type: 'object';
+    properties?: Record<string, ACPElicitationProperty>;
+    required?: string[];
+  };
+}
+
 export interface PendingAction {
   type: 'answer_question' | 'approve_plan' | 'stop_agent';
   tool_use_id: string;

--- a/src/types/agentapi.ts
+++ b/src/types/agentapi.ts
@@ -318,6 +318,8 @@ export interface ToolStatusResponseBody {
 export interface QuestionOption {
   label: string;
   description: string;
+  /** Transport value to return when it differs from the display label. */
+  value?: string;
 }
 
 export interface Question {


### PR DESCRIPTION
## Summary
- handle `session/create_elicitation` in both ACP transports
- render AskUserQuestion single-select, multi-select, and per-question custom answer fields
- reply with ACP accept/cancel results
- handle EnterPlanMode `current_mode_update` events and display the active mode
- preserve ExitPlanMode option IDs (`auto`, `acceptEdits`, `default`, `plan`) separately from display labels
- add component and plan-mode permission coverage

## Verification
- `git diff --check`
- `bun test src/lib/__tests__/acp-permission.test.ts`
- changed source files introduce no TypeScript errors; full local runner remains limited by the incomplete overlay dependency installation

Companion proxy: https://github.com/takutakahashi/agentapi-proxy/pull/947